### PR TITLE
Show top 10 tags on recipes page

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDao.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDao.kt
@@ -13,6 +13,9 @@ interface RecipeDao {
     @Query("SELECT * FROM recipes ORDER BY updatedAt DESC")
     fun getAllRecipes(): Flow<List<RecipeEntity>>
 
+    @Query("SELECT * FROM recipes ORDER BY updatedAt DESC")
+    suspend fun getAllRecipesOnce(): List<RecipeEntity>
+
     @Query("SELECT * FROM recipes WHERE id = :id")
     suspend fun getRecipeById(id: String): RecipeEntity?
 

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
@@ -78,6 +78,21 @@ class RecipeRepository @Inject constructor(
         }.toSet()
     }
 
+    /**
+     * Get all recipes with their tags for tag ranking algorithms.
+     * Returns a list of pairs: (recipeId, list of tags for that recipe)
+     */
+    suspend fun getAllRecipesWithTags(): List<Pair<String, List<String>>> {
+        return recipeDao.getAllRecipesOnce().map { entity ->
+            val tags: List<String> = try {
+                json.decodeFromString(entity.tagsJson)
+            } catch (e: Exception) {
+                emptyList()
+            }
+            entity.id to tags
+        }
+    }
+
     private fun entityToRecipe(entity: RecipeEntity): Recipe {
         val ingredientSections: List<IngredientSection> = try {
             json.decodeFromString(entity.ingredientSectionsJson)

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/GetTagsUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/GetTagsUseCase.kt
@@ -6,7 +6,79 @@ import javax.inject.Inject
 class GetTagsUseCase @Inject constructor(
     private val recipeRepository: RecipeRepository
 ) {
-    suspend fun execute(): Set<String> {
-        return recipeRepository.getAllTags()
+    companion object {
+        private const val MAX_TAGS = 10
+    }
+
+    /**
+     * Returns the top tags using a greedy set cover algorithm to maximize coverage,
+     * sorted by total recipe count.
+     *
+     * Algorithm:
+     * 1. Start with a set of all recipes
+     * 2. Find the tag with the most recipes in that set
+     * 3. Add that tag to results and remove its recipes from the set
+     * 4. Repeat until we have 10 tags or no more tags exist
+     * 5. If set becomes empty but we have fewer than 10 tags, reset the set
+     * 6. Sort final tags by total recipe count (descending)
+     */
+    suspend fun execute(): List<String> {
+        val recipesWithTags = recipeRepository.getAllRecipesWithTags()
+
+        // Build tag -> recipe IDs map
+        val tagToRecipes = mutableMapOf<String, MutableSet<String>>()
+        for ((recipeId, tags) in recipesWithTags) {
+            for (tag in tags) {
+                tagToRecipes.getOrPut(tag) { mutableSetOf() }.add(recipeId)
+            }
+        }
+
+        if (tagToRecipes.isEmpty()) {
+            return emptyList()
+        }
+
+        // If we have 10 or fewer tags, just return them sorted by count
+        if (tagToRecipes.size <= MAX_TAGS) {
+            return tagToRecipes.entries
+                .sortedByDescending { it.value.size }
+                .map { it.key }
+        }
+
+        // Greedy set cover algorithm
+        val allRecipeIds = recipesWithTags.map { it.first }.toSet()
+        val selectedTags = mutableListOf<String>()
+        var uncoveredRecipes = allRecipeIds.toMutableSet()
+
+        while (selectedTags.size < MAX_TAGS) {
+            // Find tag that covers most uncovered recipes
+            val bestTag = tagToRecipes
+                .filterKeys { it !in selectedTags }
+                .maxByOrNull { (_, recipeIds) ->
+                    recipeIds.count { it in uncoveredRecipes }
+                }
+                ?.key
+                ?: break // No more tags available
+
+            selectedTags.add(bestTag)
+
+            // Remove covered recipes
+            uncoveredRecipes.removeAll(tagToRecipes[bestTag] ?: emptySet())
+
+            // If all recipes are covered but we need more tags, reset the set
+            if (uncoveredRecipes.isEmpty() && selectedTags.size < MAX_TAGS) {
+                uncoveredRecipes = allRecipeIds.toMutableSet()
+                // Remove recipes already covered by selected tags
+                for (tag in selectedTags) {
+                    uncoveredRecipes.removeAll(tagToRecipes[tag] ?: emptySet())
+                }
+                // If still empty (all recipes covered), reset completely
+                if (uncoveredRecipes.isEmpty()) {
+                    uncoveredRecipes = allRecipeIds.toMutableSet()
+                }
+            }
+        }
+
+        // Sort by total recipe count (descending)
+        return selectedTags.sortedByDescending { tagToRecipes[it]?.size ?: 0 }
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
@@ -294,7 +294,7 @@ fun RecipeListScreen(
                         .padding(horizontal = 16.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    availableTags.sorted().forEach { tag ->
+                    availableTags.forEach { tag ->
                         FilterChip(
                             selected = selectedTag == tag,
                             onClick = { viewModel.onTagSelected(tag) },

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListViewModel.kt
@@ -32,8 +32,8 @@ class RecipeListViewModel @Inject constructor(
     private val _selectedTag = MutableStateFlow<String?>(null)
     val selectedTag: StateFlow<String?> = _selectedTag.asStateFlow()
 
-    private val _availableTags = MutableStateFlow<Set<String>>(emptySet())
-    val availableTags: StateFlow<Set<String>> = _availableTags.asStateFlow()
+    private val _availableTags = MutableStateFlow<List<String>>(emptyList())
+    val availableTags: StateFlow<List<String>> = _availableTags.asStateFlow()
 
     val recipes: StateFlow<List<RecipeListItem>> = combine(
         getRecipesUseCase.execute(),


### PR DESCRIPTION
Limit the tag filter chips on the recipe list page to the 10 most useful tags. Uses a greedy set cover algorithm to maximize recipe coverage:
1. Find tag with most recipes in remaining uncovered set
2. Remove those recipes from consideration
3. Repeat until 10 tags selected (resetting if set empties early)
4. Sort final selection by total recipe count

This ensures users see tags that collectively cover the most recipes while being sorted by popularity.