### PR TITLE
Add optional tag and update AI models

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -160,13 +160,15 @@ For successful parsing, return:
                 "alternates": [],
                 "amounts": [
                   {"value": 0.5, "unit": "teaspoons", "type": "volume", "isDefault": true}
-                ]
+                ],
+                "optional": false
               }
             ],
             "amounts": [
               {"value": 1.0, "unit": "teaspoons", "type": "volume", "isDefault": true},
               {"value": 6.0, "unit": "grams", "type": "weight", "isDefault": false}
-            ]
+            ],
+            "optional": false
           }
         ]
       }
@@ -179,7 +181,8 @@ For successful parsing, return:
             "stepNumber": 1,
             "instruction": "Preheat oven.",
             "ingredientReferences": [],
-            "ingredients": []
+            "ingredients": [],
+            "optional": false
           },
           {
             "stepNumber": 2,
@@ -188,6 +191,7 @@ For successful parsing, return:
               {"ingredientName": "all-purpose flour", "quantity": 2.0, "unit": "cups"},
               {"ingredientName": "sugar", "quantity": 1.0, "unit": "cup"}
             ],
+            "optional": false,
             "ingredients": [
               {
                 "name": "all-purpose flour",
@@ -196,7 +200,8 @@ For successful parsing, return:
                 "amounts": [
                   {"value": 2.0, "unit": "cups", "type": "volume", "isDefault": true},
                   {"value": 250.0, "unit": "grams", "type": "weight", "isDefault": false}
-                ]
+                ],
+                "optional": false
               },
               {
                 "name": "sugar",
@@ -205,7 +210,8 @@ For successful parsing, return:
                 "amounts": [
                   {"value": 1.0, "unit": "cup", "type": "volume", "isDefault": true},
                   {"value": 200.0, "unit": "grams", "type": "weight", "isDefault": false}
-                ]
+                ],
+                "optional": false
               }
             ]
           }
@@ -251,12 +257,18 @@ Guidelines:
   * If an ingredient is used in multiple steps, include it in each step's ingredients array
   * Rephrase the instruction text to remove quantity mentions since they'll be displayed separately from the ingredient list
   * Example: "Add 2 cups flour" becomes "Add flour", with quantities shown in the ingredients array
+- IMPORTANT: Mark ingredients and steps as optional when appropriate:
+  * Set "optional": true for ingredients that are clearly marked as optional in the recipe (e.g., "optional garnish", "if desired", "for garnish")
+  * Set "optional": true for instruction steps that are purely decorative or enhancement steps (e.g., "Garnish with fresh herbs if desired")
+  * Set "optional": false for all ingredients and steps that are essential to the recipe
 - Generate relevant tags based on the recipe type, cuisine, dietary restrictions, etc.
 - Keep the story brief - just the essence of any background provided
 - Return null for fields that aren't present in the source
 - Always include the alternates array (empty array if no alternates)
 - Always include the amounts array (with at least one measurement)
 - Always include the ingredients array for each step (empty array if no ingredients used in that step)
+- Always include the optional field for ingredients (default to false if not specified)
+- Always include the optional field for steps (default to false if not specified)
 """.trimIndent()
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
@@ -68,7 +68,8 @@ data class Ingredient(
     val name: String,
     val notes: String? = null,
     val alternates: List<Ingredient> = emptyList(),
-    val amounts: List<Measurement> = emptyList()
+    val amounts: List<Measurement> = emptyList(),
+    val optional: Boolean = false
 ) {
     /**
      * Returns the measurement to display based on user preference.
@@ -165,7 +166,8 @@ data class InstructionStep(
     val stepNumber: Int,
     val instruction: String,
     val ingredientReferences: List<IngredientReference> = emptyList(),
-    val ingredients: List<Ingredient> = emptyList()
+    val ingredients: List<Ingredient> = emptyList(),
+    val optional: Boolean = false
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -259,8 +259,8 @@ private fun ModelSelectionSection(
 
     val models = listOf(
         "claude-opus-4-5-20251101" to "Claude Opus 4.5 (Best quality)",
-        "claude-sonnet-4-20250514" to "Claude Sonnet 4 (Balanced)",
-        "claude-3-5-haiku-20241022" to "Claude 3.5 Haiku (Fastest)"
+        "claude-sonnet-4-5-20250612" to "Claude Sonnet 4.5 (Balanced)",
+        "claude-haiku-4-5-20250612" to "Claude Haiku 4.5 (Fastest)"
     )
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -114,8 +114,14 @@ app: {
       }
 
       recipe: Recipe
-      ingredient: Ingredient
-      instruction: InstructionStep
+      ingredient: {
+        label: Ingredient
+        tooltip: "Fields: name, notes, alternates, amounts, optional"
+      }
+      instruction: {
+        label: InstructionStep
+        tooltip: "Fields: stepNumber, instruction, ingredients, optional"
+      }
       section: IngredientSection
       measurement: Measurement
       measurement_type: MeasurementType
@@ -179,7 +185,7 @@ app: {
 
       anthropic_svc: {
         label: AnthropicService
-        tooltip: Uses extended thinking to parse recipes with volume/weight conversions and step-level ingredient extraction
+        tooltip: "Uses extended thinking to parse recipes with volume/weight conversions, step-level ingredient extraction, and optional field detection. Supports Opus 4.5, Sonnet 4.5, and Haiku 4.5"
       }
       scraper: {
         label: WebScraperService
@@ -231,7 +237,7 @@ legend: {
   flow1 -> flow2 -> flow3 -> flow4 -> flow5 -> flow6 -> flow7 -> flow8
 
   note: {
-    label: "Step 4 uses extended thinking for accurate ingredient parsing, measurement conversions, and step-level ingredient extraction"
+    label: "Step 4 uses extended thinking for accurate ingredient parsing, measurement conversions, step-level ingredient extraction, and optional field detection. Supports multiple AI models: Opus 4.5 (best quality), Sonnet 4.5 (balanced), Haiku 4.5 (fastest)"
     style: {
       font-size: 12
       italic: true


### PR DESCRIPTION
- Add optional field to Ingredient and InstructionStep models to mark optional/garnish items
- Update system prompt to detect and mark optional ingredients and steps (e.g., "optional garnish", "if desired")
- Update supported AI models from Sonnet 4/Haiku 3.5 to Sonnet 4.5/Haiku 4.5 (keep Opus 4.5)
- Update architecture diagram to document optional field and multi-model support