### PR TITLE
feat: setup shared debug keystore for CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -97,6 +97,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Setup debug keystore
+        env:
+          DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+        run: |
+          if [ -n "$DEBUG_KEYSTORE_BASE64" ]; then
+            echo "$DEBUG_KEYSTORE_BASE64" | base64 -d > ${{ runner.temp }}/debug.keystore
+            echo "DEBUG_KEYSTORE_PATH=${{ runner.temp }}/debug.keystore" >> $GITHUB_ENV
+          fi
+
       - name: Build debug APK
         run: ./gradlew assembleDebug
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,15 @@ android {
     namespace = "com.lionotter.recipes"
     compileSdk = 35
 
+    signingConfigs {
+        getByName("debug") {
+            storeFile = file(System.getenv("DEBUG_KEYSTORE_PATH") ?: "${System.getProperty("user.home")}/.android/debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     defaultConfig {
         applicationId = "com.lionotter.recipes"
         minSdk = 26


### PR DESCRIPTION
Configure debug signing to use a shared keystore in CI for consistent APK signing across builds. The keystore is stored as a base64-encoded GitHub secret (DEBUG_KEYSTORE_BASE64) and decoded at build time.

Locally, falls back to the default Android debug keystore.