### PR TITLE
Add delete functionality to recipes with confirmation

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/components/DeleteConfirmationDialog.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/components/DeleteConfirmationDialog.kt
@@ -1,0 +1,29 @@
+package com.lionotter.recipes.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+@Composable
+fun DeleteConfirmationDialog(
+    recipeName: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Delete Recipe") },
+        text = { Text("Are you sure you want to delete \"$recipeName\"? This action cannot be undone.") },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text("Delete")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -38,7 +39,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -58,6 +63,7 @@ import com.lionotter.recipes.domain.model.InstructionSection
 import com.lionotter.recipes.domain.model.MeasurementPreference
 import com.lionotter.recipes.domain.model.MeasurementType
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.ui.components.DeleteConfirmationDialog
 import com.lionotter.recipes.util.pluralize
 import com.lionotter.recipes.util.singularize
 
@@ -76,6 +82,27 @@ fun RecipeDetailScreen(
     val globalIngredientUsage by viewModel.globalIngredientUsage.collectAsStateWithLifecycle()
     val highlightedInstructionStep by viewModel.highlightedInstructionStep.collectAsStateWithLifecycle()
 
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    // Navigate back after recipe is deleted
+    LaunchedEffect(Unit) {
+        viewModel.recipeDeleted.collect {
+            onBackClick()
+        }
+    }
+
+    // Delete confirmation dialog
+    if (showDeleteDialog && recipe != null) {
+        DeleteConfirmationDialog(
+            recipeName = recipe!!.name,
+            onConfirm = {
+                showDeleteDialog = false
+                viewModel.deleteRecipe()
+            },
+            onDismiss = { showDeleteDialog = false }
+        )
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -86,6 +113,16 @@ fun RecipeDetailScreen(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back"
                         )
+                    }
+                },
+                actions = {
+                    if (recipe != null) {
+                        IconButton(onClick = { showDeleteDialog = true }) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Delete recipe"
+                            )
+                        }
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
@@ -7,15 +7,20 @@ import com.lionotter.recipes.domain.model.Ingredient
 import com.lionotter.recipes.domain.model.MeasurementPreference
 import com.lionotter.recipes.domain.model.MeasurementType
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.usecase.DeleteRecipeUseCase
 import com.lionotter.recipes.domain.usecase.GetRecipeByIdUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -49,11 +54,15 @@ data class HighlightedInstructionStep(
 @HiltViewModel
 class RecipeDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    getRecipeByIdUseCase: GetRecipeByIdUseCase
+    getRecipeByIdUseCase: GetRecipeByIdUseCase,
+    private val deleteRecipeUseCase: DeleteRecipeUseCase
 ) : ViewModel() {
 
     private val recipeId: String = savedStateHandle.get<String>("recipeId")
         ?: throw IllegalArgumentException("Recipe ID is required")
+
+    private val _recipeDeleted = MutableSharedFlow<Unit>()
+    val recipeDeleted: SharedFlow<Unit> = _recipeDeleted.asSharedFlow()
 
     val recipe: StateFlow<Recipe?> = getRecipeByIdUseCase.execute(recipeId)
         .stateIn(
@@ -258,6 +267,16 @@ class RecipeDetailViewModel @Inject constructor(
             null
         } else {
             newStep
+        }
+    }
+
+    /**
+     * Deletes the current recipe and emits an event when complete.
+     */
+    fun deleteRecipe() {
+        viewModelScope.launch {
+            deleteRecipeUseCase.execute(recipeId)
+            _recipeDeleted.emit(Unit)
         }
     }
 }


### PR DESCRIPTION
Add ability to delete recipes from two places:
- Delete button in recipe detail screen header
- Long-press context menu on recipe list items

Both actions show a confirmation dialog before deletion. Swipe-to-delete on recipe list now also shows confirmation.

Creates shared DeleteConfirmationDialog component for reuse.