### PR TITLE
fix: update UI when import finishes

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
@@ -134,6 +134,8 @@ fun RecipeListScreen(
                 }
                 snackbarHostState.showSnackbar(message)
                 googleDriveViewModel.resetOperationState()
+                // Refresh tags to include any new tags from imported recipes
+                viewModel.refreshTags()
             }
             is OperationState.Error -> {
                 snackbarHostState.showSnackbar(state.message)


### PR DESCRIPTION
## Summary
- Add WorkManager observation to RecipeListViewModel to properly clean up in-progress recipes when imports complete, even if AddRecipeScreen is no longer active
- Refresh tags after URL imports succeed to reflect newly imported recipes
- Refresh tags after Google Drive imports complete

## Problem
When an import finished:
1. The "Importing recipe..." indicator wouldn't go away if the user had navigated away from AddRecipeScreen
2. Tags at the top of the screen weren't updated to reflect newly imported recipes

## Root Cause
The `AddRecipeViewModel` was responsible for cleaning up in-progress recipes and was only active while the AddRecipeScreen was visible. If the user navigated back to the recipe list, the ViewModel would be destroyed and stop observing work completion.

Additionally, `loadTags()` was only called on ViewModel init and after recipe deletion, not after imports.

## Solution
- Added `observeImportWorkStatus()` in `RecipeListViewModel` to observe import work status and clean up in-progress recipes
- Added `refreshTags()` public method to allow tag refresh from outside the ViewModel
- Call `refreshTags()` after Google Drive imports complete in RecipeListScreen
- Call `loadTags()` after URL imports succeed in RecipeListViewModel

## Test plan
- [ ] Start importing a recipe from a URL
- [ ] Navigate back to the recipe list while import is in progress
- [ ] Verify the "Importing recipe..." card disappears when import completes
- [ ] Verify the tag filter chips update to include any new tags from the imported recipe
- [ ] Import recipes from Google Drive
- [ ] Verify the tag filter chips update after Drive import completes

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)