### PR TITLE
Enable Bitwarden autofill for API key field

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -46,6 +46,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
@@ -191,6 +193,7 @@ private fun ApiKeySection(
                 label = { Text("API Key") },
                 placeholder = { Text("sk-ant-...") },
                 singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                 visualTransformation = if (passwordVisible) {
                     VisualTransformation.None
                 } else {


### PR DESCRIPTION
Add keyboardOptions with KeyboardType.Password to the API key text field so password managers like Bitwarden will recognize it as a credential field and offer to auto-fill.