### PR TITLE
Add share target registration for recipes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,11 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -17,15 +18,27 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        val sharedUrl = extractSharedUrl(intent)
+
         setContent {
             LionOtterTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    NavGraph()
+                    NavGraph(sharedUrl = sharedUrl)
                 }
             }
+        }
+    }
+
+    private fun extractSharedUrl(intent: Intent?): String? {
+        return when (intent?.action) {
+            Intent.ACTION_SEND -> {
+                intent.getStringExtra(Intent.EXTRA_TEXT)?.takeIf { it.isNotBlank() }
+            }
+            else -> null
         }
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
@@ -47,11 +47,18 @@ fun AddRecipeScreen(
     onBackClick: () -> Unit,
     onRecipeAdded: (String) -> Unit,
     onNavigateToSettings: () -> Unit,
+    sharedUrl: String? = null,
     viewModel: AddRecipeViewModel = hiltViewModel()
 ) {
     val url by viewModel.url.collectAsStateWithLifecycle()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val hasApiKey by viewModel.hasApiKey.collectAsStateWithLifecycle()
+
+    LaunchedEffect(sharedUrl) {
+        if (sharedUrl != null) {
+            viewModel.onUrlChange(sharedUrl)
+        }
+    }
 
     LaunchedEffect(uiState) {
         if (uiState is AddRecipeUiState.Success) {


### PR DESCRIPTION
Implement Android share target functionality to allow users to share recipe URLs directly to the app:

- Add ACTION_SEND intent filter to MainActivity with text/plain MIME type
- Extract shared URLs from Intent.EXTRA_TEXT in MainActivity
- Update NavGraph to support optional URL parameter in AddRecipe route
- Modify AddRecipeScreen to accept and auto-populate shared URLs
- Navigate directly to AddRecipe screen when app is opened via share intent

Users can now long-press recipe URLs in their browser and select "Lion+Otter Recipes" to import directly.