### PR TITLE
Add Google Drive export for recipes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,14 @@ android {
     lint {
         checkReleaseBuilds = false
     }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            excludes += "META-INF/DEPENDENCIES"
+            excludes += "META-INF/INDEX.LIST"
+        }
+    }
 }
 
 dependencies {
@@ -113,6 +121,13 @@ dependencies {
 
     // HTML parsing
     implementation(libs.jsoup)
+
+    // Google Drive
+    implementation(libs.play.services.auth)
+    implementation(libs.google.api.client)
+    implementation(libs.google.drive.api) {
+        exclude(group = "org.apache.httpcomponents")
+    }
 
     // Testing
     testImplementation(libs.junit)

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/GoogleDriveService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/GoogleDriveService.kt
@@ -1,0 +1,384 @@
+package com.lionotter.recipes.data.remote
+
+import android.content.Context
+import android.content.Intent
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.common.api.Scope
+import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential
+import com.google.api.client.http.ByteArrayContent
+import com.google.api.client.http.javanet.NetHttpTransport
+import com.google.api.client.json.gson.GsonFactory
+import com.google.api.services.drive.Drive
+import com.google.api.services.drive.DriveScopes
+import com.google.api.services.drive.model.File
+import com.google.api.services.drive.model.FileList
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Represents a folder in Google Drive.
+ */
+data class DriveFolder(
+    val id: String,
+    val name: String
+)
+
+/**
+ * Represents a file in Google Drive.
+ */
+data class DriveFile(
+    val id: String,
+    val name: String,
+    val mimeType: String
+)
+
+/**
+ * Service for interacting with Google Drive API.
+ * Handles authentication, folder operations, and file uploads/downloads.
+ */
+@Singleton
+class GoogleDriveService @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private const val APP_NAME = "Lion+Otter Recipes"
+        private const val MIME_TYPE_FOLDER = "application/vnd.google-apps.folder"
+        private const val MIME_TYPE_JSON = "application/json"
+        private const val MIME_TYPE_HTML = "text/html"
+        private const val MIME_TYPE_MARKDOWN = "text/markdown"
+
+        // File names used in recipe export
+        const val RECIPE_JSON_FILENAME = "recipe.json"
+        const val RECIPE_HTML_FILENAME = "original.html"
+        const val RECIPE_MARKDOWN_FILENAME = "recipe.md"
+    }
+
+    private var driveService: Drive? = null
+    private var signInClient: GoogleSignInClient? = null
+
+    /**
+     * Returns the Google Sign-In intent for the activity to launch.
+     */
+    fun getSignInIntent(): Intent {
+        val signInOptions = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestEmail()
+            .requestScopes(Scope(DriveScopes.DRIVE_FILE))
+            .build()
+
+        signInClient = GoogleSignIn.getClient(context, signInOptions)
+        return signInClient!!.signInIntent
+    }
+
+    /**
+     * Handle sign-in result from the activity.
+     * @return true if sign-in was successful
+     */
+    suspend fun handleSignInResult(account: GoogleSignInAccount?): Boolean {
+        if (account == null) return false
+
+        return withContext(Dispatchers.IO) {
+            try {
+                initializeDriveService(account)
+                true
+            } catch (e: Exception) {
+                false
+            }
+        }
+    }
+
+    /**
+     * Check if user is signed in with Drive access.
+     */
+    fun isSignedIn(): Boolean {
+        val account = GoogleSignIn.getLastSignedInAccount(context)
+        if (account != null && GoogleSignIn.hasPermissions(account, Scope(DriveScopes.DRIVE_FILE))) {
+            if (driveService == null) {
+                initializeDriveService(account)
+            }
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Sign out from Google Drive.
+     */
+    suspend fun signOut() {
+        withContext(Dispatchers.IO) {
+            val signInOptions = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                .requestEmail()
+                .requestScopes(Scope(DriveScopes.DRIVE_FILE))
+                .build()
+            val client = GoogleSignIn.getClient(context, signInOptions)
+            client.signOut()
+            client.revokeAccess()
+            driveService = null
+        }
+    }
+
+    /**
+     * Get the signed-in user's email.
+     */
+    fun getSignedInEmail(): String? {
+        return GoogleSignIn.getLastSignedInAccount(context)?.email
+    }
+
+    private fun initializeDriveService(account: GoogleSignInAccount) {
+        val credential = GoogleAccountCredential.usingOAuth2(
+            context,
+            listOf(DriveScopes.DRIVE_FILE)
+        ).apply {
+            selectedAccount = account.account
+        }
+
+        driveService = Drive.Builder(
+            NetHttpTransport(),
+            GsonFactory.getDefaultInstance(),
+            credential
+        )
+            .setApplicationName(APP_NAME)
+            .build()
+    }
+
+    private fun requireDriveService(): Drive {
+        return driveService ?: throw IllegalStateException("Not signed in to Google Drive")
+    }
+
+    /**
+     * List folders in the user's Drive that this app can access.
+     */
+    suspend fun listFolders(parentFolderId: String? = null): Result<List<DriveFolder>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val drive = requireDriveService()
+
+                val query = buildString {
+                    append("mimeType = '$MIME_TYPE_FOLDER' and trashed = false")
+                    if (parentFolderId != null) {
+                        append(" and '$parentFolderId' in parents")
+                    }
+                }
+
+                val result = drive.files().list()
+                    .setQ(query)
+                    .setSpaces("drive")
+                    .setFields("files(id, name)")
+                    .setOrderBy("name")
+                    .execute()
+
+                val folders = result.files?.map { file ->
+                    DriveFolder(id = file.id, name = file.name)
+                } ?: emptyList()
+
+                Result.success(folders)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    /**
+     * Create a new folder in Drive.
+     */
+    suspend fun createFolder(
+        name: String,
+        parentFolderId: String? = null
+    ): Result<DriveFolder> = withContext(Dispatchers.IO) {
+        try {
+            val drive = requireDriveService()
+
+            val fileMetadata = File().apply {
+                this.name = name
+                mimeType = MIME_TYPE_FOLDER
+                if (parentFolderId != null) {
+                    parents = listOf(parentFolderId)
+                }
+            }
+
+            val folder = drive.files().create(fileMetadata)
+                .setFields("id, name")
+                .execute()
+
+            Result.success(DriveFolder(id = folder.id, name = folder.name))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Upload a text file to Drive.
+     */
+    suspend fun uploadTextFile(
+        fileName: String,
+        content: String,
+        mimeType: String,
+        parentFolderId: String
+    ): Result<DriveFile> = withContext(Dispatchers.IO) {
+        try {
+            val drive = requireDriveService()
+
+            val fileMetadata = File().apply {
+                name = fileName
+                parents = listOf(parentFolderId)
+            }
+
+            val mediaContent = ByteArrayContent(mimeType, content.toByteArray(Charsets.UTF_8))
+
+            val file = drive.files().create(fileMetadata, mediaContent)
+                .setFields("id, name, mimeType")
+                .execute()
+
+            Result.success(DriveFile(id = file.id, name = file.name, mimeType = file.mimeType))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Upload JSON file to Drive.
+     */
+    suspend fun uploadJsonFile(
+        fileName: String,
+        content: String,
+        parentFolderId: String
+    ): Result<DriveFile> = uploadTextFile(fileName, content, MIME_TYPE_JSON, parentFolderId)
+
+    /**
+     * Upload HTML file to Drive.
+     */
+    suspend fun uploadHtmlFile(
+        fileName: String,
+        content: String,
+        parentFolderId: String
+    ): Result<DriveFile> = uploadTextFile(fileName, content, MIME_TYPE_HTML, parentFolderId)
+
+    /**
+     * Upload Markdown file to Drive.
+     */
+    suspend fun uploadMarkdownFile(
+        fileName: String,
+        content: String,
+        parentFolderId: String
+    ): Result<DriveFile> = uploadTextFile(fileName, content, MIME_TYPE_MARKDOWN, parentFolderId)
+
+    /**
+     * List files in a folder.
+     */
+    suspend fun listFiles(folderId: String): Result<List<DriveFile>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val drive = requireDriveService()
+
+                val query = "'$folderId' in parents and trashed = false"
+
+                val result = drive.files().list()
+                    .setQ(query)
+                    .setSpaces("drive")
+                    .setFields("files(id, name, mimeType)")
+                    .execute()
+
+                val files = result.files?.map { file ->
+                    DriveFile(id = file.id, name = file.name, mimeType = file.mimeType ?: "")
+                } ?: emptyList()
+
+                Result.success(files)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    /**
+     * List recipe folders in a parent folder.
+     * Recipe folders are subfolders that contain recipe.json, original.html, and recipe.md.
+     */
+    suspend fun listRecipeFolders(parentFolderId: String): Result<List<DriveFolder>> =
+        listFolders(parentFolderId)
+
+    /**
+     * Download a text file from Drive.
+     */
+    suspend fun downloadTextFile(fileId: String): Result<String> =
+        withContext(Dispatchers.IO) {
+            try {
+                val drive = requireDriveService()
+
+                val outputStream = java.io.ByteArrayOutputStream()
+                drive.files().get(fileId)
+                    .executeMediaAndDownloadTo(outputStream)
+
+                val content = outputStream.toString(Charsets.UTF_8.name())
+                Result.success(content)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    /**
+     * Check if a folder contains a specific file.
+     */
+    suspend fun findFileInFolder(folderId: String, fileName: String): DriveFile? =
+        withContext(Dispatchers.IO) {
+            try {
+                val drive = requireDriveService()
+
+                val query = "'$folderId' in parents and name = '$fileName' and trashed = false"
+
+                val result = drive.files().list()
+                    .setQ(query)
+                    .setSpaces("drive")
+                    .setFields("files(id, name, mimeType)")
+                    .setPageSize(1)
+                    .execute()
+
+                result.files?.firstOrNull()?.let { file ->
+                    DriveFile(id = file.id, name = file.name, mimeType = file.mimeType ?: "")
+                }
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+    /**
+     * Find or create a folder with the given name in the parent folder.
+     */
+    suspend fun findOrCreateFolder(
+        name: String,
+        parentFolderId: String? = null
+    ): Result<DriveFolder> = withContext(Dispatchers.IO) {
+        try {
+            val drive = requireDriveService()
+
+            // First, try to find existing folder
+            val query = buildString {
+                append("mimeType = '$MIME_TYPE_FOLDER' and name = '${name.replace("'", "\\'")}' and trashed = false")
+                if (parentFolderId != null) {
+                    append(" and '$parentFolderId' in parents")
+                }
+            }
+
+            val existingResult = drive.files().list()
+                .setQ(query)
+                .setSpaces("drive")
+                .setFields("files(id, name)")
+                .setPageSize(1)
+                .execute()
+
+            val existingFolder = existingResult.files?.firstOrNull()
+            if (existingFolder != null) {
+                return@withContext Result.success(
+                    DriveFolder(id = existingFolder.id, name = existingFolder.name)
+                )
+            }
+
+            // Create new folder if not found
+            createFolder(name, parentFolderId)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
@@ -33,6 +33,13 @@ class RecipeRepository @Inject constructor(
         return recipeDao.getRecipeById(id)?.let { entityToRecipe(it) }
     }
 
+    /**
+     * Get the original HTML content for a recipe.
+     */
+    suspend fun getOriginalHtml(id: String): String? {
+        return recipeDao.getRecipeById(id)?.originalHtml
+    }
+
     fun getRecipesByTag(tag: String): Flow<List<Recipe>> {
         return recipeDao.getRecipesByTag(tag).map { entities ->
             entities.map { entity -> entityToRecipe(entity) }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportToGoogleDriveUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportToGoogleDriveUseCase.kt
@@ -1,0 +1,200 @@
+package com.lionotter.recipes.domain.usecase
+
+import com.lionotter.recipes.data.remote.DriveFolder
+import com.lionotter.recipes.data.remote.GoogleDriveService
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.util.RecipeMarkdownFormatter
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+
+/**
+ * Use case for exporting recipes to Google Drive.
+ * Creates a subfolder for each recipe containing:
+ * - recipe.json: The structured recipe data
+ * - original.html: The original HTML page (if available)
+ * - recipe.md: A human-readable Markdown version
+ */
+class ExportToGoogleDriveUseCase @Inject constructor(
+    private val googleDriveService: GoogleDriveService,
+    private val recipeRepository: RecipeRepository,
+    private val json: Json
+) {
+    sealed class ExportResult {
+        data class Success(
+            val exportedCount: Int,
+            val failedCount: Int,
+            val rootFolder: DriveFolder
+        ) : ExportResult()
+
+        data class Error(val message: String) : ExportResult()
+        object NotSignedIn : ExportResult()
+    }
+
+    sealed class ExportProgress {
+        object Starting : ExportProgress()
+        data class CreatingRootFolder(val folderName: String) : ExportProgress()
+        data class ExportingRecipe(
+            val recipeName: String,
+            val current: Int,
+            val total: Int
+        ) : ExportProgress()
+
+        data class Complete(val result: ExportResult) : ExportProgress()
+    }
+
+    /**
+     * Export all recipes to Google Drive.
+     *
+     * @param parentFolderId Optional parent folder ID. If null, creates in root.
+     * @param rootFolderName Name for the export folder (default: "Lion+Otter Recipes Export")
+     * @param onProgress Callback for progress updates
+     */
+    suspend fun exportAllRecipes(
+        parentFolderId: String? = null,
+        rootFolderName: String = "Lion+Otter Recipes Export",
+        onProgress: suspend (ExportProgress) -> Unit = {}
+    ): ExportResult {
+        if (!googleDriveService.isSignedIn()) {
+            return ExportResult.NotSignedIn
+        }
+
+        onProgress(ExportProgress.Starting)
+
+        // Get all recipes
+        val recipes = recipeRepository.getAllRecipes().first()
+        if (recipes.isEmpty()) {
+            return ExportResult.Error("No recipes to export")
+        }
+
+        // Create or find the root export folder
+        onProgress(ExportProgress.CreatingRootFolder(rootFolderName))
+        val rootFolderResult = googleDriveService.findOrCreateFolder(rootFolderName, parentFolderId)
+        if (rootFolderResult.isFailure) {
+            return ExportResult.Error(
+                "Failed to create export folder: ${rootFolderResult.exceptionOrNull()?.message}"
+            )
+        }
+        val rootFolder = rootFolderResult.getOrThrow()
+
+        var exportedCount = 0
+        var failedCount = 0
+
+        // Export each recipe
+        recipes.forEachIndexed { index, recipe ->
+            onProgress(
+                ExportProgress.ExportingRecipe(
+                    recipeName = recipe.name,
+                    current = index + 1,
+                    total = recipes.size
+                )
+            )
+
+            val success = exportRecipe(recipe, rootFolder.id)
+            if (success) {
+                exportedCount++
+            } else {
+                failedCount++
+            }
+        }
+
+        val result = ExportResult.Success(
+            exportedCount = exportedCount,
+            failedCount = failedCount,
+            rootFolder = rootFolder
+        )
+        onProgress(ExportProgress.Complete(result))
+        return result
+    }
+
+    /**
+     * Export a single recipe to Google Drive.
+     *
+     * @param recipeId The recipe ID to export
+     * @param parentFolderId The folder to export into
+     */
+    suspend fun exportSingleRecipe(
+        recipeId: String,
+        parentFolderId: String
+    ): Result<DriveFolder> {
+        if (!googleDriveService.isSignedIn()) {
+            return Result.failure(IllegalStateException("Not signed in to Google Drive"))
+        }
+
+        val recipe = recipeRepository.getRecipeByIdOnce(recipeId)
+            ?: return Result.failure(IllegalArgumentException("Recipe not found: $recipeId"))
+
+        return if (exportRecipe(recipe, parentFolderId)) {
+            // Return the folder that was created
+            googleDriveService.listFolders(parentFolderId).map { folders ->
+                folders.find { it.name == sanitizeFolderName(recipe.name) }
+                    ?: throw IllegalStateException("Failed to find exported folder")
+            }
+        } else {
+            Result.failure(Exception("Failed to export recipe"))
+        }
+    }
+
+    private suspend fun exportRecipe(recipe: Recipe, parentFolderId: String): Boolean {
+        return try {
+            // Create folder for this recipe
+            val folderName = sanitizeFolderName(recipe.name)
+            val folderResult = googleDriveService.createFolder(folderName, parentFolderId)
+            if (folderResult.isFailure) {
+                return false
+            }
+            val recipeFolder = folderResult.getOrThrow()
+
+            // Upload recipe.json
+            val recipeJson = json.encodeToString(recipe)
+            val jsonResult = googleDriveService.uploadJsonFile(
+                fileName = GoogleDriveService.RECIPE_JSON_FILENAME,
+                content = recipeJson,
+                parentFolderId = recipeFolder.id
+            )
+            if (jsonResult.isFailure) {
+                return false
+            }
+
+            // Upload original.html (if available)
+            val originalHtml = recipeRepository.getOriginalHtml(recipe.id)
+            if (originalHtml != null) {
+                googleDriveService.uploadHtmlFile(
+                    fileName = GoogleDriveService.RECIPE_HTML_FILENAME,
+                    content = originalHtml,
+                    parentFolderId = recipeFolder.id
+                )
+                // Don't fail if HTML upload fails - it's optional
+            }
+
+            // Upload recipe.md
+            val markdown = RecipeMarkdownFormatter.format(recipe)
+            val mdResult = googleDriveService.uploadMarkdownFile(
+                fileName = GoogleDriveService.RECIPE_MARKDOWN_FILENAME,
+                content = markdown,
+                parentFolderId = recipeFolder.id
+            )
+            if (mdResult.isFailure) {
+                return false
+            }
+
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Sanitize a recipe name for use as a folder name.
+     */
+    private fun sanitizeFolderName(name: String): String {
+        return name
+            .replace(Regex("[/\\\\:*?\"<>|]"), "_") // Replace invalid characters
+            .replace(Regex("\\s+"), " ") // Normalize whitespace
+            .trim()
+            .take(100) // Limit length
+            .ifEmpty { "Untitled Recipe" }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportFromGoogleDriveUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportFromGoogleDriveUseCase.kt
@@ -1,0 +1,237 @@
+package com.lionotter.recipes.domain.usecase
+
+import com.lionotter.recipes.data.remote.DriveFile
+import com.lionotter.recipes.data.remote.DriveFolder
+import com.lionotter.recipes.data.remote.GoogleDriveService
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.model.Recipe
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * Use case for importing recipes from Google Drive.
+ * For each recipe folder, it:
+ * 1. First tries to load recipe.json directly
+ * 2. If JSON loading fails, falls back to importing the HTML via the standard AI process
+ *
+ * This reuses the existing ParseHtmlUseCase to avoid duplicate logic.
+ */
+class ImportFromGoogleDriveUseCase @Inject constructor(
+    private val googleDriveService: GoogleDriveService,
+    private val recipeRepository: RecipeRepository,
+    private val parseHtmlUseCase: ParseHtmlUseCase,
+    private val json: Json
+) {
+    sealed class ImportResult {
+        data class Success(
+            val importedCount: Int,
+            val failedCount: Int,
+            val skippedCount: Int
+        ) : ImportResult()
+
+        data class Error(val message: String) : ImportResult()
+        object NotSignedIn : ImportResult()
+        object NoApiKey : ImportResult()
+    }
+
+    sealed class ImportProgress {
+        object Starting : ImportProgress()
+        object ListingFolders : ImportProgress()
+        data class ImportingRecipe(
+            val folderName: String,
+            val method: ImportMethod,
+            val current: Int,
+            val total: Int
+        ) : ImportProgress()
+
+        data class Complete(val result: ImportResult) : ImportProgress()
+    }
+
+    enum class ImportMethod {
+        JSON,           // Loaded directly from JSON
+        HTML_FALLBACK   // Fell back to HTML parsing via AI
+    }
+
+    /**
+     * Import all recipes from a Google Drive folder.
+     *
+     * @param folderId The ID of the folder containing recipe subfolders
+     * @param onProgress Callback for progress updates
+     */
+    suspend fun importFromFolder(
+        folderId: String,
+        onProgress: suspend (ImportProgress) -> Unit = {}
+    ): ImportResult {
+        if (!googleDriveService.isSignedIn()) {
+            return ImportResult.NotSignedIn
+        }
+
+        onProgress(ImportProgress.Starting)
+
+        // List recipe folders
+        onProgress(ImportProgress.ListingFolders)
+        val foldersResult = googleDriveService.listRecipeFolders(folderId)
+        if (foldersResult.isFailure) {
+            return ImportResult.Error(
+                "Failed to list folders: ${foldersResult.exceptionOrNull()?.message}"
+            )
+        }
+
+        val recipeFolders = foldersResult.getOrThrow()
+        if (recipeFolders.isEmpty()) {
+            return ImportResult.Error("No recipe folders found")
+        }
+
+        var importedCount = 0
+        var failedCount = 0
+        var skippedCount = 0
+
+        // Import each recipe folder
+        recipeFolders.forEachIndexed { index, folder ->
+            val importMethod = ImportMethod.JSON // Will be updated during import
+
+            onProgress(
+                ImportProgress.ImportingRecipe(
+                    folderName = folder.name,
+                    method = importMethod,
+                    current = index + 1,
+                    total = recipeFolders.size
+                )
+            )
+
+            val result = importRecipeFromFolder(folder)
+            when (result) {
+                is SingleImportResult.Success -> importedCount++
+                is SingleImportResult.Skipped -> skippedCount++
+                is SingleImportResult.Failed -> failedCount++
+                is SingleImportResult.NoApiKey -> {
+                    // If we need API key for HTML fallback but don't have one, count as failed
+                    failedCount++
+                }
+            }
+        }
+
+        val result = ImportResult.Success(
+            importedCount = importedCount,
+            failedCount = failedCount,
+            skippedCount = skippedCount
+        )
+        onProgress(ImportProgress.Complete(result))
+        return result
+    }
+
+    /**
+     * Import a single recipe from a folder.
+     */
+    suspend fun importSingleRecipe(folderId: String): SingleImportResult {
+        if (!googleDriveService.isSignedIn()) {
+            return SingleImportResult.Failed("Not signed in to Google Drive")
+        }
+
+        // Get folder info
+        val foldersResult = googleDriveService.listFolders()
+        if (foldersResult.isFailure) {
+            return SingleImportResult.Failed("Failed to access folder")
+        }
+
+        val folder = DriveFolder(id = folderId, name = "Recipe")
+        return importRecipeFromFolder(folder)
+    }
+
+    private suspend fun importRecipeFromFolder(folder: DriveFolder): SingleImportResult {
+        // Try to find recipe.json first
+        val jsonFile = googleDriveService.findFileInFolder(
+            folderId = folder.id,
+            fileName = GoogleDriveService.RECIPE_JSON_FILENAME
+        )
+
+        if (jsonFile != null) {
+            // Try to load from JSON
+            val jsonResult = tryImportFromJson(jsonFile)
+            if (jsonResult is SingleImportResult.Success) {
+                return jsonResult
+            }
+            // If JSON import failed, fall through to HTML fallback
+        }
+
+        // Try HTML fallback
+        val htmlFile = googleDriveService.findFileInFolder(
+            folderId = folder.id,
+            fileName = GoogleDriveService.RECIPE_HTML_FILENAME
+        )
+
+        if (htmlFile != null) {
+            return tryImportFromHtml(htmlFile, folder.name)
+        }
+
+        // Neither JSON nor HTML found
+        return SingleImportResult.Failed("No recipe.json or original.html found in folder: ${folder.name}")
+    }
+
+    private suspend fun tryImportFromJson(jsonFile: DriveFile): SingleImportResult {
+        return try {
+            val contentResult = googleDriveService.downloadTextFile(jsonFile.id)
+            if (contentResult.isFailure) {
+                return SingleImportResult.Failed("Failed to download JSON: ${contentResult.exceptionOrNull()?.message}")
+            }
+
+            val jsonContent = contentResult.getOrThrow()
+            val recipe = json.decodeFromString<Recipe>(jsonContent)
+
+            // Generate new ID to avoid conflicts with existing recipes
+            val importedRecipe = recipe.copy(
+                id = UUID.randomUUID().toString(),
+                updatedAt = kotlinx.datetime.Clock.System.now()
+            )
+
+            // Save to database without original HTML (we could download it but it's not essential)
+            recipeRepository.saveRecipe(importedRecipe)
+
+            SingleImportResult.Success(importedRecipe, ImportMethod.JSON)
+        } catch (e: Exception) {
+            SingleImportResult.Failed("Failed to parse JSON: ${e.message}")
+        }
+    }
+
+    private suspend fun tryImportFromHtml(htmlFile: DriveFile, folderName: String): SingleImportResult {
+        return try {
+            val contentResult = googleDriveService.downloadTextFile(htmlFile.id)
+            if (contentResult.isFailure) {
+                return SingleImportResult.Failed("Failed to download HTML: ${contentResult.exceptionOrNull()?.message}")
+            }
+
+            val htmlContent = contentResult.getOrThrow()
+
+            // Use the ParseHtmlUseCase to parse the HTML (reusing existing logic)
+            val parseResult = parseHtmlUseCase.execute(
+                html = htmlContent,
+                sourceUrl = null,
+                imageUrl = null,
+                saveRecipe = true
+            )
+
+            when (parseResult) {
+                is ParseHtmlUseCase.ParseResult.Success -> {
+                    SingleImportResult.Success(parseResult.recipe, ImportMethod.HTML_FALLBACK)
+                }
+                is ParseHtmlUseCase.ParseResult.Error -> {
+                    SingleImportResult.Failed(parseResult.message)
+                }
+                ParseHtmlUseCase.ParseResult.NoApiKey -> {
+                    SingleImportResult.NoApiKey
+                }
+            }
+        } catch (e: Exception) {
+            SingleImportResult.Failed("Failed to import from HTML: ${e.message}")
+        }
+    }
+
+    sealed class SingleImportResult {
+        data class Success(val recipe: Recipe, val method: ImportMethod) : SingleImportResult()
+        data class Skipped(val reason: String) : SingleImportResult()
+        data class Failed(val reason: String) : SingleImportResult()
+        object NoApiKey : SingleImportResult()
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -1,0 +1,147 @@
+package com.lionotter.recipes.domain.usecase
+
+import com.lionotter.recipes.data.local.SettingsDataStore
+import com.lionotter.recipes.data.remote.AnthropicService
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.model.Recipe
+import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Clock
+import net.dankito.readability4j.Readability4J
+import org.jsoup.Jsoup
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * Use case for parsing HTML content into a Recipe using AI.
+ * This is a reusable helper that can be called from:
+ * - ImportRecipeUseCase (URL-based import)
+ * - Google Drive import (HTML fallback)
+ */
+class ParseHtmlUseCase @Inject constructor(
+    private val anthropicService: AnthropicService,
+    private val recipeRepository: RecipeRepository,
+    private val settingsDataStore: SettingsDataStore
+) {
+    sealed class ParseResult {
+        data class Success(val recipe: Recipe) : ParseResult()
+        data class Error(val message: String) : ParseResult()
+        object NoApiKey : ParseResult()
+    }
+
+    sealed class ParseProgress {
+        object ExtractingContent : ParseProgress()
+        object ParsingRecipe : ParseProgress()
+        data class RecipeNameAvailable(val name: String) : ParseProgress()
+        object SavingRecipe : ParseProgress()
+        data class Complete(val result: ParseResult) : ParseProgress()
+    }
+
+    /**
+     * Parse HTML content into a Recipe using AI.
+     *
+     * @param html The raw HTML content
+     * @param sourceUrl Optional URL for the recipe source
+     * @param imageUrl Optional image URL extracted from the page
+     * @param saveRecipe Whether to save the recipe to the database (default true)
+     * @param onProgress Callback for progress updates
+     * @return The parsed recipe or error
+     */
+    suspend fun execute(
+        html: String,
+        sourceUrl: String? = null,
+        imageUrl: String? = null,
+        saveRecipe: Boolean = true,
+        onProgress: suspend (ParseProgress) -> Unit = {}
+    ): ParseResult {
+        // Check for API key
+        val apiKey = settingsDataStore.anthropicApiKey.first()
+        if (apiKey.isNullOrBlank()) {
+            return ParseResult.NoApiKey
+        }
+
+        val model = settingsDataStore.aiModel.first()
+
+        // Extract content from HTML
+        onProgress(ParseProgress.ExtractingContent)
+        val extractedContent = extractContent(html, sourceUrl)
+        val extractedImageUrl = imageUrl ?: extractImageUrl(html)
+
+        // Parse with AI
+        onProgress(ParseProgress.ParsingRecipe)
+        val parseResult = anthropicService.parseRecipe(extractedContent, apiKey, model)
+        if (parseResult.isFailure) {
+            return ParseResult.Error("Failed to parse recipe: ${parseResult.exceptionOrNull()?.message}")
+        }
+        val parsed = parseResult.getOrThrow()
+
+        // Notify that recipe name is available
+        onProgress(ParseProgress.RecipeNameAvailable(parsed.name))
+
+        // Create Recipe
+        val now = Clock.System.now()
+        val recipe = Recipe(
+            id = UUID.randomUUID().toString(),
+            name = parsed.name,
+            sourceUrl = sourceUrl,
+            story = parsed.story,
+            servings = parsed.servings,
+            prepTime = parsed.prepTime,
+            cookTime = parsed.cookTime,
+            totalTime = parsed.totalTime,
+            ingredientSections = parsed.ingredientSections,
+            instructionSections = parsed.instructionSections,
+            tags = parsed.tags,
+            imageUrl = extractedImageUrl,
+            createdAt = now,
+            updatedAt = now
+        )
+
+        // Save to database if requested
+        if (saveRecipe) {
+            onProgress(ParseProgress.SavingRecipe)
+            recipeRepository.saveRecipe(recipe, originalHtml = html)
+        }
+
+        onProgress(ParseProgress.Complete(ParseResult.Success(recipe)))
+        return ParseResult.Success(recipe)
+    }
+
+    private fun extractContent(html: String, sourceUrl: String?): String {
+        return try {
+            val url = sourceUrl ?: "https://example.com"
+            val readability = Readability4J(url, html)
+            val article = readability.parse()
+
+            val title = article.title
+            val content = article.textContent?.takeIf { it.isNotBlank() }
+                ?: article.content
+                ?: html
+
+            buildString {
+                if (!title.isNullOrBlank()) {
+                    appendLine("Title: $title")
+                    appendLine()
+                }
+                append(content)
+            }
+        } catch (e: Exception) {
+            html
+        }
+    }
+
+    private fun extractImageUrl(html: String): String? {
+        return try {
+            val doc = Jsoup.parse(html)
+            doc.selectFirst("meta[property=og:image]")?.attr("content")
+                ?.takeIf { it.isNotBlank() }
+                ?: doc.selectFirst("meta[name=og:image]")?.attr("content")
+                    ?.takeIf { it.isNotBlank() }
+                ?: doc.selectFirst("meta[name=twitter:image]")?.attr("content")
+                    ?.takeIf { it.isNotBlank() }
+                ?: doc.selectFirst("meta[name=image]")?.attr("content")
+                    ?.takeIf { it.isNotBlank() }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeMarkdownFormatter.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeMarkdownFormatter.kt
@@ -1,0 +1,198 @@
+package com.lionotter.recipes.domain.util
+
+import com.lionotter.recipes.domain.model.Ingredient
+import com.lionotter.recipes.domain.model.IngredientSection
+import com.lionotter.recipes.domain.model.InstructionSection
+import com.lionotter.recipes.domain.model.InstructionStep
+import com.lionotter.recipes.domain.model.Measurement
+import com.lionotter.recipes.domain.model.MeasurementPreference
+import com.lionotter.recipes.domain.model.Recipe
+
+/**
+ * Converts a Recipe to a human-readable Markdown format.
+ */
+object RecipeMarkdownFormatter {
+
+    fun format(recipe: Recipe): String = buildString {
+        // Title
+        appendLine("# ${recipe.name}")
+        appendLine()
+
+        // Source URL
+        recipe.sourceUrl?.let { url ->
+            appendLine("*Source: [$url]($url)*")
+            appendLine()
+        }
+
+        // Story/Description
+        recipe.story?.let { story ->
+            appendLine(story)
+            appendLine()
+        }
+
+        // Metadata section
+        val metadata = buildList {
+            recipe.servings?.let { add("**Servings:** $it") }
+            recipe.prepTime?.let { add("**Prep Time:** $it") }
+            recipe.cookTime?.let { add("**Cook Time:** $it") }
+            recipe.totalTime?.let { add("**Total Time:** $it") }
+        }
+        if (metadata.isNotEmpty()) {
+            appendLine(metadata.joinToString(" | "))
+            appendLine()
+        }
+
+        // Tags
+        if (recipe.tags.isNotEmpty()) {
+            appendLine("**Tags:** ${recipe.tags.joinToString(", ")}")
+            appendLine()
+        }
+
+        appendLine("---")
+        appendLine()
+
+        // Ingredients section
+        appendLine("## Ingredients")
+        appendLine()
+        formatIngredientSections(recipe.ingredientSections)
+        appendLine()
+
+        // Instructions section
+        appendLine("## Instructions")
+        appendLine()
+        formatInstructionSections(recipe.instructionSections)
+    }
+
+    private fun StringBuilder.formatIngredientSections(sections: List<IngredientSection>) {
+        if (sections.isEmpty()) {
+            appendLine("*No ingredients listed*")
+            return
+        }
+
+        sections.forEach { section ->
+            // Section header (if named)
+            section.name?.let { name ->
+                appendLine("### $name")
+                appendLine()
+            }
+
+            // Ingredients list
+            section.ingredients.forEach { ingredient ->
+                appendLine(formatIngredient(ingredient))
+            }
+            appendLine()
+        }
+    }
+
+    private fun formatIngredient(ingredient: Ingredient): String = buildString {
+        append("- ")
+
+        // Format amounts
+        if (ingredient.amounts.isNotEmpty()) {
+            val formattedAmounts = ingredient.amounts.map { formatMeasurement(it) }
+
+            // Show default amount first, then alternatives
+            val defaultAmount = ingredient.amounts.find { it.isDefault }
+                ?: ingredient.amounts.firstOrNull()
+            val otherAmounts = ingredient.amounts.filter { it != defaultAmount }
+
+            defaultAmount?.let { append("${formatMeasurement(it)} ") }
+
+            if (otherAmounts.isNotEmpty()) {
+                append("(${otherAmounts.joinToString(" / ") { formatMeasurement(it) }}) ")
+            }
+        }
+
+        // Ingredient name
+        append(ingredient.name)
+
+        // Notes
+        ingredient.notes?.let { notes ->
+            append(", $notes")
+        }
+
+        // Optional marker
+        if (ingredient.optional) {
+            append(" *(optional)*")
+        }
+
+        // Alternates
+        if (ingredient.alternates.isNotEmpty()) {
+            append(" OR ")
+            append(ingredient.alternates.joinToString(" OR ") { alt ->
+                buildString {
+                    if (alt.amounts.isNotEmpty()) {
+                        append("${formatMeasurement(alt.amounts.first())} ")
+                    }
+                    append(alt.name)
+                    alt.notes?.let { append(", $it") }
+                }
+            })
+        }
+    }
+
+    private fun formatMeasurement(measurement: Measurement): String {
+        val value = measurement.value ?: return measurement.unit
+        val formattedValue = formatQuantity(value)
+        return "$formattedValue ${measurement.unit}"
+    }
+
+    private fun formatQuantity(qty: Double): String {
+        return if (qty == qty.toLong().toDouble()) {
+            qty.toLong().toString()
+        } else {
+            // Convert to fractions for common values
+            val fractions = mapOf(
+                0.25 to "1/4",
+                0.33 to "1/3",
+                0.5 to "1/2",
+                0.66 to "2/3",
+                0.75 to "3/4"
+            )
+            val whole = qty.toLong()
+            val decimal = qty - whole
+
+            val fraction = fractions.entries.minByOrNull {
+                kotlin.math.abs(it.key - decimal)
+            }?.takeIf {
+                kotlin.math.abs(it.key - decimal) < 0.05
+            }?.value
+
+            when {
+                fraction != null && whole > 0 -> "$whole $fraction"
+                fraction != null -> fraction
+                else -> "%.2f".format(qty).trimEnd('0').trimEnd('.')
+            }
+        }
+    }
+
+    private fun StringBuilder.formatInstructionSections(sections: List<InstructionSection>) {
+        if (sections.isEmpty()) {
+            appendLine("*No instructions listed*")
+            return
+        }
+
+        sections.forEach { section ->
+            // Section header (if named)
+            section.name?.let { name ->
+                appendLine("### $name")
+                appendLine()
+            }
+
+            // Steps
+            section.steps.sortedBy { it.stepNumber }.forEach { step ->
+                appendLine(formatStep(step))
+                appendLine()
+            }
+        }
+    }
+
+    private fun formatStep(step: InstructionStep): String = buildString {
+        append("${step.stepNumber}. ")
+        append(step.instruction)
+
+        if (step.optional) {
+            append(" *(optional)*")
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/notification/ImportNotificationHelper.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/notification/ImportNotificationHelper.kt
@@ -109,4 +109,67 @@ class ImportNotificationHelper @Inject constructor(
     fun cancelProgressNotification() {
         notificationManager.cancel(NOTIFICATION_ID_PROGRESS)
     }
+
+    @SuppressLint("MissingPermission")
+    fun showExportSuccessNotification(exportedCount: Int, failedCount: Int) {
+        if (!notificationManager.areNotificationsEnabled()) return
+
+        notificationManager.cancel(NOTIFICATION_ID_PROGRESS)
+
+        val message = if (failedCount > 0) {
+            "Exported $exportedCount recipes ($failedCount failed)"
+        } else {
+            "Exported $exportedCount recipes to Google Drive"
+        }
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Export Complete")
+            .setContentText(message)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(NOTIFICATION_ID_COMPLETE, notification)
+    }
+
+    @SuppressLint("MissingPermission")
+    fun showExportErrorNotification(errorMessage: String) {
+        if (!notificationManager.areNotificationsEnabled()) return
+
+        notificationManager.cancel(NOTIFICATION_ID_PROGRESS)
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Export Failed")
+            .setContentText(errorMessage)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(NOTIFICATION_ID_ERROR, notification)
+    }
+
+    @SuppressLint("MissingPermission")
+    fun showImportFromDriveSuccessNotification(importedCount: Int, failedCount: Int) {
+        if (!notificationManager.areNotificationsEnabled()) return
+
+        notificationManager.cancel(NOTIFICATION_ID_PROGRESS)
+
+        val message = if (failedCount > 0) {
+            "Imported $importedCount recipes ($failedCount failed)"
+        } else {
+            "Imported $importedCount recipes from Google Drive"
+        }
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Import Complete")
+            .setContentText(message)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(NOTIFICATION_ID_COMPLETE, notification)
+    }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/googledrive/GoogleDriveViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/googledrive/GoogleDriveViewModel.kt
@@ -1,0 +1,250 @@
+package com.lionotter.recipes.ui.screens.googledrive
+
+import android.content.Intent
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.lionotter.recipes.data.remote.DriveFolder
+import com.lionotter.recipes.data.remote.GoogleDriveService
+import com.lionotter.recipes.worker.GoogleDriveExportWorker
+import com.lionotter.recipes.worker.GoogleDriveImportWorker
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class GoogleDriveViewModel @Inject constructor(
+    private val googleDriveService: GoogleDriveService,
+    private val workManager: WorkManager
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<GoogleDriveUiState>(GoogleDriveUiState.Loading)
+    val uiState: StateFlow<GoogleDriveUiState> = _uiState.asStateFlow()
+
+    private val _folders = MutableStateFlow<List<DriveFolder>>(emptyList())
+    val folders: StateFlow<List<DriveFolder>> = _folders.asStateFlow()
+
+    private val _operationState = MutableStateFlow<OperationState>(OperationState.Idle)
+    val operationState: StateFlow<OperationState> = _operationState.asStateFlow()
+
+    private var currentWorkId: UUID? = null
+
+    init {
+        checkSignInStatus()
+        observeWorkStatus()
+    }
+
+    private fun checkSignInStatus() {
+        viewModelScope.launch {
+            if (googleDriveService.isSignedIn()) {
+                val email = googleDriveService.getSignedInEmail()
+                _uiState.value = GoogleDriveUiState.SignedIn(email ?: "Unknown")
+                loadRootFolders()
+            } else {
+                _uiState.value = GoogleDriveUiState.SignedOut
+            }
+        }
+    }
+
+    /**
+     * Refresh the sign-in status. Call this when returning to a screen
+     * to ensure the UI reflects the current sign-in state.
+     */
+    fun refreshSignInStatus() {
+        checkSignInStatus()
+    }
+
+    fun getSignInIntent(): Intent {
+        return googleDriveService.getSignInIntent()
+    }
+
+    fun handleSignInResult(account: GoogleSignInAccount?) {
+        viewModelScope.launch {
+            val success = googleDriveService.handleSignInResult(account)
+            if (success) {
+                val email = googleDriveService.getSignedInEmail()
+                _uiState.value = GoogleDriveUiState.SignedIn(email ?: "Unknown")
+                loadRootFolders()
+            } else {
+                _uiState.value = GoogleDriveUiState.Error("Sign in failed - account was null")
+            }
+        }
+    }
+
+    fun handleSignInError(errorMessage: String) {
+        _uiState.value = GoogleDriveUiState.Error(errorMessage)
+    }
+
+    fun signOut() {
+        viewModelScope.launch {
+            googleDriveService.signOut()
+            _uiState.value = GoogleDriveUiState.SignedOut
+            _folders.value = emptyList()
+        }
+    }
+
+    private fun loadRootFolders() {
+        viewModelScope.launch {
+            val result = googleDriveService.listFolders()
+            result.onSuccess { folders ->
+                _folders.value = folders
+            }.onFailure { error ->
+                _uiState.value = GoogleDriveUiState.Error("Failed to load folders: ${error.message}")
+            }
+        }
+    }
+
+    fun loadFolders(parentFolderId: String? = null) {
+        viewModelScope.launch {
+            val result = googleDriveService.listFolders(parentFolderId)
+            result.onSuccess { folders ->
+                _folders.value = folders
+            }.onFailure { error ->
+                _operationState.value = OperationState.Error("Failed to load folders: ${error.message}")
+            }
+        }
+    }
+
+    fun exportToGoogleDrive(parentFolderId: String? = null) {
+        if (_uiState.value !is GoogleDriveUiState.SignedIn) {
+            _operationState.value = OperationState.Error("Please sign in to Google Drive first")
+            return
+        }
+
+        val workRequest = OneTimeWorkRequestBuilder<GoogleDriveExportWorker>()
+            .setInputData(GoogleDriveExportWorker.createInputData(parentFolderId))
+            .addTag(GoogleDriveExportWorker.TAG_DRIVE_EXPORT)
+            .build()
+
+        currentWorkId = workRequest.id
+        workManager.enqueue(workRequest)
+        _operationState.value = OperationState.Exporting
+    }
+
+    fun importFromGoogleDrive(folderId: String) {
+        if (_uiState.value !is GoogleDriveUiState.SignedIn) {
+            _operationState.value = OperationState.Error("Please sign in to Google Drive first")
+            return
+        }
+
+        val workRequest = OneTimeWorkRequestBuilder<GoogleDriveImportWorker>()
+            .setInputData(GoogleDriveImportWorker.createInputData(folderId))
+            .addTag(GoogleDriveImportWorker.TAG_DRIVE_IMPORT)
+            .build()
+
+        currentWorkId = workRequest.id
+        workManager.enqueue(workRequest)
+        _operationState.value = OperationState.Importing
+    }
+
+    private fun observeWorkStatus() {
+        // Observe export work
+        viewModelScope.launch {
+            workManager.getWorkInfosByTagFlow(GoogleDriveExportWorker.TAG_DRIVE_EXPORT)
+                .collect { workInfos ->
+                    val workInfo = currentWorkId?.let { id ->
+                        workInfos.find { it.id == id }
+                    }
+                    workInfo?.let { handleExportWorkInfo(it) }
+                }
+        }
+
+        // Observe import work
+        viewModelScope.launch {
+            workManager.getWorkInfosByTagFlow(GoogleDriveImportWorker.TAG_DRIVE_IMPORT)
+                .collect { workInfos ->
+                    val workInfo = currentWorkId?.let { id ->
+                        workInfos.find { it.id == id }
+                    }
+                    workInfo?.let { handleImportWorkInfo(it) }
+                }
+        }
+    }
+
+    private fun handleExportWorkInfo(workInfo: WorkInfo) {
+        when (workInfo.state) {
+            WorkInfo.State.RUNNING -> {
+                val current = workInfo.progress.getInt(GoogleDriveExportWorker.KEY_CURRENT, 0)
+                val total = workInfo.progress.getInt(GoogleDriveExportWorker.KEY_TOTAL, 0)
+                val recipeName = workInfo.progress.getString(GoogleDriveExportWorker.KEY_RECIPE_NAME)
+                _operationState.value = OperationState.Exporting
+            }
+            WorkInfo.State.SUCCEEDED -> {
+                val exported = workInfo.outputData.getInt(GoogleDriveExportWorker.KEY_EXPORTED_COUNT, 0)
+                val failed = workInfo.outputData.getInt(GoogleDriveExportWorker.KEY_FAILED_COUNT, 0)
+                _operationState.value = OperationState.ExportComplete(exported, failed)
+                currentWorkId = null
+                workManager.pruneWork()
+            }
+            WorkInfo.State.FAILED -> {
+                val error = workInfo.outputData.getString(GoogleDriveExportWorker.KEY_ERROR_MESSAGE)
+                    ?: "Export failed"
+                _operationState.value = OperationState.Error(error)
+                currentWorkId = null
+                workManager.pruneWork()
+            }
+            else -> {}
+        }
+    }
+
+    private fun handleImportWorkInfo(workInfo: WorkInfo) {
+        when (workInfo.state) {
+            WorkInfo.State.RUNNING -> {
+                val current = workInfo.progress.getInt(GoogleDriveImportWorker.KEY_CURRENT, 0)
+                val total = workInfo.progress.getInt(GoogleDriveImportWorker.KEY_TOTAL, 0)
+                _operationState.value = OperationState.Importing
+            }
+            WorkInfo.State.SUCCEEDED -> {
+                val imported = workInfo.outputData.getInt(GoogleDriveImportWorker.KEY_IMPORTED_COUNT, 0)
+                val failed = workInfo.outputData.getInt(GoogleDriveImportWorker.KEY_FAILED_COUNT, 0)
+                _operationState.value = OperationState.ImportComplete(imported, failed)
+                currentWorkId = null
+                workManager.pruneWork()
+            }
+            WorkInfo.State.FAILED -> {
+                val error = workInfo.outputData.getString(GoogleDriveImportWorker.KEY_ERROR_MESSAGE)
+                    ?: "Import failed"
+                _operationState.value = OperationState.Error(error)
+                currentWorkId = null
+                workManager.pruneWork()
+            }
+            else -> {}
+        }
+    }
+
+    fun resetOperationState() {
+        _operationState.value = OperationState.Idle
+    }
+
+    fun dismissError() {
+        if (_uiState.value is GoogleDriveUiState.Error) {
+            checkSignInStatus()
+        }
+        if (_operationState.value is OperationState.Error) {
+            _operationState.value = OperationState.Idle
+        }
+    }
+}
+
+sealed class GoogleDriveUiState {
+    object Loading : GoogleDriveUiState()
+    object SignedOut : GoogleDriveUiState()
+    data class SignedIn(val email: String) : GoogleDriveUiState()
+    data class Error(val message: String) : GoogleDriveUiState()
+}
+
+sealed class OperationState {
+    object Idle : OperationState()
+    object Exporting : OperationState()
+    object Importing : OperationState()
+    data class ExportComplete(val exportedCount: Int, val failedCount: Int) : OperationState()
+    data class ImportComplete(val importedCount: Int, val failedCount: Int) : OperationState()
+    data class Error(val message: String) : OperationState()
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/GoogleDriveExportWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/GoogleDriveExportWorker.kt
@@ -1,0 +1,157 @@
+package com.lionotter.recipes.worker
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.lionotter.recipes.R
+import com.lionotter.recipes.domain.usecase.ExportToGoogleDriveUseCase
+import com.lionotter.recipes.notification.ImportNotificationHelper
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class GoogleDriveExportWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val exportToGoogleDriveUseCase: ExportToGoogleDriveUseCase,
+    private val notificationHelper: ImportNotificationHelper
+) : CoroutineWorker(context, workerParams) {
+
+    companion object {
+        const val TAG_DRIVE_EXPORT = "google_drive_export"
+
+        const val KEY_PARENT_FOLDER_ID = "parent_folder_id"
+        const val KEY_FOLDER_NAME = "folder_name"
+        const val KEY_RESULT_TYPE = "result_type"
+        const val KEY_EXPORTED_COUNT = "exported_count"
+        const val KEY_FAILED_COUNT = "failed_count"
+        const val KEY_ERROR_MESSAGE = "error_message"
+        const val KEY_PROGRESS = "progress"
+        const val KEY_CURRENT = "current"
+        const val KEY_TOTAL = "total"
+        const val KEY_RECIPE_NAME = "recipe_name"
+
+        const val RESULT_SUCCESS = "success"
+        const val RESULT_ERROR = "error"
+        const val RESULT_NOT_SIGNED_IN = "not_signed_in"
+
+        const val PROGRESS_STARTING = "starting"
+        const val PROGRESS_CREATING_FOLDER = "creating_folder"
+        const val PROGRESS_EXPORTING = "exporting"
+
+        fun createInputData(
+            parentFolderId: String? = null,
+            folderName: String = "Lion+Otter Recipes Export"
+        ): Data {
+            return workDataOf(
+                KEY_PARENT_FOLDER_ID to parentFolderId,
+                KEY_FOLDER_NAME to folderName
+            )
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        val parentFolderId = inputData.getString(KEY_PARENT_FOLDER_ID)
+        val folderName = inputData.getString(KEY_FOLDER_NAME) ?: "Lion+Otter Recipes Export"
+
+        setForeground(createForegroundInfo("Starting export..."))
+
+        val result = exportToGoogleDriveUseCase.exportAllRecipes(
+            parentFolderId = parentFolderId,
+            rootFolderName = folderName,
+            onProgress = { progress ->
+                val progressMessage = when (progress) {
+                    is ExportToGoogleDriveUseCase.ExportProgress.Starting -> {
+                        setProgress(workDataOf(KEY_PROGRESS to PROGRESS_STARTING))
+                        "Starting export..."
+                    }
+                    is ExportToGoogleDriveUseCase.ExportProgress.CreatingRootFolder -> {
+                        setProgress(workDataOf(
+                            KEY_PROGRESS to PROGRESS_CREATING_FOLDER,
+                            KEY_FOLDER_NAME to progress.folderName
+                        ))
+                        "Creating folder: ${progress.folderName}"
+                    }
+                    is ExportToGoogleDriveUseCase.ExportProgress.ExportingRecipe -> {
+                        setProgress(workDataOf(
+                            KEY_PROGRESS to PROGRESS_EXPORTING,
+                            KEY_RECIPE_NAME to progress.recipeName,
+                            KEY_CURRENT to progress.current,
+                            KEY_TOTAL to progress.total
+                        ))
+                        "Exporting ${progress.current}/${progress.total}: ${progress.recipeName}"
+                    }
+                    is ExportToGoogleDriveUseCase.ExportProgress.Complete -> "Complete!"
+                }
+                setForeground(createForegroundInfo(progressMessage))
+            }
+        )
+
+        return when (result) {
+            is ExportToGoogleDriveUseCase.ExportResult.Success -> {
+                notificationHelper.showExportSuccessNotification(
+                    exportedCount = result.exportedCount,
+                    failedCount = result.failedCount
+                )
+                Result.success(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_SUCCESS,
+                        KEY_EXPORTED_COUNT to result.exportedCount,
+                        KEY_FAILED_COUNT to result.failedCount
+                    )
+                )
+            }
+            is ExportToGoogleDriveUseCase.ExportResult.Error -> {
+                notificationHelper.showExportErrorNotification(result.message)
+                Result.failure(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_ERROR,
+                        KEY_ERROR_MESSAGE to result.message
+                    )
+                )
+            }
+            ExportToGoogleDriveUseCase.ExportResult.NotSignedIn -> {
+                notificationHelper.cancelProgressNotification()
+                Result.failure(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_NOT_SIGNED_IN,
+                        KEY_ERROR_MESSAGE to "Not signed in to Google Drive"
+                    )
+                )
+            }
+        }
+    }
+
+    private fun createForegroundInfo(progress: String): ForegroundInfo {
+        val notification = androidx.core.app.NotificationCompat.Builder(
+            context,
+            ImportNotificationHelper.CHANNEL_ID
+        )
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Exporting to Google Drive")
+            .setContentText(progress)
+            .setPriority(androidx.core.app.NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setProgress(0, 0, true)
+            .build()
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                ImportNotificationHelper.NOTIFICATION_ID_PROGRESS,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            ForegroundInfo(
+                ImportNotificationHelper.NOTIFICATION_ID_PROGRESS,
+                notification
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/GoogleDriveImportWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/GoogleDriveImportWorker.kt
@@ -1,0 +1,169 @@
+package com.lionotter.recipes.worker
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.lionotter.recipes.R
+import com.lionotter.recipes.domain.usecase.ImportFromGoogleDriveUseCase
+import com.lionotter.recipes.notification.ImportNotificationHelper
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class GoogleDriveImportWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val importFromGoogleDriveUseCase: ImportFromGoogleDriveUseCase,
+    private val notificationHelper: ImportNotificationHelper
+) : CoroutineWorker(context, workerParams) {
+
+    companion object {
+        const val TAG_DRIVE_IMPORT = "google_drive_import"
+
+        const val KEY_FOLDER_ID = "folder_id"
+        const val KEY_RESULT_TYPE = "result_type"
+        const val KEY_IMPORTED_COUNT = "imported_count"
+        const val KEY_FAILED_COUNT = "failed_count"
+        const val KEY_SKIPPED_COUNT = "skipped_count"
+        const val KEY_ERROR_MESSAGE = "error_message"
+        const val KEY_PROGRESS = "progress"
+        const val KEY_CURRENT = "current"
+        const val KEY_TOTAL = "total"
+        const val KEY_FOLDER_NAME = "folder_name"
+        const val KEY_IMPORT_METHOD = "import_method"
+
+        const val RESULT_SUCCESS = "success"
+        const val RESULT_ERROR = "error"
+        const val RESULT_NOT_SIGNED_IN = "not_signed_in"
+        const val RESULT_NO_API_KEY = "no_api_key"
+
+        const val PROGRESS_STARTING = "starting"
+        const val PROGRESS_LISTING = "listing"
+        const val PROGRESS_IMPORTING = "importing"
+
+        fun createInputData(folderId: String): Data {
+            return workDataOf(KEY_FOLDER_ID to folderId)
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        val folderId = inputData.getString(KEY_FOLDER_ID)
+            ?: return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "No folder ID provided"
+                )
+            )
+
+        setForeground(createForegroundInfo("Starting import from Google Drive..."))
+
+        val result = importFromGoogleDriveUseCase.importFromFolder(
+            folderId = folderId,
+            onProgress = { progress ->
+                val progressMessage = when (progress) {
+                    is ImportFromGoogleDriveUseCase.ImportProgress.Starting -> {
+                        setProgress(workDataOf(KEY_PROGRESS to PROGRESS_STARTING))
+                        "Starting import..."
+                    }
+                    is ImportFromGoogleDriveUseCase.ImportProgress.ListingFolders -> {
+                        setProgress(workDataOf(KEY_PROGRESS to PROGRESS_LISTING))
+                        "Scanning for recipes..."
+                    }
+                    is ImportFromGoogleDriveUseCase.ImportProgress.ImportingRecipe -> {
+                        val method = when (progress.method) {
+                            ImportFromGoogleDriveUseCase.ImportMethod.JSON -> "JSON"
+                            ImportFromGoogleDriveUseCase.ImportMethod.HTML_FALLBACK -> "HTML"
+                        }
+                        setProgress(workDataOf(
+                            KEY_PROGRESS to PROGRESS_IMPORTING,
+                            KEY_FOLDER_NAME to progress.folderName,
+                            KEY_IMPORT_METHOD to method,
+                            KEY_CURRENT to progress.current,
+                            KEY_TOTAL to progress.total
+                        ))
+                        "Importing ${progress.current}/${progress.total}: ${progress.folderName}"
+                    }
+                    is ImportFromGoogleDriveUseCase.ImportProgress.Complete -> "Complete!"
+                }
+                setForeground(createForegroundInfo(progressMessage))
+            }
+        )
+
+        return when (result) {
+            is ImportFromGoogleDriveUseCase.ImportResult.Success -> {
+                notificationHelper.showImportFromDriveSuccessNotification(
+                    importedCount = result.importedCount,
+                    failedCount = result.failedCount
+                )
+                Result.success(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_SUCCESS,
+                        KEY_IMPORTED_COUNT to result.importedCount,
+                        KEY_FAILED_COUNT to result.failedCount,
+                        KEY_SKIPPED_COUNT to result.skippedCount
+                    )
+                )
+            }
+            is ImportFromGoogleDriveUseCase.ImportResult.Error -> {
+                notificationHelper.showErrorNotification(result.message)
+                Result.failure(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_ERROR,
+                        KEY_ERROR_MESSAGE to result.message
+                    )
+                )
+            }
+            ImportFromGoogleDriveUseCase.ImportResult.NotSignedIn -> {
+                notificationHelper.cancelProgressNotification()
+                Result.failure(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_NOT_SIGNED_IN,
+                        KEY_ERROR_MESSAGE to "Not signed in to Google Drive"
+                    )
+                )
+            }
+            ImportFromGoogleDriveUseCase.ImportResult.NoApiKey -> {
+                notificationHelper.cancelProgressNotification()
+                Result.failure(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_NO_API_KEY,
+                        KEY_ERROR_MESSAGE to "API key required for HTML fallback import"
+                    )
+                )
+            }
+        }
+    }
+
+    private fun createForegroundInfo(progress: String): ForegroundInfo {
+        val notification = androidx.core.app.NotificationCompat.Builder(
+            context,
+            ImportNotificationHelper.CHANNEL_ID
+        )
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Importing from Google Drive")
+            .setContentText(progress)
+            .setPriority(androidx.core.app.NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setProgress(0, 0, true)
+            .build()
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                ImportNotificationHelper.NOTIFICATION_ID_PROGRESS,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            ForegroundInfo(
+                ImportNotificationHelper.NOTIFICATION_ID_PROGRESS,
+                notification
+            )
+        }
+    }
+}

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -32,6 +32,14 @@ external: {
     label: Recipe Websites
     shape: rectangle
   }
+
+  google_drive: {
+    label: Google Drive
+    shape: rectangle
+    style: {
+      fill: "#4285f4"
+    }
+  }
 }
 
 # Android App
@@ -78,6 +86,10 @@ app: {
       detail_vm: RecipeDetailViewModel
       add_vm: AddRecipeViewModel
       settings_vm: SettingsViewModel
+      drive_vm: {
+        label: GoogleDriveViewModel
+        tooltip: "Manages Google Drive sign-in state, folder navigation, and export/import operations"
+      }
     }
 
     state: {
@@ -93,9 +105,11 @@ app: {
     }
 
     screens.list -> viewmodels.list_vm
+    screens.list -> viewmodels.drive_vm: export/import menu
     screens.detail -> viewmodels.detail_vm
     screens.add -> viewmodels.add_vm
     screens.settings -> viewmodels.settings_vm
+    screens.settings -> viewmodels.drive_vm: sign in/out
     viewmodels.list_vm -> state.in_progress_mgr: observes
     viewmodels.add_vm -> state.in_progress_mgr: updates
   }
@@ -116,7 +130,15 @@ app: {
 
       import_worker: {
         label: RecipeImportWorker
-        tooltip: "CoroutineWorker that handles recipe import in background. Survives app closure and shows progress notifications."
+        tooltip: "CoroutineWorker that handles recipe import in background. Survives app closure and shows progress notifications. Supports queue of multiple imports."
+      }
+      export_worker: {
+        label: GoogleDriveExportWorker
+        tooltip: "Exports all recipes to Google Drive. Creates folder per recipe with JSON, HTML, and Markdown files."
+      }
+      drive_import_worker: {
+        label: GoogleDriveImportWorker
+        tooltip: "Imports recipes from Google Drive. Tries JSON first, falls back to HTML parsing via AI."
       }
     }
 
@@ -128,11 +150,13 @@ app: {
 
       helper: {
         label: ImportNotificationHelper
-        tooltip: "Manages notification channel and shows progress/success/error notifications for recipe imports"
+        tooltip: "Manages notification channel and shows progress/success/error notifications for recipe imports and Google Drive operations"
       }
     }
 
     worker.import_worker -> notification.helper: notify progress
+    worker.export_worker -> notification.helper: notify progress
+    worker.drive_import_worker -> notification.helper: notify progress
   }
 
   # Domain Layer
@@ -150,10 +174,34 @@ app: {
       }
 
       import: ImportRecipeUseCase
+      parse_html: {
+        label: ParseHtmlUseCase
+        tooltip: "Reusable helper for parsing HTML via AI. Used by both URL import and Google Drive HTML fallback."
+      }
+      export_drive: {
+        label: ExportToGoogleDriveUseCase
+        tooltip: "Exports recipes to Google Drive with JSON, HTML, and Markdown files per recipe folder."
+      }
+      import_drive: {
+        label: ImportFromGoogleDriveUseCase
+        tooltip: "Imports from Drive: tries JSON first, falls back to HTML parsing. Reuses ParseHtmlUseCase."
+      }
       get_all: GetRecipesUseCase
       get_one: GetRecipeByIdUseCase
       delete: DeleteRecipeUseCase
       tags: GetTagsUseCase
+    }
+
+    util: {
+      label: Utilities
+      style: {
+        fill: "#ffffff"
+      }
+
+      markdown: {
+        label: RecipeMarkdownFormatter
+        tooltip: "Converts Recipe to human-readable Markdown format for export"
+      }
     }
 
     models: {
@@ -184,6 +232,10 @@ app: {
       recipe -> instruction
       instruction -> ingredient: step ingredients
     }
+
+    usecases.import -> usecases.parse_html: uses
+    usecases.import_drive -> usecases.parse_html: HTML fallback
+    usecases.export_drive -> util.markdown: format
   }
 
   # Data Layer
@@ -240,6 +292,10 @@ app: {
         label: WebScraperService
         tooltip: Uses Readability4J to extract article content
       }
+      google_drive_svc: {
+        label: GoogleDriveService
+        tooltip: "Handles Google Sign-In, folder operations, and file upload/download for Drive integration"
+      }
     }
 
     repository.repo -> local.dao
@@ -262,33 +318,55 @@ app: {
 
   # Connections within app
   ui.viewmodels.add_vm -> background.worker: enqueue work
+  ui.viewmodels.drive_vm -> background.worker.export_worker: export
+  ui.viewmodels.drive_vm -> background.worker.drive_import_worker: import
   background.worker.import_worker -> domain.usecases.import: execute
+  background.worker.export_worker -> domain.usecases.export_drive: execute
+  background.worker.drive_import_worker -> domain.usecases.import_drive: execute
   domain.usecases -> data.repository: access data
   data.remote.scraper -> external.web: fetch HTML
   data.remote.anthropic_svc -> external.anthropic: parse recipe
+  data.remote.google_drive_svc -> external.google_drive: sync files
 }
 
 # Data Flow Legend
 legend: {
-  label: Data Flow (Background Import)
+  label: Data Flow
   near: bottom-center
   style: {
     fill: "#f5f5f5"
   }
 
+  import_flow: {
+    label: "URL Import Flow"
+    style: {
+      font-size: 14
+      bold: true
+    }
+  }
   flow1: "1. User pastes URL and taps Import"
   flow2: "2. ViewModel enqueues WorkManager job"
   flow3: "3. RecipeImportWorker runs as foreground service"
-  flow4: "4. Notification shows import progress"
-  flow5: "5. Scraper fetches HTML, Anthropic parses recipe"
-  flow6: "6. Repository saves to Room"
-  flow7: "7. Success notification shown (tap to view recipe)"
-  flow8: "8. User can close app during import - work continues"
+  flow4: "4. Scraper fetches HTML, AI parses recipe"
+  flow5: "5. Repository saves to Room"
 
-  flow1 -> flow2 -> flow3 -> flow4 -> flow5 -> flow6 -> flow7 -> flow8
+  flow1 -> flow2 -> flow3 -> flow4 -> flow5
+
+  drive_flow: {
+    label: "Google Drive Flow"
+    style: {
+      font-size: 14
+      bold: true
+    }
+  }
+  drive1: "Export: Creates folder per recipe (JSON + HTML + Markdown)"
+  drive2: "Import: Reads JSON directly, falls back to HTML via AI"
+  drive3: "Supports queued batch operations in background"
+
+  drive1 -> drive2 -> drive3
 
   note: {
-    label: "Import runs in background via WorkManager. User can leave the app and will receive a notification when complete. Supports multiple AI models: Opus 4.5 (best quality), Sonnet 4.5 (balanced), Haiku 4.5 (fastest)"
+    label: "Import runs in background via WorkManager. Supports multiple concurrent imports. Google Drive export/import runs in background with progress notifications."
     style: {
       font-size: 12
       italic: true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ coil = "2.7.0"
 ksp = "2.1.0-1.0.29"
 readability4j = "1.0.8"
 jsoup = "1.18.1"
+playServicesAuth = "21.2.0"
+googleApiClient = "2.7.0"
+googleDriveApi = "v3-rev20241206-2.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -72,6 +75,11 @@ readability4j = { group = "net.dankito.readability4j", name = "readability4j", v
 
 # HTML parsing
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
+
+# Google Drive
+play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
+google-api-client = { group = "com.google.api-client", name = "google-api-client-android", version.ref = "googleApiClient" }
+google-drive-api = { group = "com.google.apis", name = "google-api-services-drive", version.ref = "googleDriveApi" }
 
 # Testing
 junit = { group = "junit", name = "junit", version = "4.13.2" }


### PR DESCRIPTION
This implements GH issue #31: Google Drive recipe export/import.

Export features:
- Creates a subfolder for each recipe containing:
  - recipe.json: Structured recipe data
  - original.html: Original HTML page (if available)
  - recipe.md: Human-readable Markdown format

Import features:
- Lists folders in selected Drive folder
- Tries to load JSON directly first
- Falls back to HTML import via AI if JSON fails
- Reuses ParseHtmlUseCase to avoid duplicate logic

Background processing:
- Refactored to support queue of multiple concurrent imports
- Changed from unique work names to tag-based work tracking
- GoogleDriveExportWorker for background export
- GoogleDriveImportWorker for background import

UI changes:
- Settings screen: Google Drive sign-in/sign-out section
- Recipe list: Menu with export/import options
- Folder picker dialog for selecting Drive folders
- Progress indicators during operations
- Snackbar notifications for completion

New components:
- GoogleDriveService: Auth and file operations
- ParseHtmlUseCase: Reusable HTML parsing helper
- ExportToGoogleDriveUseCase: Export logic
- ImportFromGoogleDriveUseCase: Import with JSON/HTML fallback
- RecipeMarkdownFormatter: Converts recipes to Markdown
- GoogleDriveViewModel: UI state management

Also updated architecture.d2 diagram with all new components.