### PR TITLE
Make background notifications clickable for recipes

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
@@ -20,6 +20,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         val sharedUrl = extractSharedUrl(intent)
+        val recipeId = extractRecipeId(intent)
 
         setContent {
             LionOtterTheme {
@@ -27,10 +28,15 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    NavGraph(sharedUrl = sharedUrl)
+                    NavGraph(sharedUrl = sharedUrl, recipeId = recipeId)
                 }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
     }
 
     private fun extractSharedUrl(intent: Intent?): String? {
@@ -40,5 +46,9 @@ class MainActivity : ComponentActivity() {
             }
             else -> null
         }
+    }
+
+    private fun extractRecipeId(intent: Intent?): String? {
+        return intent?.getStringExtra("recipe_id")
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
@@ -25,13 +25,13 @@ sealed class Screen(val route: String) {
 }
 
 @Composable
-fun NavGraph(sharedUrl: String? = null) {
+fun NavGraph(sharedUrl: String? = null, recipeId: String? = null) {
     val navController = rememberNavController()
 
-    val startDestination = if (sharedUrl != null) {
-        Screen.AddRecipe.createRoute(sharedUrl)
-    } else {
-        Screen.RecipeList.route
+    val startDestination = when {
+        recipeId != null -> Screen.RecipeDetail.createRoute(recipeId)
+        sharedUrl != null -> Screen.AddRecipe.createRoute(sharedUrl)
+        else -> Screen.RecipeList.route
     }
 
     // Helper to navigate back, falling back to RecipeList if back stack is empty.


### PR DESCRIPTION
- Extract recipe_id from notification intent in MainActivity
- Add onNewIntent() override to handle clicks when app is already running
- Update NavGraph to navigate to RecipeDetail when recipeId is provided
- Prioritize recipeId over sharedUrl for start destination selection
- Works with existing ImportNotificationHelper PendingIntent