### PR TITLE
Fix recipe page not switching to import on share

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.LionOtterRecipes">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
@@ -5,16 +5,21 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
 import com.lionotter.recipes.ui.navigation.NavGraph
 import com.lionotter.recipes.ui.theme.LionOtterTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    private val sharedIntentViewModel: SharedIntentViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -22,13 +27,23 @@ class MainActivity : ComponentActivity() {
         val sharedUrl = extractSharedUrl(intent)
         val recipeId = extractRecipeId(intent)
 
+        if (sharedUrl != null) {
+            lifecycleScope.launch {
+                sharedIntentViewModel.onSharedUrlReceived(sharedUrl)
+            }
+        }
+
         setContent {
             LionOtterTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    NavGraph(sharedUrl = sharedUrl, recipeId = recipeId)
+                    NavGraph(
+                        sharedIntentViewModel = sharedIntentViewModel,
+                        initialSharedUrl = sharedUrl,
+                        recipeId = recipeId
+                    )
                 }
             }
         }
@@ -37,6 +52,12 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        val sharedUrl = extractSharedUrl(intent)
+        if (sharedUrl != null) {
+            lifecycleScope.launch {
+                sharedIntentViewModel.onSharedUrlReceived(sharedUrl)
+            }
+        }
     }
 
     private fun extractSharedUrl(intent: Intent?): String? {

--- a/app/src/main/kotlin/com/lionotter/recipes/SharedIntentViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/SharedIntentViewModel.kt
@@ -1,0 +1,19 @@
+package com.lionotter.recipes
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SharedIntentViewModel @Inject constructor() : ViewModel() {
+    private val _sharedUrl = MutableSharedFlow<String?>(replay = 0)
+    val sharedUrl: SharedFlow<String?> = _sharedUrl
+
+    suspend fun onSharedUrlReceived(url: String?) {
+        if (url != null) {
+            _sharedUrl.emit(url)
+        }
+    }
+}


### PR DESCRIPTION
When the app was already running and displaying a recipe detail page, receiving a shared link would not navigate to the import page. This was because the MainActivity only extracted the shared URL in onCreate(), which is only called when the activity is first created.

Changes:
- Add SharedIntentViewModel to manage shared URL state across activity lifecycle
- Update MainActivity to override onNewIntent() to capture new share intents
- Set android:launchMode="singleTop" to ensure onNewIntent() is called
- Update NavGraph to observe shared URL changes and navigate to AddRecipe when a new URL is received

Now when a user shares a link while the app is running, the app will navigate to the import page with the shared URL pre-populated.