### PR TITLE
Add image display support from Readability

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,6 +97,9 @@ dependencies {
     // Readability (content extraction)
     implementation(libs.readability4j)
 
+    // HTML parsing
+    implementation(libs.jsoup)
+
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -137,8 +137,7 @@ Return ONLY valid JSON (no markdown, no explanations) with this exact structure:
       ]
     }
   ],
-  "tags": ["dessert", "cake", "baking"],
-  "imageUrl": "https://example.com/image.jpg"
+  "tags": ["dessert", "cake", "baking"]
 }
 
 Guidelines:
@@ -148,7 +147,6 @@ Guidelines:
 - Include notes for ingredient modifications like "room temperature", "divided", etc.
 - For ingredientReferences, include the specific quantity used in that step if mentioned
 - Generate relevant tags based on the recipe type, cuisine, dietary restrictions, etc.
-- Extract the main image URL if available
 - Keep the story brief - just the essence of any background provided
 - Return null for fields that aren't present in the source
 """.trimIndent()

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportRecipeUseCase.kt
@@ -71,7 +71,7 @@ class ImportRecipeUseCase @Inject constructor(
             ingredientSections = parsed.ingredientSections,
             instructionSections = parsed.instructionSections,
             tags = parsed.tags,
-            imageUrl = parsed.imageUrl,
+            imageUrl = page.imageUrl,
             createdAt = now,
             updatedAt = now
         )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ navigationCompose = "2.8.5"
 coil = "2.7.0"
 ksp = "2.1.0-1.0.29"
 readability4j = "1.0.8"
+jsoup = "1.18.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -61,6 +62,9 @@ coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coi
 
 # Readability
 readability4j = { group = "net.dankito.readability4j", name = "readability4j", version.ref = "readability4j" }
+
+# HTML parsing
+jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 
 # Testing
 junit = { group = "junit", name = "junit", version = "4.13.2" }


### PR DESCRIPTION
Use jsoup to extract og:image, twitter:image, and other meta tags from recipe websites. This is more reliable than asking Claude to parse image URLs from HTML since the AI can't actually see images. The extracted image URL is now passed directly to the Recipe model instead of relying on the Anthropic API response.

Changes:
- Add jsoup dependency for HTML parsing
- Extract image URLs in WebScraperService from meta tags
- Return imageUrl in ScrapedPage
- Use extracted image in ImportRecipeUseCase instead of parsed.imageUrl
- Remove image URL extraction instruction from AnthropicService prompt to reduce unnecessary token usage