### PR TITLE
Request notification permission on first import

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
@@ -1,5 +1,9 @@
 package com.lionotter.recipes.ui.screens.addrecipe
 
+import android.Manifest
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -66,6 +70,18 @@ fun AddRecipeScreen(
     LaunchedEffect(uiState) {
         if (uiState is AddRecipeUiState.Success) {
             onRecipeAdded((uiState as AddRecipeUiState.Success).recipeId)
+        }
+    }
+
+    // Request notification permission on Android 13+ (API 33+)
+    // This is contextually relevant since we notify users when imports complete
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { /* Permission result handled by system */ }
+
+    LaunchedEffect(Unit) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
 


### PR DESCRIPTION
Request POST_NOTIFICATIONS permission when users first visit the import screen on Android 13+. This is contextually appropriate since the screen mentions notifications will be sent when imports complete.