### PR TITLE
feat: enhance API key security with EncryptedSharedPreferences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,9 @@ dependencies {
     // DataStore
     implementation(libs.datastore.preferences)
 
+    // Security
+    implementation(libs.security.crypto)
+
     // Coil
     implementation(libs.coil.compose)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <application
         android:name=".LionOtterApp"
         android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <!-- Exclude encrypted preferences containing API key -->
+    <exclude domain="sharedpref" path="secure_settings.xml" />
+    <!-- Exclude security-crypto master key prefs -->
+    <exclude domain="sharedpref" path="__androidx_security_crypto_encrypted_prefs__.xml" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <!-- Exclude encrypted preferences containing API key from cloud backups -->
+        <exclude domain="sharedpref" path="secure_settings.xml" />
+        <exclude domain="sharedpref" path="__androidx_security_crypto_encrypted_prefs__.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <!-- Exclude encrypted preferences from device-to-device transfers -->
+        <exclude domain="sharedpref" path="secure_settings.xml" />
+        <exclude domain="sharedpref" path="__androidx_security_crypto_encrypted_prefs__.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -272,13 +272,25 @@ app: {
         label: DataStore
         shape: cylinder
       }
+      encrypted_prefs: {
+        label: EncryptedSharedPreferences
+        shape: cylinder
+        tooltip: "AES256-GCM encrypted storage for sensitive data like API keys"
+        style: {
+          fill: "#c8e6c9"
+        }
+      }
       dao: RecipeDao
       entity: RecipeEntity
-      settings: SettingsDataStore
+      settings: {
+        label: SettingsDataStore
+        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings"
+      }
 
       dao -> room
       entity -> room
-      settings -> datastore
+      settings -> datastore: non-sensitive settings
+      settings -> encrypted_prefs: API key
     }
 
     remote: {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ ktor = "3.0.3"
 kotlinxSerialization = "1.7.3"
 kotlinxDatetime = "0.6.1"
 datastore = "1.1.1"
+securityCrypto = "1.1.0-alpha06"
 navigationCompose = "2.8.5"
 coil = "2.7.0"
 ksp = "2.1.0-1.0.29"
@@ -66,6 +67,9 @@ kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime",
 
 # DataStore
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+
+# Security
+security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 
 # Coil
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }


### PR DESCRIPTION
## Summary

- Migrated Anthropic API key storage from plain-text DataStore to AES256-GCM encrypted EncryptedSharedPreferences
- Added backup exclusion rules to prevent API key from being included in device backups
- Updated architecture documentation to reflect the new encrypted storage mechanism

## Security Improvements

1. **Encrypted Storage**: API key is now encrypted with AES256-GCM using a hardware-backed master key (when available)
2. **Backup Protection**: Added `backup_rules.xml` and `data_extraction_rules.xml` to exclude sensitive data from:
   - Cloud backups (Google backup)
   - Device-to-device transfers
3. **Architecture**: Non-sensitive settings (like AI model preference) remain in DataStore for simplicity

## Implementation Details

- Uses `MasterKey` with `AES256_GCM` key scheme
- Key encryption: `AES256_SIV`
- Value encryption: `AES256_GCM`
- Reactive Flow API maintained via `MutableStateFlow` wrapper

## Test plan

- [ ] Verify existing API key is no longer accessible (user needs to re-enter after update)
- [ ] Verify new API key is saved and retrieved correctly
- [ ] Verify API key works for recipe imports
- [ ] Verify device backup does not include `secure_settings.xml`

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)