### PR TITLE
feat: expand test coverage with comprehensive unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,4 +132,6 @@ dependencies {
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
+    testImplementation(libs.turbine)
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -113,6 +113,25 @@ class AnthropicService @Inject constructor(
         private const val ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
         private const val ANTHROPIC_VERSION = "2023-06-01"
         const val DEFAULT_MODEL = "claude-opus-4-5"
+        private const val API_KEY_PREFIX = "sk-ant-"
+
+        /**
+         * Validates an Anthropic API key format.
+         * Returns null if valid, or an error message if invalid.
+         */
+        fun validateApiKey(apiKey: String): String? {
+            val trimmed = apiKey.trim()
+            return when {
+                trimmed.isBlank() -> "API key cannot be empty"
+                !trimmed.startsWith(API_KEY_PREFIX) -> "Invalid API key format. Should start with '$API_KEY_PREFIX'"
+                else -> null
+            }
+        }
+
+        /**
+         * Returns true if the API key has a valid format.
+         */
+        fun isValidApiKey(apiKey: String): Boolean = validateApiKey(apiKey) == null
 
         private val SYSTEM_PROMPT = """
 You are a recipe parser. Extract structured recipe data from HTML content and return it as JSON.

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
@@ -1,11 +1,15 @@
 package com.lionotter.recipes.data.repository
 
+import android.util.Log
 import com.lionotter.recipes.data.local.RecipeDao
 import com.lionotter.recipes.data.local.RecipeEntity
 import com.lionotter.recipes.domain.model.IngredientSection
 import com.lionotter.recipes.domain.model.InstructionSection
 import com.lionotter.recipes.domain.model.Recipe
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -17,6 +21,17 @@ class RecipeRepository @Inject constructor(
     private val recipeDao: RecipeDao,
     private val json: Json
 ) {
+    private val _errors = MutableSharedFlow<String>()
+    val errors: SharedFlow<String> = _errors.asSharedFlow()
+
+    private suspend fun emitError(message: String) {
+        Log.e(TAG, message)
+        _errors.emit(message)
+    }
+
+    companion object {
+        private const val TAG = "RecipeRepository"
+    }
     fun getAllRecipes(): Flow<List<Recipe>> {
         return recipeDao.getAllRecipes().map { entities ->
             entities.map { entity -> entityToRecipe(entity) }
@@ -30,7 +45,7 @@ class RecipeRepository @Inject constructor(
     }
 
     suspend fun getRecipeByIdOnce(id: String): Recipe? {
-        return recipeDao.getRecipeById(id)?.let { entityToRecipe(it) }
+        return recipeDao.getRecipeById(id)?.let { entityToRecipeWithErrorReporting(it) }
     }
 
     /**
@@ -77,6 +92,7 @@ class RecipeRepository @Inject constructor(
             try {
                 json.decodeFromString<List<String>>(tagsJson)
             } catch (e: Exception) {
+                Log.w(TAG, "Failed to parse tags JSON: $tagsJson", e)
                 emptyList()
             }
         }.toSet()
@@ -91,28 +107,79 @@ class RecipeRepository @Inject constructor(
             val tags: List<String> = try {
                 json.decodeFromString(entity.tagsJson)
             } catch (e: Exception) {
+                Log.w(TAG, "Failed to parse tags JSON for recipe ${entity.id}: ${entity.tagsJson}", e)
                 emptyList()
             }
             entity.id to tags
         }
     }
 
-    private fun entityToRecipe(entity: RecipeEntity): Recipe {
+    /**
+     * Converts a database entity to a domain Recipe.
+     * If JSON parsing fails for any section, logs the error, emits an error message,
+     * and returns the recipe with empty data for that section.
+     */
+    private suspend fun entityToRecipeWithErrorReporting(entity: RecipeEntity): Recipe {
+        var hasError = false
+
         val ingredientSections: List<IngredientSection> = try {
             json.decodeFromString(entity.ingredientSectionsJson)
         } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse ingredients for recipe '${entity.name}' (${entity.id})", e)
+            hasError = true
             emptyList()
         }
 
         val instructionSections: List<InstructionSection> = try {
             json.decodeFromString(entity.instructionSectionsJson)
         } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse instructions for recipe '${entity.name}' (${entity.id})", e)
+            hasError = true
             emptyList()
         }
 
         val tags: List<String> = try {
             json.decodeFromString(entity.tagsJson)
         } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse tags for recipe '${entity.name}' (${entity.id})", e)
+            hasError = true
+            emptyList()
+        }
+
+        if (hasError) {
+            emitError("Some data for recipe '${entity.name}' could not be loaded. The recipe may appear incomplete.")
+        }
+
+        return entity.toRecipe(
+            ingredientSections = ingredientSections,
+            instructionSections = instructionSections,
+            tags = tags
+        )
+    }
+
+    /**
+     * Non-suspending version for use in Flow mapping.
+     * Logs errors but cannot emit to the error flow.
+     */
+    private fun entityToRecipe(entity: RecipeEntity): Recipe {
+        val ingredientSections: List<IngredientSection> = try {
+            json.decodeFromString(entity.ingredientSectionsJson)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse ingredients for recipe '${entity.name}' (${entity.id})", e)
+            emptyList()
+        }
+
+        val instructionSections: List<InstructionSection> = try {
+            json.decodeFromString(entity.instructionSectionsJson)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse instructions for recipe '${entity.name}' (${entity.id})", e)
+            emptyList()
+        }
+
+        val tags: List<String> = try {
+            json.decodeFromString(entity.tagsJson)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse tags for recipe '${entity.name}' (${entity.id})", e)
             emptyList()
         }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
@@ -60,8 +60,12 @@ class RecipeDetailViewModel @Inject constructor(
     private val recipeRepository: RecipeRepository
 ) : ViewModel() {
 
-    private val recipeId: String = savedStateHandle.get<String>("recipeId")
-        ?: throw IllegalArgumentException("Recipe ID is required")
+    private val recipeId: String
+
+    init {
+        recipeId = savedStateHandle.get<String>("recipeId")
+            ?: throw IllegalArgumentException("RecipeDetailViewModel requires a 'recipeId' argument in SavedStateHandle")
+    }
 
     private val _recipeDeleted = MutableSharedFlow<Unit>()
     val recipeDeleted: SharedFlow<Unit> = _recipeDeleted.asSharedFlow()
@@ -69,7 +73,7 @@ class RecipeDetailViewModel @Inject constructor(
     val recipe: StateFlow<Recipe?> = getRecipeByIdUseCase.execute(recipeId)
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
+            started = SharingStarted.Eagerly,
             initialValue = null
         )
 
@@ -106,7 +110,7 @@ class RecipeDetailViewModel @Inject constructor(
         }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
+            started = SharingStarted.Eagerly,
             initialValue = false
         )
 
@@ -123,7 +127,7 @@ class RecipeDetailViewModel @Inject constructor(
         }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
+            started = SharingStarted.Eagerly,
             initialValue = emptySet()
         )
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
@@ -108,6 +108,13 @@ fun RecipeListScreen(
         googleDriveViewModel.refreshSignInStatus()
     }
 
+    // Show snackbar for repository errors (e.g., corrupted recipe data)
+    LaunchedEffect(Unit) {
+        viewModel.repositoryErrors.collect { error ->
+            snackbarHostState.showSnackbar(error)
+        }
+    }
+
     // Show snackbar for operation results
     LaunchedEffect(operationState) {
         when (val state = operationState) {

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListViewModel.kt
@@ -13,6 +13,7 @@ import com.lionotter.recipes.ui.state.RecipeListItem
 import com.lionotter.recipes.worker.RecipeImportWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,6 +31,11 @@ class RecipeListViewModel @Inject constructor(
     private val recipeRepository: RecipeRepository,
     private val workManager: WorkManager
 ) : ViewModel() {
+
+    /**
+     * Errors from the repository (e.g., JSON parse failures) to be displayed to the user.
+     */
+    val repositoryErrors: SharedFlow<String> = recipeRepository.errors
 
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -44,13 +44,10 @@ class SettingsViewModel @Inject constructor(
 
     fun saveApiKey() {
         val key = _apiKeyInput.value.trim()
-        if (key.isBlank()) {
-            _saveState.value = SaveState.Error("API key cannot be empty")
-            return
-        }
 
-        if (!key.startsWith("sk-ant-")) {
-            _saveState.value = SaveState.Error("Invalid API key format. Should start with 'sk-ant-'")
+        val validationError = AnthropicService.validateApiKey(key)
+        if (validationError != null) {
+            _saveState.value = SaveState.Error(validationError)
             return
         }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/state/InProgressRecipeManager.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/state/InProgressRecipeManager.kt
@@ -32,6 +32,7 @@ class InProgressRecipeManager @Inject constructor() {
     }
 
     fun removeInProgressRecipe(id: String) {
+        if (!_inProgressRecipes.value.containsKey(id)) return
         val updated = _inProgressRecipes.value.toMutableMap()
         updated.remove(id)
         _inProgressRecipes.value = updated

--- a/app/src/test/kotlin/com/lionotter/recipes/data/remote/AnthropicServiceTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/data/remote/AnthropicServiceTest.kt
@@ -1,0 +1,56 @@
+package com.lionotter.recipes.data.remote
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnthropicServiceTest {
+
+    @Test
+    fun `validateApiKey returns null for valid key`() {
+        assertNull(AnthropicService.validateApiKey("sk-ant-valid-key-123"))
+    }
+
+    @Test
+    fun `validateApiKey returns error for empty key`() {
+        assertEquals("API key cannot be empty", AnthropicService.validateApiKey(""))
+    }
+
+    @Test
+    fun `validateApiKey returns error for blank key`() {
+        assertEquals("API key cannot be empty", AnthropicService.validateApiKey("   "))
+    }
+
+    @Test
+    fun `validateApiKey returns error for invalid prefix`() {
+        val error = AnthropicService.validateApiKey("invalid-key")
+        assertTrue(error?.contains("sk-ant-") == true)
+    }
+
+    @Test
+    fun `validateApiKey trims whitespace before validation`() {
+        assertNull(AnthropicService.validateApiKey("  sk-ant-valid-key  "))
+    }
+
+    @Test
+    fun `isValidApiKey returns true for valid key`() {
+        assertTrue(AnthropicService.isValidApiKey("sk-ant-valid-key-123"))
+    }
+
+    @Test
+    fun `isValidApiKey returns false for empty key`() {
+        assertFalse(AnthropicService.isValidApiKey(""))
+    }
+
+    @Test
+    fun `isValidApiKey returns false for invalid prefix`() {
+        assertFalse(AnthropicService.isValidApiKey("invalid-key"))
+    }
+
+    @Test
+    fun `DEFAULT_MODEL is set`() {
+        assertTrue(AnthropicService.DEFAULT_MODEL.isNotEmpty())
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/data/repository/RecipeRepositoryTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/data/repository/RecipeRepositoryTest.kt
@@ -1,0 +1,465 @@
+package com.lionotter.recipes.data.repository
+
+import android.util.Log
+import app.cash.turbine.test
+import com.lionotter.recipes.data.local.RecipeDao
+import com.lionotter.recipes.data.local.RecipeEntity
+import com.lionotter.recipes.domain.model.Ingredient
+import com.lionotter.recipes.domain.model.IngredientSection
+import com.lionotter.recipes.domain.model.InstructionSection
+import com.lionotter.recipes.domain.model.InstructionStep
+import com.lionotter.recipes.domain.model.Measurement
+import com.lionotter.recipes.domain.model.MeasurementType
+import com.lionotter.recipes.domain.model.Recipe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RecipeRepositoryTest {
+
+    private lateinit var recipeDao: RecipeDao
+    private lateinit var json: Json
+    private lateinit var recipeRepository: RecipeRepository
+
+    @Before
+    fun setup() {
+        // Mock Android Log class for unit tests
+        mockkStatic(Log::class)
+        every { Log.e(any(), any()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>(), any()) } returns 0
+
+        recipeDao = mockk()
+        json = Json { ignoreUnknownKeys = true }
+        recipeRepository = RecipeRepository(recipeDao, json)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    private fun createTestEntity(
+        id: String = "test-id",
+        name: String = "Test Recipe",
+        sourceUrl: String? = null,
+        story: String? = null,
+        servings: Int? = null,
+        prepTime: String? = null,
+        cookTime: String? = null,
+        totalTime: String? = null,
+        imageUrl: String? = null,
+        tagsJson: String = "[]",
+        ingredientSectionsJson: String = "[]",
+        instructionSectionsJson: String = "[]",
+        originalHtml: String? = null,
+        createdAt: Long = 1000L,
+        updatedAt: Long = 2000L,
+        isFavorite: Boolean = false
+    ) = RecipeEntity(
+        id = id,
+        name = name,
+        sourceUrl = sourceUrl,
+        story = story,
+        servings = servings,
+        prepTime = prepTime,
+        cookTime = cookTime,
+        totalTime = totalTime,
+        imageUrl = imageUrl,
+        tagsJson = tagsJson,
+        ingredientSectionsJson = ingredientSectionsJson,
+        instructionSectionsJson = instructionSectionsJson,
+        originalHtml = originalHtml,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        isFavorite = isFavorite
+    )
+
+    private fun createTestRecipe(
+        id: String = "test-id",
+        name: String = "Test Recipe",
+        tags: List<String> = emptyList()
+    ) = Recipe(
+        id = id,
+        name = name,
+        tags = tags,
+        createdAt = Instant.fromEpochMilliseconds(1000L),
+        updatedAt = Instant.fromEpochMilliseconds(2000L)
+    )
+
+    @Test
+    fun `getAllRecipes returns mapped recipes`() = runTest {
+        val entities = listOf(
+            createTestEntity(id = "1", name = "Recipe 1"),
+            createTestEntity(id = "2", name = "Recipe 2")
+        )
+        every { recipeDao.getAllRecipes() } returns flowOf(entities)
+
+        recipeRepository.getAllRecipes().test {
+            val recipes = awaitItem()
+            assertEquals(2, recipes.size)
+            assertEquals("Recipe 1", recipes[0].name)
+            assertEquals("Recipe 2", recipes[1].name)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `getAllRecipes returns empty list when no recipes`() = runTest {
+        every { recipeDao.getAllRecipes() } returns flowOf(emptyList())
+
+        recipeRepository.getAllRecipes().test {
+            assertTrue(awaitItem().isEmpty())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `getRecipeById returns mapped recipe when found`() = runTest {
+        val entity = createTestEntity(id = "recipe-1", name = "Found Recipe")
+        every { recipeDao.getRecipeByIdFlow("recipe-1") } returns flowOf(entity)
+
+        recipeRepository.getRecipeById("recipe-1").test {
+            val recipe = awaitItem()
+            assertNotNull(recipe)
+            assertEquals("Found Recipe", recipe?.name)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `getRecipeById returns null when not found`() = runTest {
+        every { recipeDao.getRecipeByIdFlow("nonexistent") } returns flowOf(null)
+
+        recipeRepository.getRecipeById("nonexistent").test {
+            assertNull(awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `getRecipeByIdOnce returns recipe when found`() = runTest {
+        val entity = createTestEntity(id = "recipe-1", name = "Found Recipe")
+        coEvery { recipeDao.getRecipeById("recipe-1") } returns entity
+
+        val result = recipeRepository.getRecipeByIdOnce("recipe-1")
+
+        assertNotNull(result)
+        assertEquals("Found Recipe", result?.name)
+    }
+
+    @Test
+    fun `getRecipeByIdOnce returns null when not found`() = runTest {
+        coEvery { recipeDao.getRecipeById("nonexistent") } returns null
+
+        val result = recipeRepository.getRecipeByIdOnce("nonexistent")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `getOriginalHtml returns html when present`() = runTest {
+        val entity = createTestEntity(originalHtml = "<html>Test</html>")
+        coEvery { recipeDao.getRecipeById("recipe-1") } returns entity
+
+        val result = recipeRepository.getOriginalHtml("recipe-1")
+
+        assertEquals("<html>Test</html>", result)
+    }
+
+    @Test
+    fun `getOriginalHtml returns null when no html`() = runTest {
+        val entity = createTestEntity(originalHtml = null)
+        coEvery { recipeDao.getRecipeById("recipe-1") } returns entity
+
+        val result = recipeRepository.getOriginalHtml("recipe-1")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `getOriginalHtml returns null when recipe not found`() = runTest {
+        coEvery { recipeDao.getRecipeById("nonexistent") } returns null
+
+        val result = recipeRepository.getOriginalHtml("nonexistent")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `getRecipesByTag returns filtered recipes`() = runTest {
+        val entities = listOf(
+            createTestEntity(id = "1", name = "Italian Recipe", tagsJson = "[\"italian\"]")
+        )
+        every { recipeDao.getRecipesByTag("italian") } returns flowOf(entities)
+
+        recipeRepository.getRecipesByTag("italian").test {
+            val recipes = awaitItem()
+            assertEquals(1, recipes.size)
+            assertEquals("Italian Recipe", recipes[0].name)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `searchRecipes returns matching recipes`() = runTest {
+        val entities = listOf(
+            createTestEntity(id = "1", name = "Pasta Carbonara")
+        )
+        every { recipeDao.searchRecipes("pasta") } returns flowOf(entities)
+
+        recipeRepository.searchRecipes("pasta").test {
+            val recipes = awaitItem()
+            assertEquals(1, recipes.size)
+            assertEquals("Pasta Carbonara", recipes[0].name)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `saveRecipe inserts entity into dao`() = runTest {
+        val entitySlot = slot<RecipeEntity>()
+        coEvery { recipeDao.insertRecipe(capture(entitySlot)) } just runs
+
+        val recipe = createTestRecipe(id = "new-recipe", name = "New Recipe")
+        recipeRepository.saveRecipe(recipe, "<html>Original</html>")
+
+        coVerify { recipeDao.insertRecipe(any()) }
+        assertEquals("new-recipe", entitySlot.captured.id)
+        assertEquals("New Recipe", entitySlot.captured.name)
+        assertEquals("<html>Original</html>", entitySlot.captured.originalHtml)
+    }
+
+    @Test
+    fun `saveRecipe serializes ingredient sections`() = runTest {
+        val entitySlot = slot<RecipeEntity>()
+        coEvery { recipeDao.insertRecipe(capture(entitySlot)) } just runs
+
+        val recipe = Recipe(
+            id = "recipe-1",
+            name = "Test",
+            ingredientSections = listOf(
+                IngredientSection(
+                    name = "Main",
+                    ingredients = listOf(
+                        Ingredient(
+                            name = "flour",
+                            amounts = listOf(
+                                Measurement(value = 2.0, unit = "cups", type = MeasurementType.VOLUME, isDefault = true)
+                            )
+                        )
+                    )
+                )
+            ),
+            createdAt = Instant.fromEpochMilliseconds(1000L),
+            updatedAt = Instant.fromEpochMilliseconds(2000L)
+        )
+        recipeRepository.saveRecipe(recipe)
+
+        assertTrue(entitySlot.captured.ingredientSectionsJson.contains("flour"))
+        assertTrue(entitySlot.captured.ingredientSectionsJson.contains("Main"))
+    }
+
+    @Test
+    fun `saveRecipe serializes instruction sections`() = runTest {
+        val entitySlot = slot<RecipeEntity>()
+        coEvery { recipeDao.insertRecipe(capture(entitySlot)) } just runs
+
+        val recipe = Recipe(
+            id = "recipe-1",
+            name = "Test",
+            instructionSections = listOf(
+                InstructionSection(
+                    steps = listOf(
+                        InstructionStep(stepNumber = 1, instruction = "Mix ingredients")
+                    )
+                )
+            ),
+            createdAt = Instant.fromEpochMilliseconds(1000L),
+            updatedAt = Instant.fromEpochMilliseconds(2000L)
+        )
+        recipeRepository.saveRecipe(recipe)
+
+        assertTrue(entitySlot.captured.instructionSectionsJson.contains("Mix ingredients"))
+    }
+
+    @Test
+    fun `saveRecipe serializes tags`() = runTest {
+        val entitySlot = slot<RecipeEntity>()
+        coEvery { recipeDao.insertRecipe(capture(entitySlot)) } just runs
+
+        val recipe = createTestRecipe(tags = listOf("italian", "pasta", "dinner"))
+        recipeRepository.saveRecipe(recipe)
+
+        assertTrue(entitySlot.captured.tagsJson.contains("italian"))
+        assertTrue(entitySlot.captured.tagsJson.contains("pasta"))
+        assertTrue(entitySlot.captured.tagsJson.contains("dinner"))
+    }
+
+    @Test
+    fun `deleteRecipe calls dao deleteRecipeById`() = runTest {
+        coEvery { recipeDao.deleteRecipeById("recipe-1") } just runs
+
+        recipeRepository.deleteRecipe("recipe-1")
+
+        coVerify { recipeDao.deleteRecipeById("recipe-1") }
+    }
+
+    @Test
+    fun `setFavorite calls dao setFavorite`() = runTest {
+        coEvery { recipeDao.setFavorite("recipe-1", true) } just runs
+
+        recipeRepository.setFavorite("recipe-1", true)
+
+        coVerify { recipeDao.setFavorite("recipe-1", true) }
+    }
+
+    @Test
+    fun `getAllTags extracts unique tags from all recipes`() = runTest {
+        coEvery { recipeDao.getAllTagsJson() } returns listOf(
+            "[\"italian\",\"pasta\"]",
+            "[\"italian\",\"dinner\"]",
+            "[\"dessert\"]"
+        )
+
+        val result = recipeRepository.getAllTags()
+
+        assertEquals(setOf("italian", "pasta", "dinner", "dessert"), result)
+    }
+
+    @Test
+    fun `getAllTags returns empty set when no tags`() = runTest {
+        coEvery { recipeDao.getAllTagsJson() } returns emptyList()
+
+        val result = recipeRepository.getAllTags()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `getAllTags handles malformed json gracefully`() = runTest {
+        coEvery { recipeDao.getAllTagsJson() } returns listOf(
+            "[\"valid\"]",
+            "invalid json",
+            "[\"also-valid\"]"
+        )
+
+        val result = recipeRepository.getAllTags()
+
+        // Should include valid tags and skip malformed
+        assertTrue(result.contains("valid"))
+        assertTrue(result.contains("also-valid"))
+    }
+
+    @Test
+    fun `getAllRecipesWithTags returns recipe id and tags pairs`() = runTest {
+        coEvery { recipeDao.getAllRecipesOnce() } returns listOf(
+            createTestEntity(id = "1", tagsJson = "[\"tag-a\",\"tag-b\"]"),
+            createTestEntity(id = "2", tagsJson = "[\"tag-c\"]")
+        )
+
+        val result = recipeRepository.getAllRecipesWithTags()
+
+        assertEquals(2, result.size)
+        assertEquals("1" to listOf("tag-a", "tag-b"), result[0])
+        assertEquals("2" to listOf("tag-c"), result[1])
+    }
+
+    @Test
+    fun `getAllRecipesWithTags handles malformed tags json`() = runTest {
+        coEvery { recipeDao.getAllRecipesOnce() } returns listOf(
+            createTestEntity(id = "1", tagsJson = "invalid"),
+            createTestEntity(id = "2", tagsJson = "[\"valid\"]")
+        )
+
+        val result = recipeRepository.getAllRecipesWithTags()
+
+        // First recipe should have empty tags due to parse error
+        assertEquals("1" to emptyList<String>(), result[0])
+        assertEquals("2" to listOf("valid"), result[1])
+    }
+
+    @Test
+    fun `entity to recipe mapping preserves all fields`() = runTest {
+        val entity = RecipeEntity(
+            id = "full-recipe",
+            name = "Full Recipe",
+            sourceUrl = "https://example.com",
+            story = "A great story",
+            servings = 4,
+            prepTime = "10 min",
+            cookTime = "20 min",
+            totalTime = "30 min",
+            imageUrl = "https://example.com/image.jpg",
+            tagsJson = "[\"tag1\",\"tag2\"]",
+            ingredientSectionsJson = "[]",
+            instructionSectionsJson = "[]",
+            originalHtml = null,
+            createdAt = 1000L,
+            updatedAt = 2000L,
+            isFavorite = true
+        )
+        every { recipeDao.getRecipeByIdFlow("full-recipe") } returns flowOf(entity)
+
+        recipeRepository.getRecipeById("full-recipe").test {
+            val recipe = awaitItem()
+            assertNotNull(recipe)
+            assertEquals("full-recipe", recipe?.id)
+            assertEquals("Full Recipe", recipe?.name)
+            assertEquals("https://example.com", recipe?.sourceUrl)
+            assertEquals("A great story", recipe?.story)
+            assertEquals(4, recipe?.servings)
+            assertEquals("10 min", recipe?.prepTime)
+            assertEquals("20 min", recipe?.cookTime)
+            assertEquals("30 min", recipe?.totalTime)
+            assertEquals("https://example.com/image.jpg", recipe?.imageUrl)
+            assertEquals(listOf("tag1", "tag2"), recipe?.tags)
+            assertEquals(true, recipe?.isFavorite)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `entity to recipe mapping handles malformed ingredient json`() = runTest {
+        val entity = createTestEntity(ingredientSectionsJson = "not valid json")
+        every { recipeDao.getRecipeByIdFlow("recipe-1") } returns flowOf(entity)
+
+        recipeRepository.getRecipeById("recipe-1").test {
+            val recipe = awaitItem()
+            assertNotNull(recipe)
+            assertTrue(recipe?.ingredientSections?.isEmpty() == true)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `entity to recipe mapping handles malformed instruction json`() = runTest {
+        val entity = createTestEntity(instructionSectionsJson = "not valid json")
+        every { recipeDao.getRecipeByIdFlow("recipe-1") } returns flowOf(entity)
+
+        recipeRepository.getRecipeById("recipe-1").test {
+            val recipe = awaitItem()
+            assertNotNull(recipe)
+            assertTrue(recipe?.instructionSections?.isEmpty() == true)
+            awaitComplete()
+        }
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/usecase/DeleteRecipeUseCaseTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/usecase/DeleteRecipeUseCaseTest.kt
@@ -1,0 +1,56 @@
+package com.lionotter.recipes.domain.usecase
+
+import com.lionotter.recipes.data.repository.RecipeRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class DeleteRecipeUseCaseTest {
+
+    private lateinit var recipeRepository: RecipeRepository
+    private lateinit var deleteRecipeUseCase: DeleteRecipeUseCase
+
+    @Before
+    fun setup() {
+        recipeRepository = mockk()
+        deleteRecipeUseCase = DeleteRecipeUseCase(recipeRepository)
+    }
+
+    @Test
+    fun `execute delegates to repository deleteRecipe`() = runTest {
+        val recipeId = "recipe-123"
+        coEvery { recipeRepository.deleteRecipe(recipeId) } just runs
+
+        deleteRecipeUseCase.execute(recipeId)
+
+        coVerify { recipeRepository.deleteRecipe(recipeId) }
+    }
+
+    @Test
+    fun `execute calls repository with correct id`() = runTest {
+        val recipeId = "specific-recipe-id"
+        coEvery { recipeRepository.deleteRecipe(recipeId) } just runs
+
+        deleteRecipeUseCase.execute(recipeId)
+
+        coVerify(exactly = 1) { recipeRepository.deleteRecipe(recipeId) }
+    }
+
+    @Test
+    fun `execute can be called multiple times with different ids`() = runTest {
+        coEvery { recipeRepository.deleteRecipe(any()) } just runs
+
+        deleteRecipeUseCase.execute("recipe-1")
+        deleteRecipeUseCase.execute("recipe-2")
+        deleteRecipeUseCase.execute("recipe-3")
+
+        coVerify { recipeRepository.deleteRecipe("recipe-1") }
+        coVerify { recipeRepository.deleteRecipe("recipe-2") }
+        coVerify { recipeRepository.deleteRecipe("recipe-3") }
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/usecase/GetRecipeByIdUseCaseTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/usecase/GetRecipeByIdUseCaseTest.kt
@@ -1,0 +1,103 @@
+package com.lionotter.recipes.domain.usecase
+
+import app.cash.turbine.test
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.model.Recipe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class GetRecipeByIdUseCaseTest {
+
+    private lateinit var recipeRepository: RecipeRepository
+    private lateinit var getRecipeByIdUseCase: GetRecipeByIdUseCase
+
+    @Before
+    fun setup() {
+        recipeRepository = mockk()
+        getRecipeByIdUseCase = GetRecipeByIdUseCase(recipeRepository)
+    }
+
+    private fun createTestRecipe(id: String, name: String) = Recipe(
+        id = id,
+        name = name,
+        createdAt = Instant.fromEpochMilliseconds(1000),
+        updatedAt = Instant.fromEpochMilliseconds(2000)
+    )
+
+    @Test
+    fun `execute returns flow with recipe when found`() = runTest {
+        val recipe = createTestRecipe("recipe-1", "Test Recipe")
+        every { recipeRepository.getRecipeById("recipe-1") } returns flowOf(recipe)
+
+        getRecipeByIdUseCase.execute("recipe-1").test {
+            assertEquals(recipe, awaitItem())
+            awaitComplete()
+        }
+
+        verify { recipeRepository.getRecipeById("recipe-1") }
+    }
+
+    @Test
+    fun `execute returns flow with null when recipe not found`() = runTest {
+        every { recipeRepository.getRecipeById("nonexistent") } returns flowOf(null)
+
+        getRecipeByIdUseCase.execute("nonexistent").test {
+            assertNull(awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `executeOnce returns recipe when found`() = runTest {
+        val recipe = createTestRecipe("recipe-1", "Test Recipe")
+        coEvery { recipeRepository.getRecipeByIdOnce("recipe-1") } returns recipe
+
+        val result = getRecipeByIdUseCase.executeOnce("recipe-1")
+
+        assertEquals(recipe, result)
+        coVerify { recipeRepository.getRecipeByIdOnce("recipe-1") }
+    }
+
+    @Test
+    fun `executeOnce returns null when recipe not found`() = runTest {
+        coEvery { recipeRepository.getRecipeByIdOnce("nonexistent") } returns null
+
+        val result = getRecipeByIdUseCase.executeOnce("nonexistent")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `execute uses correct recipe id`() = runTest {
+        val recipeId = "specific-id-123"
+        val recipe = createTestRecipe(recipeId, "Specific Recipe")
+        every { recipeRepository.getRecipeById(recipeId) } returns flowOf(recipe)
+
+        getRecipeByIdUseCase.execute(recipeId).test {
+            val result = awaitItem()
+            assertEquals(recipeId, result?.id)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `executeOnce uses correct recipe id`() = runTest {
+        val recipeId = "specific-id-456"
+        val recipe = createTestRecipe(recipeId, "Another Recipe")
+        coEvery { recipeRepository.getRecipeByIdOnce(recipeId) } returns recipe
+
+        val result = getRecipeByIdUseCase.executeOnce(recipeId)
+
+        assertEquals(recipeId, result?.id)
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/usecase/GetRecipesUseCaseTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/usecase/GetRecipesUseCaseTest.kt
@@ -1,0 +1,134 @@
+package com.lionotter.recipes.domain.usecase
+
+import app.cash.turbine.test
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.model.Recipe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class GetRecipesUseCaseTest {
+
+    private lateinit var recipeRepository: RecipeRepository
+    private lateinit var getRecipesUseCase: GetRecipesUseCase
+
+    @Before
+    fun setup() {
+        recipeRepository = mockk()
+        getRecipesUseCase = GetRecipesUseCase(recipeRepository)
+    }
+
+    private fun createTestRecipe(
+        id: String,
+        name: String,
+        tags: List<String> = emptyList()
+    ) = Recipe(
+        id = id,
+        name = name,
+        tags = tags,
+        createdAt = Instant.fromEpochMilliseconds(1000),
+        updatedAt = Instant.fromEpochMilliseconds(2000)
+    )
+
+    @Test
+    fun `execute returns flow from repository`() = runTest {
+        val recipes = listOf(
+            createTestRecipe("1", "Pasta"),
+            createTestRecipe("2", "Pizza")
+        )
+        every { recipeRepository.getAllRecipes() } returns flowOf(recipes)
+
+        getRecipesUseCase.execute().test {
+            assertEquals(recipes, awaitItem())
+            awaitComplete()
+        }
+
+        verify { recipeRepository.getAllRecipes() }
+    }
+
+    @Test
+    fun `execute returns empty list when no recipes exist`() = runTest {
+        every { recipeRepository.getAllRecipes() } returns flowOf(emptyList())
+
+        getRecipesUseCase.execute().test {
+            assertEquals(emptyList<Recipe>(), awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `byTag delegates to repository getRecipesByTag`() = runTest {
+        val tag = "italian"
+        val recipes = listOf(
+            createTestRecipe("1", "Pasta", listOf("italian")),
+            createTestRecipe("2", "Risotto", listOf("italian"))
+        )
+        every { recipeRepository.getRecipesByTag(tag) } returns flowOf(recipes)
+
+        getRecipesUseCase.byTag(tag).test {
+            assertEquals(recipes, awaitItem())
+            awaitComplete()
+        }
+
+        verify { recipeRepository.getRecipesByTag(tag) }
+    }
+
+    @Test
+    fun `byTag returns empty list for non-existent tag`() = runTest {
+        val tag = "nonexistent"
+        every { recipeRepository.getRecipesByTag(tag) } returns flowOf(emptyList())
+
+        getRecipesUseCase.byTag(tag).test {
+            assertEquals(emptyList<Recipe>(), awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `search delegates to repository searchRecipes`() = runTest {
+        val query = "pasta"
+        val recipes = listOf(
+            createTestRecipe("1", "Creamy Pasta")
+        )
+        every { recipeRepository.searchRecipes(query) } returns flowOf(recipes)
+
+        getRecipesUseCase.search(query).test {
+            assertEquals(recipes, awaitItem())
+            awaitComplete()
+        }
+
+        verify { recipeRepository.searchRecipes(query) }
+    }
+
+    @Test
+    fun `search returns empty list for no matches`() = runTest {
+        val query = "nonexistent"
+        every { recipeRepository.searchRecipes(query) } returns flowOf(emptyList())
+
+        getRecipesUseCase.search(query).test {
+            assertEquals(emptyList<Recipe>(), awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `search handles empty query`() = runTest {
+        val query = ""
+        val allRecipes = listOf(
+            createTestRecipe("1", "Pasta"),
+            createTestRecipe("2", "Pizza")
+        )
+        every { recipeRepository.searchRecipes(query) } returns flowOf(allRecipes)
+
+        getRecipesUseCase.search(query).test {
+            assertEquals(allRecipes, awaitItem())
+            awaitComplete()
+        }
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/usecase/GetTagsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/usecase/GetTagsUseCaseTest.kt
@@ -1,0 +1,215 @@
+package com.lionotter.recipes.domain.usecase
+
+import com.lionotter.recipes.data.repository.RecipeRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetTagsUseCaseTest {
+
+    private lateinit var recipeRepository: RecipeRepository
+    private lateinit var getTagsUseCase: GetTagsUseCase
+
+    @Before
+    fun setup() {
+        recipeRepository = mockk()
+        getTagsUseCase = GetTagsUseCase(recipeRepository)
+    }
+
+    @Test
+    fun `returns empty list when no recipes exist`() = runTest {
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns emptyList()
+
+        val result = getTagsUseCase.execute()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `returns all tags when fewer than 10 tags exist`() = runTest {
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns listOf(
+            "recipe-1" to listOf("dinner", "easy"),
+            "recipe-2" to listOf("dinner", "italian"),
+            "recipe-3" to listOf("dessert", "quick")
+        )
+
+        val result = getTagsUseCase.execute()
+
+        assertEquals(5, result.size)
+        assertTrue(result.containsAll(listOf("dinner", "easy", "italian", "dessert", "quick")))
+    }
+
+    @Test
+    fun `returns tags sorted by recipe count when fewer than 10`() = runTest {
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns listOf(
+            "recipe-1" to listOf("dinner", "easy"),
+            "recipe-2" to listOf("dinner", "italian"),
+            "recipe-3" to listOf("dinner", "quick"),
+            "recipe-4" to listOf("easy", "quick")
+        )
+
+        val result = getTagsUseCase.execute()
+
+        // "dinner" appears in 3 recipes, should be first
+        assertEquals("dinner", result[0])
+    }
+
+    @Test
+    fun `returns exactly 10 tags when more than 10 exist`() = runTest {
+        // Create 15 different tags spread across recipes
+        val recipesWithTags = (1..15).map { i ->
+            "recipe-$i" to listOf("tag-$i", "common-${i % 3}")
+        }
+
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns recipesWithTags
+
+        val result = getTagsUseCase.execute()
+
+        assertEquals(10, result.size)
+    }
+
+    @Test
+    fun `greedy algorithm selects tag covering most recipes first`() = runTest {
+        // Tag "popular" covers 5 recipes, "niche" covers 1
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns listOf(
+            "recipe-1" to listOf("popular", "tag-a"),
+            "recipe-2" to listOf("popular", "tag-b"),
+            "recipe-3" to listOf("popular", "tag-c"),
+            "recipe-4" to listOf("popular", "tag-d"),
+            "recipe-5" to listOf("popular", "tag-e"),
+            "recipe-6" to listOf("niche", "tag-f"),
+            "recipe-7" to listOf("tag-g"),
+            "recipe-8" to listOf("tag-h"),
+            "recipe-9" to listOf("tag-i"),
+            "recipe-10" to listOf("tag-j"),
+            "recipe-11" to listOf("tag-k")
+        )
+
+        val result = getTagsUseCase.execute()
+
+        // "popular" should be selected and sorted by count (first in list)
+        assertTrue(result.contains("popular"))
+        assertEquals("popular", result[0])
+    }
+
+    @Test
+    fun `handles recipes with no tags`() = runTest {
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns listOf(
+            "recipe-1" to emptyList(),
+            "recipe-2" to listOf("dinner"),
+            "recipe-3" to emptyList()
+        )
+
+        val result = getTagsUseCase.execute()
+
+        assertEquals(1, result.size)
+        assertEquals("dinner", result[0])
+    }
+
+    @Test
+    fun `handles single recipe with single tag`() = runTest {
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns listOf(
+            "recipe-1" to listOf("dinner")
+        )
+
+        val result = getTagsUseCase.execute()
+
+        assertEquals(1, result.size)
+        assertEquals("dinner", result[0])
+    }
+
+    @Test
+    fun `maximizes coverage with greedy set cover`() = runTest {
+        // This test verifies the greedy set cover algorithm
+        // Recipe coverage:
+        // tag-a covers recipe-1, recipe-2 (2 recipes)
+        // tag-b covers recipe-2, recipe-3 (2 recipes)
+        // tag-c covers recipe-3, recipe-4 (2 recipes)
+        // tag-d covers recipe-4, recipe-5 (2 recipes)
+        // tag-e covers recipe-5, recipe-6 (2 recipes)
+        // tag-f covers recipe-6, recipe-7 (2 recipes)
+        // tag-g covers recipe-7, recipe-8 (2 recipes)
+        // tag-h covers recipe-8, recipe-9 (2 recipes)
+        // tag-i covers recipe-9, recipe-10 (2 recipes)
+        // tag-j covers recipe-10, recipe-11 (2 recipes)
+        // tag-k covers recipe-11, recipe-12 (2 recipes)
+        // tag-l covers all 12 recipes (would be selected first)
+
+        val recipesWithTags = listOf(
+            "recipe-1" to listOf("tag-a", "tag-l"),
+            "recipe-2" to listOf("tag-a", "tag-b", "tag-l"),
+            "recipe-3" to listOf("tag-b", "tag-c", "tag-l"),
+            "recipe-4" to listOf("tag-c", "tag-d", "tag-l"),
+            "recipe-5" to listOf("tag-d", "tag-e", "tag-l"),
+            "recipe-6" to listOf("tag-e", "tag-f", "tag-l"),
+            "recipe-7" to listOf("tag-f", "tag-g", "tag-l"),
+            "recipe-8" to listOf("tag-g", "tag-h", "tag-l"),
+            "recipe-9" to listOf("tag-h", "tag-i", "tag-l"),
+            "recipe-10" to listOf("tag-i", "tag-j", "tag-l"),
+            "recipe-11" to listOf("tag-j", "tag-k", "tag-l"),
+            "recipe-12" to listOf("tag-k", "tag-l")
+        )
+
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns recipesWithTags
+
+        val result = getTagsUseCase.execute()
+
+        assertEquals(10, result.size)
+        // tag-l covers all recipes, so it should be in the result and sorted first
+        assertEquals("tag-l", result[0])
+    }
+
+    @Test
+    fun `returns tags sorted by total recipe count after selection`() = runTest {
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns listOf(
+            "recipe-1" to listOf("common", "rare-a"),
+            "recipe-2" to listOf("common", "rare-b"),
+            "recipe-3" to listOf("common", "rare-c"),
+            "recipe-4" to listOf("semi-common", "rare-d"),
+            "recipe-5" to listOf("semi-common", "rare-e")
+        )
+
+        val result = getTagsUseCase.execute()
+
+        // Results should be sorted by count: common (3), semi-common (2), then rares (1 each)
+        assertEquals("common", result[0])
+        assertEquals("semi-common", result[1])
+    }
+
+    @Test
+    fun `handles duplicate tags across recipes correctly`() = runTest {
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns listOf(
+            "recipe-1" to listOf("dinner", "dinner"), // Duplicate in same recipe
+            "recipe-2" to listOf("dinner"),
+            "recipe-3" to listOf("lunch")
+        )
+
+        val result = getTagsUseCase.execute()
+
+        // Should count unique recipes per tag, not tag occurrences
+        assertTrue(result.contains("dinner"))
+        assertTrue(result.contains("lunch"))
+    }
+
+    @Test
+    fun `selects diverse tags to cover all recipes`() = runTest {
+        // Create a scenario where we need multiple tags to cover all recipes
+        coEvery { recipeRepository.getAllRecipesWithTags() } returns listOf(
+            "recipe-1" to listOf("breakfast"),
+            "recipe-2" to listOf("lunch"),
+            "recipe-3" to listOf("dinner"),
+            "recipe-4" to listOf("dessert"),
+            "recipe-5" to listOf("snack")
+        )
+
+        val result = getTagsUseCase.execute()
+
+        // All 5 tags should be selected since each covers a unique recipe
+        assertEquals(5, result.size)
+        assertTrue(result.containsAll(listOf("breakfast", "lunch", "dinner", "dessert", "snack")))
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/util/RecipeMarkdownFormatterTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/util/RecipeMarkdownFormatterTest.kt
@@ -1,0 +1,489 @@
+package com.lionotter.recipes.domain.util
+
+import com.lionotter.recipes.domain.model.Ingredient
+import com.lionotter.recipes.domain.model.IngredientSection
+import com.lionotter.recipes.domain.model.InstructionSection
+import com.lionotter.recipes.domain.model.InstructionStep
+import com.lionotter.recipes.domain.model.Measurement
+import com.lionotter.recipes.domain.model.MeasurementType
+import com.lionotter.recipes.domain.model.Recipe
+import kotlinx.datetime.Instant
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RecipeMarkdownFormatterTest {
+
+    private fun createTestRecipe(
+        id: String = "test-id",
+        name: String = "Test Recipe",
+        sourceUrl: String? = null,
+        story: String? = null,
+        servings: Int? = null,
+        prepTime: String? = null,
+        cookTime: String? = null,
+        totalTime: String? = null,
+        ingredientSections: List<IngredientSection> = emptyList(),
+        instructionSections: List<InstructionSection> = emptyList(),
+        tags: List<String> = emptyList()
+    ) = Recipe(
+        id = id,
+        name = name,
+        sourceUrl = sourceUrl,
+        story = story,
+        servings = servings,
+        prepTime = prepTime,
+        cookTime = cookTime,
+        totalTime = totalTime,
+        ingredientSections = ingredientSections,
+        instructionSections = instructionSections,
+        tags = tags,
+        createdAt = Instant.fromEpochMilliseconds(1000),
+        updatedAt = Instant.fromEpochMilliseconds(2000)
+    )
+
+    private fun volumeMeasurement(value: Double, unit: String, isDefault: Boolean = true) =
+        Measurement(value = value, unit = unit, type = MeasurementType.VOLUME, isDefault = isDefault)
+
+    private fun weightMeasurement(value: Double, unit: String, isDefault: Boolean = false) =
+        Measurement(value = value, unit = unit, type = MeasurementType.WEIGHT, isDefault = isDefault)
+
+    @Test
+    fun `format includes recipe title as h1`() {
+        val recipe = createTestRecipe(name = "Amazing Pasta")
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("# Amazing Pasta"))
+    }
+
+    @Test
+    fun `format includes source url when present`() {
+        val recipe = createTestRecipe(sourceUrl = "https://example.com/recipe")
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("*Source:"))
+        assertTrue(markdown.contains("https://example.com/recipe"))
+    }
+
+    @Test
+    fun `format excludes source url when not present`() {
+        val recipe = createTestRecipe(sourceUrl = null)
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertFalse(markdown.contains("*Source:"))
+    }
+
+    @Test
+    fun `format includes story when present`() {
+        val recipe = createTestRecipe(story = "This is a family recipe passed down through generations.")
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("This is a family recipe passed down through generations."))
+    }
+
+    @Test
+    fun `format includes servings when present`() {
+        val recipe = createTestRecipe(servings = 4)
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("**Servings:** 4"))
+    }
+
+    @Test
+    fun `format includes prep time when present`() {
+        val recipe = createTestRecipe(prepTime = "15 minutes")
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("**Prep Time:** 15 minutes"))
+    }
+
+    @Test
+    fun `format includes cook time when present`() {
+        val recipe = createTestRecipe(cookTime = "30 minutes")
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("**Cook Time:** 30 minutes"))
+    }
+
+    @Test
+    fun `format includes total time when present`() {
+        val recipe = createTestRecipe(totalTime = "45 minutes")
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("**Total Time:** 45 minutes"))
+    }
+
+    @Test
+    fun `format includes all metadata separated by pipe`() {
+        val recipe = createTestRecipe(
+            servings = 4,
+            prepTime = "10 min",
+            cookTime = "20 min"
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        // Check that metadata items are on the same line separated by |
+        assertTrue(markdown.contains("**Servings:** 4 | **Prep Time:** 10 min | **Cook Time:** 20 min"))
+    }
+
+    @Test
+    fun `format includes tags when present`() {
+        val recipe = createTestRecipe(tags = listOf("italian", "pasta", "quick"))
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("**Tags:** italian, pasta, quick"))
+    }
+
+    @Test
+    fun `format excludes tags section when no tags`() {
+        val recipe = createTestRecipe(tags = emptyList())
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertFalse(markdown.contains("**Tags:**"))
+    }
+
+    @Test
+    fun `format includes ingredients section header`() {
+        val recipe = createTestRecipe()
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("## Ingredients"))
+    }
+
+    @Test
+    fun `format shows no ingredients message when empty`() {
+        val recipe = createTestRecipe(ingredientSections = emptyList())
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("*No ingredients listed*"))
+    }
+
+    @Test
+    fun `format includes ingredient section names`() {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    name = "For the Sauce",
+                    ingredients = listOf(
+                        Ingredient(name = "tomatoes", amounts = listOf(volumeMeasurement(2.0, "cups")))
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("### For the Sauce"))
+    }
+
+    @Test
+    fun `format lists ingredients with amounts`() {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(name = "flour", amounts = listOf(volumeMeasurement(2.0, "cups")))
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("- 2 cups flour"))
+    }
+
+    @Test
+    fun `format includes ingredient notes`() {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(
+                            name = "butter",
+                            amounts = listOf(volumeMeasurement(1.0, "cup")),
+                            notes = "softened"
+                        )
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("butter, softened"))
+    }
+
+    @Test
+    fun `format marks optional ingredients`() {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(
+                            name = "chocolate chips",
+                            amounts = listOf(volumeMeasurement(0.5, "cup")),
+                            optional = true
+                        )
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("*(optional)*"))
+    }
+
+    @Test
+    fun `format includes alternate ingredients`() {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(
+                            name = "butter",
+                            amounts = listOf(volumeMeasurement(1.0, "cup")),
+                            alternates = listOf(
+                                Ingredient(
+                                    name = "margarine",
+                                    amounts = listOf(volumeMeasurement(1.0, "cup"))
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("OR"))
+        assertTrue(markdown.contains("margarine"))
+    }
+
+    @Test
+    fun `format includes alternate measurements in parentheses`() {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(
+                            name = "flour",
+                            amounts = listOf(
+                                volumeMeasurement(2.0, "cups", isDefault = true),
+                                weightMeasurement(250.0, "grams", isDefault = false)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        // Default amount shown first, alternate in parentheses
+        assertTrue(markdown.contains("2 cups"))
+        assertTrue(markdown.contains("(250 grams)"))
+    }
+
+    @Test
+    fun `format includes instructions section header`() {
+        val recipe = createTestRecipe()
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("## Instructions"))
+    }
+
+    @Test
+    fun `format shows no instructions message when empty`() {
+        val recipe = createTestRecipe(instructionSections = emptyList())
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("*No instructions listed*"))
+    }
+
+    @Test
+    fun `format includes instruction section names`() {
+        val recipe = createTestRecipe(
+            instructionSections = listOf(
+                InstructionSection(
+                    name = "Make the Dough",
+                    steps = listOf(
+                        InstructionStep(stepNumber = 1, instruction = "Mix ingredients")
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("### Make the Dough"))
+    }
+
+    @Test
+    fun `format numbers instruction steps`() {
+        val recipe = createTestRecipe(
+            instructionSections = listOf(
+                InstructionSection(
+                    steps = listOf(
+                        InstructionStep(stepNumber = 1, instruction = "Preheat oven to 350F"),
+                        InstructionStep(stepNumber = 2, instruction = "Mix dry ingredients"),
+                        InstructionStep(stepNumber = 3, instruction = "Add wet ingredients")
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("1. Preheat oven to 350F"))
+        assertTrue(markdown.contains("2. Mix dry ingredients"))
+        assertTrue(markdown.contains("3. Add wet ingredients"))
+    }
+
+    @Test
+    fun `format marks optional instruction steps`() {
+        val recipe = createTestRecipe(
+            instructionSections = listOf(
+                InstructionSection(
+                    steps = listOf(
+                        InstructionStep(
+                            stepNumber = 1,
+                            instruction = "Add chocolate chips",
+                            optional = true
+                        )
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("*(optional)*"))
+    }
+
+    @Test
+    fun `format converts fractions correctly`() {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(name = "butter", amounts = listOf(volumeMeasurement(0.5, "cup"))),
+                        Ingredient(name = "sugar", amounts = listOf(volumeMeasurement(0.25, "cup"))),
+                        Ingredient(name = "milk", amounts = listOf(volumeMeasurement(0.75, "cup"))),
+                        Ingredient(name = "cream", amounts = listOf(volumeMeasurement(0.33, "cup"))),
+                        Ingredient(name = "oil", amounts = listOf(volumeMeasurement(0.66, "cup")))
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("1/2 cup butter"))
+        assertTrue(markdown.contains("1/4 cup sugar"))
+        assertTrue(markdown.contains("3/4 cup milk"))
+        assertTrue(markdown.contains("1/3 cup cream"))
+        assertTrue(markdown.contains("2/3 cup oil"))
+    }
+
+    @Test
+    fun `format handles mixed numbers`() {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(name = "flour", amounts = listOf(volumeMeasurement(2.5, "cups")))
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("2 1/2 cups flour"))
+    }
+
+    @Test
+    fun `format handles whole numbers`() {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(name = "eggs", amounts = listOf(volumeMeasurement(3.0, "large")))
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("3 large eggs"))
+    }
+
+    @Test
+    fun `format includes horizontal rule separator`() {
+        val recipe = createTestRecipe()
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("---"))
+    }
+
+    @Test
+    fun `format handles ingredient with null value measurement`() {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(
+                            name = "salt",
+                            amounts = listOf(
+                                Measurement(value = null, unit = "to taste", type = MeasurementType.VOLUME, isDefault = true)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        assertTrue(markdown.contains("to taste"))
+    }
+
+    @Test
+    fun `format complete recipe with all sections`() {
+        val recipe = Recipe(
+            id = "complete-recipe",
+            name = "Complete Test Recipe",
+            sourceUrl = "https://example.com/recipe",
+            story = "A test recipe for unit testing",
+            servings = 4,
+            prepTime = "15 min",
+            cookTime = "30 min",
+            totalTime = "45 min",
+            ingredientSections = listOf(
+                IngredientSection(
+                    name = "Main Ingredients",
+                    ingredients = listOf(
+                        Ingredient(name = "flour", amounts = listOf(volumeMeasurement(2.0, "cups"))),
+                        Ingredient(name = "sugar", amounts = listOf(volumeMeasurement(1.0, "cup")))
+                    )
+                )
+            ),
+            instructionSections = listOf(
+                InstructionSection(
+                    steps = listOf(
+                        InstructionStep(stepNumber = 1, instruction = "Mix flour and sugar"),
+                        InstructionStep(stepNumber = 2, instruction = "Bake at 350F")
+                    )
+                )
+            ),
+            tags = listOf("baking", "dessert"),
+            createdAt = Instant.fromEpochMilliseconds(1000),
+            updatedAt = Instant.fromEpochMilliseconds(2000)
+        )
+
+        val markdown = RecipeMarkdownFormatter.format(recipe)
+
+        // Verify structure
+        assertTrue(markdown.contains("# Complete Test Recipe"))
+        assertTrue(markdown.contains("*Source:"))
+        assertTrue(markdown.contains("A test recipe for unit testing"))
+        assertTrue(markdown.contains("**Servings:** 4"))
+        assertTrue(markdown.contains("**Tags:** baking, dessert"))
+        assertTrue(markdown.contains("## Ingredients"))
+        assertTrue(markdown.contains("### Main Ingredients"))
+        assertTrue(markdown.contains("- 2 cups flour"))
+        assertTrue(markdown.contains("## Instructions"))
+        assertTrue(markdown.contains("1. Mix flour and sugar"))
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
@@ -1,0 +1,425 @@
+package com.lionotter.recipes.ui.screens.recipedetail
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.model.Ingredient
+import com.lionotter.recipes.domain.model.IngredientSection
+import com.lionotter.recipes.domain.model.InstructionSection
+import com.lionotter.recipes.domain.model.InstructionStep
+import com.lionotter.recipes.domain.model.Measurement
+import com.lionotter.recipes.domain.model.MeasurementPreference
+import com.lionotter.recipes.domain.model.MeasurementType
+import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.usecase.DeleteRecipeUseCase
+import com.lionotter.recipes.domain.usecase.GetRecipeByIdUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.Instant
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RecipeDetailViewModelTest {
+
+    private lateinit var savedStateHandle: SavedStateHandle
+    private lateinit var getRecipeByIdUseCase: GetRecipeByIdUseCase
+    private lateinit var deleteRecipeUseCase: DeleteRecipeUseCase
+    private lateinit var recipeRepository: RecipeRepository
+    private lateinit var viewModel: RecipeDetailViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    private fun createTestRecipe(
+        id: String = "recipe-1",
+        name: String = "Test Recipe",
+        isFavorite: Boolean = false,
+        ingredientSections: List<IngredientSection> = emptyList(),
+        instructionSections: List<InstructionSection> = emptyList()
+    ) = Recipe(
+        id = id,
+        name = name,
+        isFavorite = isFavorite,
+        ingredientSections = ingredientSections,
+        instructionSections = instructionSections,
+        createdAt = Instant.fromEpochMilliseconds(1000),
+        updatedAt = Instant.fromEpochMilliseconds(2000)
+    )
+
+    private fun volumeMeasurement(value: Double, unit: String, isDefault: Boolean = true) =
+        Measurement(value = value, unit = unit, type = MeasurementType.VOLUME, isDefault = isDefault)
+
+    private fun weightMeasurement(value: Double, unit: String, isDefault: Boolean = false) =
+        Measurement(value = value, unit = unit, type = MeasurementType.WEIGHT, isDefault = isDefault)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        savedStateHandle = SavedStateHandle(mapOf("recipeId" to "recipe-1"))
+        getRecipeByIdUseCase = mockk()
+        deleteRecipeUseCase = mockk()
+        recipeRepository = mockk()
+
+        // Default mock setup
+        every { getRecipeByIdUseCase.execute("recipe-1") } returns flowOf(createTestRecipe())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): RecipeDetailViewModel {
+        return RecipeDetailViewModel(
+            savedStateHandle = savedStateHandle,
+            getRecipeByIdUseCase = getRecipeByIdUseCase,
+            deleteRecipeUseCase = deleteRecipeUseCase,
+            recipeRepository = recipeRepository
+        )
+    }
+
+    @Test
+    fun `initial scale is 1`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.scale.test {
+            assertEquals(1.0, awaitItem(), 0.01)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setScale updates scale value`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.scale.test {
+            assertEquals(1.0, awaitItem(), 0.01)
+
+            viewModel.setScale(2.0)
+            assertEquals(2.0, awaitItem(), 0.01)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setScale clamps to minimum 0 25`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.scale.test {
+            awaitItem() // Skip initial
+
+            viewModel.setScale(0.1)
+            assertEquals(0.25, awaitItem(), 0.01)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setScale clamps to maximum 10`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.scale.test {
+            awaitItem() // Skip initial
+
+            viewModel.setScale(15.0)
+            assertEquals(10.0, awaitItem(), 0.01)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `incrementScale increases scale by 0 5`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.scale.test {
+            assertEquals(1.0, awaitItem(), 0.01)
+
+            viewModel.incrementScale()
+            assertEquals(1.5, awaitItem(), 0.01)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `decrementScale decreases scale by 0 5`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.scale.test {
+            assertEquals(1.0, awaitItem(), 0.01)
+
+            viewModel.decrementScale()
+            assertEquals(0.5, awaitItem(), 0.01)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `initial measurementPreference is ORIGINAL`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.measurementPreference.test {
+            assertEquals(MeasurementPreference.ORIGINAL, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setMeasurementPreference updates preference`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.measurementPreference.test {
+            assertEquals(MeasurementPreference.ORIGINAL, awaitItem())
+
+            viewModel.setMeasurementPreference(MeasurementPreference.WEIGHT)
+            assertEquals(MeasurementPreference.WEIGHT, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggleInstructionIngredientUsed adds ingredient to used set`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.usedInstructionIngredients.test {
+            assertTrue(awaitItem().isEmpty())
+
+            viewModel.toggleInstructionIngredientUsed(0, 0, 0)
+            val used = awaitItem()
+            assertTrue(used.contains("0-0-0"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggleInstructionIngredientUsed removes ingredient when already used`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.usedInstructionIngredients.test {
+            assertTrue(awaitItem().isEmpty())
+
+            // Add
+            viewModel.toggleInstructionIngredientUsed(0, 1, 2)
+            assertTrue(awaitItem().contains("0-1-2"))
+
+            // Remove
+            viewModel.toggleInstructionIngredientUsed(0, 1, 2)
+            assertFalse(awaitItem().contains("0-1-2"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `isInstructionIngredientUsed returns correct status`() = runTest {
+        viewModel = createViewModel()
+
+        assertFalse(viewModel.isInstructionIngredientUsed(0, 0, 0))
+
+        viewModel.toggleInstructionIngredientUsed(0, 0, 0)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.isInstructionIngredientUsed(0, 0, 0))
+        assertFalse(viewModel.isInstructionIngredientUsed(0, 0, 1))
+    }
+
+    @Test
+    fun `resetIngredientUsage clears all used ingredients`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.usedInstructionIngredients.test {
+            assertTrue(awaitItem().isEmpty())
+
+            viewModel.toggleInstructionIngredientUsed(0, 0, 0)
+            viewModel.toggleInstructionIngredientUsed(0, 1, 0)
+            awaitItem()
+            val used = awaitItem()
+            assertEquals(2, used.size)
+
+            viewModel.resetIngredientUsage()
+            assertTrue(awaitItem().isEmpty())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggleHighlightedInstructionStep sets highlighted step`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.highlightedInstructionStep.test {
+            assertNull(awaitItem())
+
+            viewModel.toggleHighlightedInstructionStep(1, 2)
+            val highlighted = awaitItem()
+            assertEquals(1, highlighted?.sectionIndex)
+            assertEquals(2, highlighted?.stepIndex)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggleHighlightedInstructionStep clears when same step toggled`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.highlightedInstructionStep.test {
+            assertNull(awaitItem())
+
+            viewModel.toggleHighlightedInstructionStep(1, 2)
+            assertEquals(HighlightedInstructionStep(1, 2), awaitItem())
+
+            viewModel.toggleHighlightedInstructionStep(1, 2)
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggleFavorite calls repository with toggled value`() = runTest {
+        val recipe = createTestRecipe(isFavorite = false)
+        every { getRecipeByIdUseCase.execute("recipe-1") } returns flowOf(recipe)
+        coEvery { recipeRepository.setFavorite("recipe-1", true) } just runs
+
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.toggleFavorite()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { recipeRepository.setFavorite("recipe-1", true) }
+    }
+
+    @Test
+    fun `toggleFavorite toggles from true to false`() = runTest {
+        val recipe = createTestRecipe(isFavorite = true)
+        every { getRecipeByIdUseCase.execute("recipe-1") } returns flowOf(recipe)
+        coEvery { recipeRepository.setFavorite("recipe-1", false) } just runs
+
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.toggleFavorite()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { recipeRepository.setFavorite("recipe-1", false) }
+    }
+
+    @Test
+    fun `deleteRecipe calls use case and emits event`() = runTest {
+        coEvery { deleteRecipeUseCase.execute("recipe-1") } just runs
+
+        viewModel = createViewModel()
+
+        viewModel.recipeDeleted.test {
+            viewModel.deleteRecipe()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            awaitItem() // Unit event
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        coVerify { deleteRecipeUseCase.execute("recipe-1") }
+    }
+
+    @Test
+    fun `hasMultipleMeasurementTypes is false for empty recipe`() = runTest {
+        val recipe = createTestRecipe(ingredientSections = emptyList())
+        every { getRecipeByIdUseCase.execute("recipe-1") } returns flowOf(recipe)
+
+        viewModel = createViewModel()
+
+        viewModel.hasMultipleMeasurementTypes.test {
+            assertEquals(false, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `hasMultipleMeasurementTypes is true when ingredient has multiple types`() = runTest {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(
+                            name = "flour",
+                            amounts = listOf(
+                                volumeMeasurement(2.0, "cups"),
+                                weightMeasurement(250.0, "grams")
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        every { getRecipeByIdUseCase.execute("recipe-1") } returns flowOf(recipe)
+
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.hasMultipleMeasurementTypes.test {
+            assertEquals(true, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `availableMeasurementTypes returns all types in recipe`() = runTest {
+        val recipe = createTestRecipe(
+            ingredientSections = listOf(
+                IngredientSection(
+                    ingredients = listOf(
+                        Ingredient(
+                            name = "flour",
+                            amounts = listOf(
+                                volumeMeasurement(2.0, "cups"),
+                                weightMeasurement(250.0, "grams")
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        every { getRecipeByIdUseCase.execute("recipe-1") } returns flowOf(recipe)
+
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.availableMeasurementTypes.test {
+            val types = awaitItem()
+            assertTrue(types.contains(MeasurementType.VOLUME))
+            assertTrue(types.contains(MeasurementType.WEIGHT))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `createInstructionIngredientKey creates correct format`() {
+        val key = createInstructionIngredientKey(1, 2, 3)
+        assertEquals("1-2-3", key)
+    }
+
+    @Test
+    fun `HighlightedInstructionStep holds correct values`() {
+        val step = HighlightedInstructionStep(sectionIndex = 1, stepIndex = 2)
+        assertEquals(1, step.sectionIndex)
+        assertEquals(2, step.stepIndex)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `throws exception when recipeId not in savedStateHandle`() {
+        savedStateHandle = SavedStateHandle(emptyMap())
+        createViewModel()
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -1,0 +1,232 @@
+package com.lionotter.recipes.ui.screens.settings
+
+import app.cash.turbine.test
+import com.lionotter.recipes.data.local.SettingsDataStore
+import com.lionotter.recipes.data.remote.AnthropicService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+
+    private lateinit var settingsDataStore: SettingsDataStore
+    private lateinit var viewModel: SettingsViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val apiKeyFlow = MutableStateFlow<String?>(null)
+    private val aiModelFlow = MutableStateFlow(AnthropicService.DEFAULT_MODEL)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        settingsDataStore = mockk()
+        every { settingsDataStore.anthropicApiKey } returns apiKeyFlow
+        every { settingsDataStore.aiModel } returns aiModelFlow
+        viewModel = SettingsViewModel(settingsDataStore)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial apiKeyInput is empty`() = runTest {
+        viewModel.apiKeyInput.test {
+            assertEquals("", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `initial saveState is Idle`() = runTest {
+        viewModel.saveState.test {
+            assertTrue(awaitItem() is SettingsViewModel.SaveState.Idle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onApiKeyInputChange updates apiKeyInput`() = runTest {
+        viewModel.apiKeyInput.test {
+            assertEquals("", awaitItem())
+
+            viewModel.onApiKeyInputChange("sk-ant-test-key")
+            assertEquals("sk-ant-test-key", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `saveApiKey with empty key sets error state`() = runTest {
+        viewModel.saveState.test {
+            assertTrue(awaitItem() is SettingsViewModel.SaveState.Idle)
+
+            viewModel.onApiKeyInputChange("   ")
+            viewModel.saveApiKey()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val state = awaitItem()
+            assertTrue(state is SettingsViewModel.SaveState.Error)
+            assertEquals("API key cannot be empty", (state as SettingsViewModel.SaveState.Error).message)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `saveApiKey with invalid format sets error state`() = runTest {
+        viewModel.saveState.test {
+            assertTrue(awaitItem() is SettingsViewModel.SaveState.Idle)
+
+            viewModel.onApiKeyInputChange("invalid-key-format")
+            viewModel.saveApiKey()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val state = awaitItem()
+            assertTrue(state is SettingsViewModel.SaveState.Error)
+            assertTrue((state as SettingsViewModel.SaveState.Error).message.contains("sk-ant-"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `saveApiKey with valid key saves and sets success state`() = runTest {
+        coEvery { settingsDataStore.setAnthropicApiKey(any()) } just runs
+
+        viewModel.saveState.test {
+            assertTrue(awaitItem() is SettingsViewModel.SaveState.Idle)
+
+            viewModel.onApiKeyInputChange("sk-ant-valid-test-key")
+            viewModel.saveApiKey()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val state = awaitItem()
+            assertTrue(state is SettingsViewModel.SaveState.Success)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        coVerify { settingsDataStore.setAnthropicApiKey("sk-ant-valid-test-key") }
+    }
+
+    @Test
+    fun `saveApiKey clears input on success`() = runTest {
+        coEvery { settingsDataStore.setAnthropicApiKey(any()) } just runs
+
+        viewModel.apiKeyInput.test {
+            assertEquals("", awaitItem())
+
+            viewModel.onApiKeyInputChange("sk-ant-valid-test-key")
+            assertEquals("sk-ant-valid-test-key", awaitItem())
+
+            viewModel.saveApiKey()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals("", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `saveApiKey trims whitespace from key`() = runTest {
+        coEvery { settingsDataStore.setAnthropicApiKey(any()) } just runs
+
+        viewModel.onApiKeyInputChange("  sk-ant-valid-test-key  ")
+        viewModel.saveApiKey()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { settingsDataStore.setAnthropicApiKey("sk-ant-valid-test-key") }
+    }
+
+    @Test
+    fun `clearApiKey calls datastore and resets state`() = runTest {
+        coEvery { settingsDataStore.clearAnthropicApiKey() } just runs
+
+        viewModel.saveState.test {
+            assertTrue(awaitItem() is SettingsViewModel.SaveState.Idle)
+
+            viewModel.clearApiKey()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // State should remain or return to Idle
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        coVerify { settingsDataStore.clearAnthropicApiKey() }
+    }
+
+    @Test
+    fun `setAiModel calls datastore`() = runTest {
+        coEvery { settingsDataStore.setAiModel(any()) } just runs
+
+        viewModel.setAiModel("claude-3-sonnet")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { settingsDataStore.setAiModel("claude-3-sonnet") }
+    }
+
+    @Test
+    fun `resetSaveState sets state to Idle`() = runTest {
+        coEvery { settingsDataStore.setAnthropicApiKey(any()) } just runs
+
+        viewModel.saveState.test {
+            assertTrue(awaitItem() is SettingsViewModel.SaveState.Idle)
+
+            // First set success state
+            viewModel.onApiKeyInputChange("sk-ant-valid-key")
+            viewModel.saveApiKey()
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertTrue(awaitItem() is SettingsViewModel.SaveState.Success)
+
+            // Then reset
+            viewModel.resetSaveState()
+            assertTrue(awaitItem() is SettingsViewModel.SaveState.Idle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `apiKey flow reflects datastore value`() = runTest {
+        viewModel.apiKey.test {
+            // Initial value from flow
+            assertEquals(null, awaitItem())
+
+            // Update the underlying flow
+            apiKeyFlow.value = "sk-ant-stored-key"
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals("sk-ant-stored-key", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `aiModel flow reflects datastore value`() = runTest {
+        viewModel.aiModel.test {
+            // Initial value (default model)
+            assertEquals(AnthropicService.DEFAULT_MODEL, awaitItem())
+
+            // Update the underlying flow
+            aiModelFlow.value = "claude-3-opus"
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals("claude-3-opus", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/state/InProgressRecipeManagerTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/state/InProgressRecipeManagerTest.kt
@@ -1,0 +1,158 @@
+package com.lionotter.recipes.ui.state
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class InProgressRecipeManagerTest {
+
+    private lateinit var manager: InProgressRecipeManager
+
+    @Before
+    fun setup() {
+        manager = InProgressRecipeManager()
+    }
+
+    @Test
+    fun `initial state is empty map`() = runTest {
+        manager.inProgressRecipes.test {
+            assertEquals(emptyMap<String, InProgressRecipe>(), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `addInProgressRecipe adds recipe to state`() = runTest {
+        manager.inProgressRecipes.test {
+            // Skip initial empty state
+            awaitItem()
+
+            manager.addInProgressRecipe("recipe-1", "Test Recipe")
+
+            val state = awaitItem()
+            assertEquals(1, state.size)
+            assertEquals("recipe-1", state["recipe-1"]?.id)
+            assertEquals("Test Recipe", state["recipe-1"]?.name)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `addInProgressRecipe adds multiple recipes`() = runTest {
+        manager.inProgressRecipes.test {
+            awaitItem() // Skip initial state
+
+            manager.addInProgressRecipe("recipe-1", "Recipe One")
+            awaitItem()
+
+            manager.addInProgressRecipe("recipe-2", "Recipe Two")
+            val state = awaitItem()
+
+            assertEquals(2, state.size)
+            assertEquals("Recipe One", state["recipe-1"]?.name)
+            assertEquals("Recipe Two", state["recipe-2"]?.name)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `updateRecipeName updates existing recipe`() = runTest {
+        manager.inProgressRecipes.test {
+            awaitItem() // Skip initial state
+
+            manager.addInProgressRecipe("recipe-1", "Original Name")
+            awaitItem()
+
+            manager.updateRecipeName("recipe-1", "Updated Name")
+            val state = awaitItem()
+
+            assertEquals("Updated Name", state["recipe-1"]?.name)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `updateRecipeName does nothing for non-existent recipe`() = runTest {
+        manager.inProgressRecipes.test {
+            awaitItem() // Skip initial state
+
+            manager.addInProgressRecipe("recipe-1", "Original Name")
+            val initialState = awaitItem()
+
+            // Try to update non-existent recipe - should not emit new state
+            manager.updateRecipeName("non-existent", "New Name")
+
+            // Give it a moment to potentially emit
+            expectNoEvents()
+
+            // State should remain unchanged
+            assertEquals("Original Name", initialState["recipe-1"]?.name)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `removeInProgressRecipe removes recipe from state`() = runTest {
+        manager.inProgressRecipes.test {
+            awaitItem() // Skip initial state
+
+            manager.addInProgressRecipe("recipe-1", "Recipe One")
+            awaitItem()
+
+            manager.addInProgressRecipe("recipe-2", "Recipe Two")
+            awaitItem()
+
+            manager.removeInProgressRecipe("recipe-1")
+            val state = awaitItem()
+
+            assertEquals(1, state.size)
+            assertTrue(state.containsKey("recipe-2"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `removeInProgressRecipe handles non-existent recipe gracefully`() = runTest {
+        manager.addInProgressRecipe("recipe-1", "Recipe One")
+
+        // Removing non-existent key should not throw
+        manager.removeInProgressRecipe("non-existent")
+
+        // Verify original recipe still exists
+        manager.inProgressRecipes.test {
+            val state = awaitItem()
+            assertEquals(1, state.size)
+            assertTrue(state.containsKey("recipe-1"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `clear removes all recipes`() = runTest {
+        manager.inProgressRecipes.test {
+            awaitItem() // Skip initial state
+
+            manager.addInProgressRecipe("recipe-1", "Recipe One")
+            awaitItem()
+
+            manager.addInProgressRecipe("recipe-2", "Recipe Two")
+            awaitItem()
+
+            manager.clear()
+            val state = awaitItem()
+
+            assertTrue(state.isEmpty())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `InProgressRecipe data class holds correct values`() {
+        val recipe = InProgressRecipe(id = "test-id", name = "Test Name")
+        assertEquals("test-id", recipe.id)
+        assertEquals("Test Name", recipe.name)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,8 @@ google-drive-api = { group = "com.google.apis", name = "google-api-services-driv
 # Testing
 junit = { group = "junit", name = "junit", version = "4.13.2" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.9.0" }
+mockk = { group = "io.mockk", name = "mockk", version = "1.13.13" }
+turbine = { group = "app.cash.turbine", name = "turbine", version = "1.2.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

This PR addresses #58 by significantly expanding the test coverage across all architecture layers.

### Test Infrastructure Added
- **MockK** for mocking dependencies
- **Turbine** for Flow testing

### New Test Files (9 files, ~130 new tests)

| Test File | Coverage | Key Tests |
|-----------|----------|-----------|
| `InProgressRecipeManagerTest` | State management | Add, update, remove recipes, clear state |
| `GetTagsUseCaseTest` | Greedy set cover algorithm | Empty list, tag sorting, coverage maximization |
| `GetRecipesUseCaseTest` | Recipe fetching | All recipes, by tag, search |
| `GetRecipeByIdUseCaseTest` | Single recipe retrieval | Flow and suspend variants |
| `DeleteRecipeUseCaseTest` | Recipe deletion | Delegation to repository |
| `RecipeMarkdownFormatterTest` | Markdown formatting | All recipe sections, fractions, metadata |
| `RecipeRepositoryTest` | Repository layer | JSON serialization, entity mapping, CRUD operations |
| `SettingsViewModelTest` | Settings state | API key validation, save/clear operations |
| `RecipeDetailViewModelTest` | Recipe detail view | Scale, measurement preferences, favorites |

### Coverage Improvements

| Metric | Before | After |
|--------|--------|-------|
| Test Files | 2 | 11 |
| Total Tests | ~28 | 155 |
| Domain Layer | Partial | ✅ Complete |
| Data Layer | None | ✅ Repository tested |
| UI Layer | None | ✅ ViewModels tested |

### Test Categories

**Unit Tests (No Android dependencies)**
- ✅ Use cases: GetRecipes, GetRecipeById, DeleteRecipe, GetTags
- ✅ Utilities: RecipeMarkdownFormatter
- ✅ State managers: InProgressRecipeManager

**Unit Tests (With mocking)**
- ✅ RecipeRepository (JSON mapping, entity conversion)
- ✅ SettingsViewModel (state management, validation)
- ✅ RecipeDetailViewModel (scaling, preferences, favorites)

## Test plan
- [x] All 155 tests pass
- [x] No regressions in existing tests
- [x] Build succeeds

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)