### PR TITLE
feat: add favorite recipes with star button

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDao.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDao.kt
@@ -42,4 +42,7 @@ interface RecipeDao {
 
     @Query("SELECT DISTINCT tagsJson FROM recipes")
     suspend fun getAllTagsJson(): List<String>
+
+    @Query("UPDATE recipes SET isFavorite = :isFavorite WHERE id = :id")
+    suspend fun setFavorite(id: String, isFavorite: Boolean)
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
@@ -2,12 +2,22 @@ package com.lionotter.recipes.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [RecipeEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = true
 )
 abstract class RecipeDatabase : RoomDatabase() {
     abstract fun recipeDao(): RecipeDao
+
+    companion object {
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE recipes ADD COLUMN isFavorite INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeEntity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeEntity.kt
@@ -24,7 +24,8 @@ data class RecipeEntity(
     val imageUrl: String?,
     val originalHtml: String?,
     val createdAt: Long,
-    val updatedAt: Long
+    val updatedAt: Long,
+    val isFavorite: Boolean = false
 ) {
     fun toRecipe(
         ingredientSections: List<IngredientSection>,
@@ -45,7 +46,8 @@ data class RecipeEntity(
             tags = tags,
             imageUrl = imageUrl,
             createdAt = Instant.fromEpochMilliseconds(createdAt),
-            updatedAt = Instant.fromEpochMilliseconds(updatedAt)
+            updatedAt = Instant.fromEpochMilliseconds(updatedAt),
+            isFavorite = isFavorite
         )
     }
 
@@ -72,7 +74,8 @@ data class RecipeEntity(
                 imageUrl = recipe.imageUrl,
                 originalHtml = originalHtml,
                 createdAt = recipe.createdAt.toEpochMilliseconds(),
-                updatedAt = recipe.updatedAt.toEpochMilliseconds()
+                updatedAt = recipe.updatedAt.toEpochMilliseconds(),
+                isFavorite = recipe.isFavorite
             )
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
@@ -67,6 +67,10 @@ class RecipeRepository @Inject constructor(
         recipeDao.deleteRecipeById(id)
     }
 
+    suspend fun setFavorite(id: String, isFavorite: Boolean) {
+        recipeDao.setFavorite(id, isFavorite)
+    }
+
     suspend fun getAllTags(): Set<String> {
         val allTagsJson = recipeDao.getAllTagsJson()
         return allTagsJson.flatMap { tagsJson ->

--- a/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
@@ -24,7 +24,9 @@ object DatabaseModule {
             context,
             RecipeDatabase::class.java,
             "recipes.db"
-        ).build()
+        )
+            .addMigrations(RecipeDatabase.MIGRATION_1_2)
+            .build()
     }
 
     @Provides

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
@@ -54,7 +54,8 @@ data class Recipe(
     val tags: List<String> = emptyList(),
     val imageUrl: String? = null,
     val createdAt: Instant,
-    val updatedAt: Instant
+    val updatedAt: Instant,
+    val isFavorite: Boolean = false
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -57,6 +59,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
 import coil.compose.AsyncImage
 import com.lionotter.recipes.domain.model.IngredientSection
 import com.lionotter.recipes.domain.model.InstructionSection
@@ -117,6 +120,13 @@ fun RecipeDetailScreen(
                 },
                 actions = {
                     if (recipe != null) {
+                        IconButton(onClick = { viewModel.toggleFavorite() }) {
+                            Icon(
+                                imageVector = if (recipe!!.isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                                contentDescription = if (recipe!!.isFavorite) "Remove from favorites" else "Add to favorites",
+                                tint = if (recipe!!.isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                        }
                         IconButton(onClick = { showDeleteDialog = true }) {
                             Icon(
                                 imageVector = Icons.Default.Delete,
@@ -302,7 +312,7 @@ private fun RecipeContent(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.clickable {
-                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
                         context.startActivity(intent)
                     }
                 )

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.lionotter.recipes.ui.screens.recipedetail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.lionotter.recipes.data.repository.RecipeRepository
 import com.lionotter.recipes.domain.model.Ingredient
 import com.lionotter.recipes.domain.model.MeasurementPreference
 import com.lionotter.recipes.domain.model.MeasurementType
@@ -55,7 +56,8 @@ data class HighlightedInstructionStep(
 class RecipeDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     getRecipeByIdUseCase: GetRecipeByIdUseCase,
-    private val deleteRecipeUseCase: DeleteRecipeUseCase
+    private val deleteRecipeUseCase: DeleteRecipeUseCase,
+    private val recipeRepository: RecipeRepository
 ) : ViewModel() {
 
     private val recipeId: String = savedStateHandle.get<String>("recipeId")
@@ -267,6 +269,16 @@ class RecipeDetailViewModel @Inject constructor(
             null
         } else {
             newStep
+        }
+    }
+
+    /**
+     * Toggles the favorite status of the current recipe.
+     */
+    fun toggleFavorite() {
+        viewModelScope.launch {
+            val currentRecipe = recipe.value ?: return@launch
+            recipeRepository.setFavorite(recipeId, !currentRecipe.isFavorite)
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -345,7 +347,8 @@ fun RecipeListScreen(
                                 SwipeableRecipeCard(
                                     recipe = item.recipe,
                                     onClick = { onRecipeClick(item.id) },
-                                    onDeleteRequest = { recipeToDelete = item.recipe }
+                                    onDeleteRequest = { recipeToDelete = item.recipe },
+                                    onFavoriteClick = { viewModel.toggleFavorite(item.id) }
                                 )
                             }
                             is RecipeListItem.InProgress -> {
@@ -589,7 +592,8 @@ private fun FolderPickerDialog(
 private fun SwipeableRecipeCard(
     recipe: Recipe,
     onClick: () -> Unit,
-    onDeleteRequest: () -> Unit
+    onDeleteRequest: () -> Unit,
+    onFavoriteClick: () -> Unit
 ) {
     var showMenu by remember { mutableStateOf(false) }
     val dismissState = rememberSwipeToDismissBoxState(
@@ -627,7 +631,8 @@ private fun SwipeableRecipeCard(
             onLongClick = { showMenu = true },
             showMenu = showMenu,
             onDismissMenu = { showMenu = false },
-            onDeleteRequest = onDeleteRequest
+            onDeleteRequest = onDeleteRequest,
+            onFavoriteClick = onFavoriteClick
         )
     }
 }
@@ -640,7 +645,8 @@ private fun RecipeCard(
     onLongClick: () -> Unit,
     showMenu: Boolean,
     onDismissMenu: () -> Unit,
-    onDeleteRequest: () -> Unit
+    onDeleteRequest: () -> Unit,
+    onFavoriteClick: () -> Unit
 ) {
     Box {
         Card(
@@ -724,6 +730,18 @@ private fun RecipeCard(
                             }
                         }
                     }
+                }
+
+                // Favorite button
+                IconButton(
+                    onClick = onFavoriteClick,
+                    modifier = Modifier.align(Alignment.Top)
+                ) {
+                    Icon(
+                        imageVector = if (recipe.isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                        contentDescription = if (recipe.isFavorite) "Remove from favorites" else "Add to favorites",
+                        tint = if (recipe.isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -3,6 +3,7 @@ package com.lionotter.recipes.ui.screens.settings
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -283,7 +284,7 @@ private fun ApiKeySection(
 
         OutlinedButton(
             onClick = {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://platform.claude.com/settings/keys"))
+                val intent = Intent(Intent.ACTION_VIEW, "https://platform.claude.com/settings/keys".toUri())
                 context.startActivity(intent)
             },
             modifier = Modifier.fillMaxWidth()

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -210,7 +210,10 @@ app: {
         fill: "#ffffff"
       }
 
-      recipe: Recipe
+      recipe: {
+        label: Recipe
+        tooltip: "Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, tags, imageUrl, timestamps, isFavorite"
+      }
       ingredient: {
         label: Ingredient
         tooltip: "Fields: name, notes, alternates, amounts, optional"
@@ -372,4 +375,17 @@ legend: {
       italic: true
     }
   }
+
+  favorites: {
+    label: "Favorites Feature"
+    style: {
+      font-size: 14
+      bold: true
+    }
+  }
+  fav1: "Recipes can be starred/favorited from list or detail view"
+  fav2: "Favorites are sorted first in the recipe list"
+  fav3: "Re-sorting only occurs on filter/tag/search changes to avoid jarring UI"
+
+  fav1 -> fav2 -> fav3
 }


### PR DESCRIPTION
## Summary

- Add ability to favorite/star recipes with a star button on recipe cards in the list view
- Add star button in the recipe detail screen's app bar
- Favorites are sorted first in the recipe list when filtering/searching changes
- Sorting only triggers on filter/tag/search changes to avoid jarring UI when starring a recipe

## Implementation Details

**Database changes:**
- Add `isFavorite` boolean field to RecipeEntity with default value `false`
- Add migration from schema version 1 to 2 (adds `isFavorite` column)
- Add `setFavorite` method to RecipeDao for toggling favorite status

**UI changes:**
- Star button (filled/outlined) on recipe cards in RecipeListScreen
- Star button in RecipeDetailScreen's app bar
- Favorites sorted first, but only re-sorted on filter/tag/search changes (not on star toggle) to avoid jarring movement of cards the user is interacting with

## Test plan

- [ ] Verify star button appears on recipe cards
- [ ] Verify tapping star toggles the favorite status (star fills/empties)
- [ ] Verify favorites appear first after changing tags or search
- [ ] Verify starring a recipe doesn't immediately resort the list
- [ ] Verify favorite status persists after app restart
- [ ] Verify star button appears in recipe detail screen

Closes #53

---
Generated with [Claude Code](https://claude.com/claude-code)