### PR TITLE
Handle "to taste" ingredient values in recipes

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -243,6 +243,7 @@ Guidelines:
   * Provide approximate conversions to other measurement types (volume to weight or vice versa)
   * Use your knowledge of common ingredient densities for conversions (e.g., flour ~125g/cup, sugar ~200g/cup, butter ~227g/cup)
   * For items that are counted (eggs, onions, etc.), use "type": "count" and only include that measurement
+  * For ingredients marked "to taste", "as needed", or similar non-quantifiable amounts: leave the "amounts" array EMPTY and put the phrase in the "notes" field instead (e.g., notes: "to taste")
 - IMPORTANT: Always spell out units fully (use "cups" not "c", "tablespoons" not "tbsp", "teaspoons" not "tsp", "grams" not "g", "ounces" not "oz", etc.)
 - Extract quantities as decimal numbers (e.g., 0.5 for 1/2, 0.25 for 1/4)
 - Include notes for ingredient modifications like "room temperature", "divided", etc.
@@ -265,7 +266,7 @@ Guidelines:
 - Keep the story brief - just the essence of any background provided
 - Return null for fields that aren't present in the source
 - Always include the alternates array (empty array if no alternates)
-- Always include the amounts array (with at least one measurement)
+- Always include the amounts array (with at least one measurement, or empty if the ingredient is "to taste", "as needed", etc.)
 - Always include the ingredients array for each step (empty array if no ingredients used in that step)
 - Always include the optional field for ingredients (default to false if not specified)
 - Always include the optional field for steps (default to false if not specified)

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
@@ -24,7 +24,7 @@ enum class MeasurementType {
  */
 @Serializable
 data class Measurement(
-    val value: Double,
+    val value: Double?,
     val unit: String,
     val type: MeasurementType,
     val isDefault: Boolean = false
@@ -108,7 +108,8 @@ data class Ingredient(
         val measurement = getPreferredMeasurement(preference)
             ?: return name + (notes?.let { ", $it" } ?: "")
 
-        val scaledQty = measurement.value * scale
+        val value = measurement.value ?: return name + (notes?.let { ", $it" } ?: "")
+        val scaledQty = value * scale
         return buildString {
             append(formatQuantity(scaledQty))
             append(" ")

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/model/IngredientTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/model/IngredientTest.kt
@@ -54,6 +54,18 @@ class IngredientTest {
     }
 
     @Test
+    fun `format with null value in measurement (to taste)`() {
+        val ingredient = Ingredient(
+            name = "salt",
+            amounts = listOf(
+                Measurement(value = null, unit = "to taste", type = MeasurementType.VOLUME, isDefault = true)
+            ),
+            notes = "to taste"
+        )
+        assertEquals("salt, to taste", ingredient.format())
+    }
+
+    @Test
     fun `format with scaling`() {
         val ingredient = Ingredient(
             name = "butter",


### PR DESCRIPTION
- Update AI prompt to explicitly handle "to taste", "as needed", and similar non-quantifiable amounts by leaving amounts array empty and storing the phrase in notes field
- Allow amounts array to be empty for ingredients that can't be precisely measured
- Make Measurement.value nullable to gracefully handle cases where value is null
- Update Ingredient.format() to handle null values in measurements
- Add test case for null values in measurements to ensure proper fallback to notes

This fixes JSON parse errors when the AI returns null values for ingredients like salt "to taste" where there is no measurable quantity.