### PR TITLE
feat: add instruction step highlighting on click

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.ui.screens.recipedetail
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -73,6 +74,7 @@ fun RecipeDetailScreen(
     val availableMeasurementTypes by viewModel.availableMeasurementTypes.collectAsStateWithLifecycle()
     val usedInstructionIngredients by viewModel.usedInstructionIngredients.collectAsStateWithLifecycle()
     val globalIngredientUsage by viewModel.globalIngredientUsage.collectAsStateWithLifecycle()
+    val highlightedInstructionStep by viewModel.highlightedInstructionStep.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
@@ -115,6 +117,8 @@ fun RecipeDetailScreen(
                 usedInstructionIngredients = usedInstructionIngredients,
                 globalIngredientUsage = globalIngredientUsage,
                 onToggleInstructionIngredient = viewModel::toggleInstructionIngredientUsed,
+                highlightedInstructionStep = highlightedInstructionStep,
+                onToggleHighlightedInstruction = viewModel::toggleHighlightedInstructionStep,
                 modifier = Modifier.padding(paddingValues)
             )
         }
@@ -135,6 +139,8 @@ private fun RecipeContent(
     usedInstructionIngredients: Set<InstructionIngredientKey>,
     globalIngredientUsage: Map<String, IngredientUsageStatus>,
     onToggleInstructionIngredient: (Int, Int, Int) -> Unit,
+    highlightedInstructionStep: HighlightedInstructionStep?,
+    onToggleHighlightedInstruction: (Int, Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -242,7 +248,9 @@ private fun RecipeContent(
                     scale = scale,
                     measurementPreference = measurementPreference,
                     usedInstructionIngredients = usedInstructionIngredients,
-                    onToggleIngredient = onToggleInstructionIngredient
+                    onToggleIngredient = onToggleInstructionIngredient,
+                    highlightedInstructionStep = highlightedInstructionStep,
+                    onToggleHighlightedInstruction = onToggleHighlightedInstruction
                 )
             }
 
@@ -555,7 +563,9 @@ private fun InstructionSectionContent(
     scale: Double,
     measurementPreference: MeasurementPreference,
     usedInstructionIngredients: Set<InstructionIngredientKey>,
-    onToggleIngredient: (Int, Int, Int) -> Unit
+    onToggleIngredient: (Int, Int, Int) -> Unit,
+    highlightedInstructionStep: HighlightedInstructionStep?,
+    onToggleHighlightedInstruction: (Int, Int) -> Unit
 ) {
     Column {
         section.name?.let { name ->
@@ -569,31 +579,55 @@ private fun InstructionSectionContent(
         }
 
         section.steps.forEachIndexed { stepIndex, step ->
+            val isHighlighted = highlightedInstructionStep?.sectionIndex == sectionIndex &&
+                                highlightedInstructionStep?.stepIndex == stepIndex
+
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = 8.dp)
+                    .clickable { onToggleHighlightedInstruction(sectionIndex, stepIndex) }
+                    .then(
+                        if (isHighlighted) {
+                            Modifier
+                                .clip(MaterialTheme.shapes.medium)
+                                .background(MaterialTheme.colorScheme.tertiaryContainer)
+                        } else {
+                            Modifier
+                        }
+                    )
+                    .padding(horizontal = 8.dp, vertical = 8.dp)
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Card(
                         colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.primary
+                            containerColor = if (isHighlighted)
+                                MaterialTheme.colorScheme.secondaryContainer
+                            else
+                                MaterialTheme.colorScheme.primary
                         ),
                         modifier = Modifier.padding(end = 12.dp)
                     ) {
                         Text(
                             text = "${step.stepNumber}",
                             style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.onPrimary,
+                            color = if (isHighlighted)
+                                MaterialTheme.colorScheme.onSecondaryContainer
+                            else
+                                MaterialTheme.colorScheme.onPrimary,
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
                         )
                     }
                     Text(
                         text = step.instruction,
                         style = MaterialTheme.typography.bodyLarge,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
+                        color = if (isHighlighted)
+                            MaterialTheme.colorScheme.onSurface
+                        else
+                            MaterialTheme.colorScheme.onSurface
                     )
                 }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
@@ -38,6 +38,14 @@ typealias InstructionIngredientKey = String
 fun createInstructionIngredientKey(sectionIndex: Int, stepIndex: Int, ingredientIndex: Int): InstructionIngredientKey =
     "$sectionIndex-$stepIndex-$ingredientIndex"
 
+/**
+ * Represents the location of a highlighted instruction step.
+ */
+data class HighlightedInstructionStep(
+    val sectionIndex: Int,
+    val stepIndex: Int
+)
+
 @HiltViewModel
 class RecipeDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -66,6 +74,12 @@ class RecipeDetailViewModel @Inject constructor(
      */
     private val _usedInstructionIngredients = MutableStateFlow<Set<InstructionIngredientKey>>(emptySet())
     val usedInstructionIngredients: StateFlow<Set<InstructionIngredientKey>> = _usedInstructionIngredients.asStateFlow()
+
+    /**
+     * Tracks which instruction step is currently highlighted.
+     */
+    private val _highlightedInstructionStep = MutableStateFlow<HighlightedInstructionStep?>(null)
+    val highlightedInstructionStep: StateFlow<HighlightedInstructionStep?> = _highlightedInstructionStep.asStateFlow()
 
     /**
      * Returns true if the recipe has ingredients with multiple measurement types available.
@@ -231,5 +245,19 @@ class RecipeDetailViewModel @Inject constructor(
      */
     fun resetIngredientUsage() {
         _usedInstructionIngredients.value = emptySet()
+    }
+
+    /**
+     * Toggles the highlighted instruction step.
+     * If the step is already highlighted, clears the highlight.
+     * Otherwise, sets this step as highlighted.
+     */
+    fun toggleHighlightedInstructionStep(sectionIndex: Int, stepIndex: Int) {
+        val newStep = HighlightedInstructionStep(sectionIndex, stepIndex)
+        _highlightedInstructionStep.value = if (_highlightedInstructionStep.value == newStep) {
+            null
+        } else {
+            newStep
+        }
     }
 }


### PR DESCRIPTION
- Add HighlightedInstructionStep data class to track the currently highlighted step
- Add highlightedInstructionStep StateFlow to RecipeDetailViewModel
- Implement toggleHighlightedInstructionStep() method to toggle highlight state
- Make instruction steps clickable with visual feedback when highlighted
- Highlight background color uses tertiaryContainer for visual distinction
- Step number badge changes color when step is highlighted (secondary to highlight)
- Only one instruction step can be highlighted at a time (toggle behavior)
- Clicking a highlighted step clears the highlight

Addresses GH issue #29 to help users keep track of where they are in the recipe