### PR TITLE
Add click to mark ingredients used feature

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.lionotter.recipes.ui.screens.recipedetail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.lionotter.recipes.domain.model.Ingredient
 import com.lionotter.recipes.domain.model.MeasurementPreference
 import com.lionotter.recipes.domain.model.MeasurementType
 import com.lionotter.recipes.domain.model.Recipe
@@ -12,9 +13,30 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
+
+/**
+ * Represents the usage status of a global ingredient based on instruction step usage.
+ */
+data class IngredientUsageStatus(
+    val totalAmount: Double?,
+    val usedAmount: Double,
+    val unit: String?,
+    val isFullyUsed: Boolean,
+    val remainingAmount: Double?
+)
+
+/**
+ * Key to uniquely identify an ingredient in an instruction step.
+ * Format: "sectionIndex-stepIndex-ingredientIndex"
+ */
+typealias InstructionIngredientKey = String
+
+fun createInstructionIngredientKey(sectionIndex: Int, stepIndex: Int, ingredientIndex: Int): InstructionIngredientKey =
+    "$sectionIndex-$stepIndex-$ingredientIndex"
 
 @HiltViewModel
 class RecipeDetailViewModel @Inject constructor(
@@ -37,6 +59,13 @@ class RecipeDetailViewModel @Inject constructor(
 
     private val _measurementPreference = MutableStateFlow(MeasurementPreference.ORIGINAL)
     val measurementPreference: StateFlow<MeasurementPreference> = _measurementPreference.asStateFlow()
+
+    /**
+     * Tracks which instruction step ingredients have been marked as used.
+     * Key is InstructionIngredientKey (sectionIndex-stepIndex-ingredientIndex).
+     */
+    private val _usedInstructionIngredients = MutableStateFlow<Set<InstructionIngredientKey>>(emptySet())
+    val usedInstructionIngredients: StateFlow<Set<InstructionIngredientKey>> = _usedInstructionIngredients.asStateFlow()
 
     /**
      * Returns true if the recipe has ingredients with multiple measurement types available.
@@ -87,5 +116,120 @@ class RecipeDetailViewModel @Inject constructor(
 
     fun setMeasurementPreference(preference: MeasurementPreference) {
         _measurementPreference.value = preference
+    }
+
+    /**
+     * Toggles the used status of an instruction ingredient.
+     * An ingredient and its alternates are treated as one item.
+     */
+    fun toggleInstructionIngredientUsed(sectionIndex: Int, stepIndex: Int, ingredientIndex: Int) {
+        val key = createInstructionIngredientKey(sectionIndex, stepIndex, ingredientIndex)
+        _usedInstructionIngredients.value = if (key in _usedInstructionIngredients.value) {
+            _usedInstructionIngredients.value - key
+        } else {
+            _usedInstructionIngredients.value + key
+        }
+    }
+
+    /**
+     * Checks if an instruction ingredient is marked as used.
+     */
+    fun isInstructionIngredientUsed(sectionIndex: Int, stepIndex: Int, ingredientIndex: Int): Boolean {
+        val key = createInstructionIngredientKey(sectionIndex, stepIndex, ingredientIndex)
+        return key in _usedInstructionIngredients.value
+    }
+
+    /**
+     * Computes the usage status for all global ingredients based on which instruction
+     * ingredients have been marked as used.
+     * Key: ingredient name (lowercase)
+     * Value: IngredientUsageStatus with total, used, and remaining amounts
+     */
+    val globalIngredientUsage: StateFlow<Map<String, IngredientUsageStatus>> = combine(
+        recipe,
+        _usedInstructionIngredients,
+        _scale,
+        _measurementPreference
+    ) { recipe, usedKeys, scale, preference ->
+        if (recipe == null) return@combine emptyMap()
+
+        // Build a map of global ingredient totals
+        val globalTotals = mutableMapOf<String, Pair<Double?, String?>>()
+        recipe.ingredientSections.forEach { section ->
+            section.ingredients.forEach { ingredient ->
+                val key = ingredient.name.lowercase()
+                val measurement = ingredient.getPreferredMeasurement(preference)
+                val value = measurement?.value?.let { it * scale }
+                globalTotals[key] = Pair(value, measurement?.unit)
+
+                // Also include alternates as separate entries
+                ingredient.alternates.forEach { alt ->
+                    val altKey = alt.name.lowercase()
+                    val altMeasurement = alt.getPreferredMeasurement(preference)
+                    val altValue = altMeasurement?.value?.let { it * scale }
+                    globalTotals[altKey] = Pair(altValue, altMeasurement?.unit)
+                }
+            }
+        }
+
+        // Sum used amounts from instruction ingredients
+        val usedAmounts = mutableMapOf<String, Double>()
+        recipe.instructionSections.forEachIndexed { sectionIndex, section ->
+            section.steps.forEachIndexed { stepIndex, step ->
+                step.ingredients.forEachIndexed { ingredientIndex, ingredient ->
+                    val stepKey = createInstructionIngredientKey(sectionIndex, stepIndex, ingredientIndex)
+                    if (stepKey in usedKeys) {
+                        // Add this ingredient's amount to used total
+                        addIngredientUsage(ingredient, usedAmounts, scale, preference)
+                        // Also add all alternates
+                        ingredient.alternates.forEach { alt ->
+                            addIngredientUsage(alt, usedAmounts, scale, preference)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Build the result map
+        globalTotals.mapValues { (key, totalPair) ->
+            val (total, unit) = totalPair
+            val used = usedAmounts[key] ?: 0.0
+            val remaining = total?.let { it - used }
+            val isFullyUsed = when {
+                total == null -> used > 0 // For count-less ingredients, any usage means fully used
+                total <= 0 -> used > 0
+                else -> used >= total
+            }
+            IngredientUsageStatus(
+                totalAmount = total,
+                usedAmount = used,
+                unit = unit,
+                isFullyUsed = isFullyUsed,
+                remainingAmount = remaining?.coerceAtLeast(0.0)
+            )
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = emptyMap()
+    )
+
+    private fun addIngredientUsage(
+        ingredient: Ingredient,
+        usedAmounts: MutableMap<String, Double>,
+        scale: Double,
+        preference: MeasurementPreference
+    ) {
+        val key = ingredient.name.lowercase()
+        val measurement = ingredient.getPreferredMeasurement(preference)
+        val amount = measurement?.value?.let { it * scale } ?: 0.0
+        usedAmounts[key] = (usedAmounts[key] ?: 0.0) + amount
+    }
+
+    /**
+     * Resets all ingredient usage tracking.
+     */
+    fun resetIngredientUsage() {
+        _usedInstructionIngredients.value = emptySet()
     }
 }


### PR DESCRIPTION
Implements the ability to tap ingredients in instruction steps to mark them as used. Key features:

- Clickable ingredients in per-instruction ingredient lists
- Visual feedback with checkmark and strikethrough when used
- Ingredient + alternates treated as one toggleable item
- Global ingredient list syncs with instruction usage:
  - Shows strikethrough when fully used
  - Shows "x cups left" when partially used
- Global ingredient list is read-only (no clicking)

Closes #30