### PR TITLE
Add error handling tool for data parsing failures

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/RecipeParseResponse.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/RecipeParseResponse.kt
@@ -1,0 +1,14 @@
+package com.lionotter.recipes.data.remote
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wrapper response for recipe parsing that allows the AI to indicate
+ * success with parsed data or failure with a human-readable error message.
+ */
+@Serializable
+data class RecipeParseResponse(
+    val success: Boolean,
+    val error: String? = null,
+    val recipe: RecipeParseResult? = null
+)

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -171,7 +171,10 @@ app: {
         fill: "#ffffff"
       }
 
-      anthropic_svc: AnthropicService
+      anthropic_svc: {
+        label: AnthropicService
+        tooltip: Returns RecipeParseResponse (success with recipe or error message)
+      }
       scraper: {
         label: WebScraperService
         tooltip: Uses Readability4J to extract article content
@@ -213,9 +216,17 @@ legend: {
   flow1: "1. User pastes URL"
   flow2: "2. Scraper fetches HTML"
   flow3: "3. Readability4J extracts content"
-  flow4: "4. Anthropic parses recipe"
+  flow4: "4. Anthropic parses recipe (or returns error)"
   flow5: "5. Repository saves to Room"
   flow6: "6. UI observes Flow<Recipe>"
 
   flow1 -> flow2 -> flow3 -> flow4 -> flow5 -> flow6
+
+  note: {
+    label: "Step 4 can return a parse error with human-readable message if content is not a valid recipe"
+    style: {
+      font-size: 12
+      italic: true
+    }
+  }
 }


### PR DESCRIPTION
Allow the AI to return a structured error response when it cannot parse the provided content as a recipe. This displays a human-readable error message to the user instead of failing silently or producing malformed data.

Fixes #12