### PR TITLE
feat: add keep screen on setting for recipe detail view

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -28,6 +29,7 @@ class SettingsDataStore @Inject constructor(
 ) {
     private object Keys {
         val AI_MODEL = stringPreferencesKey("ai_model")
+        val KEEP_SCREEN_ON = booleanPreferencesKey("keep_screen_on")
         const val ENCRYPTED_API_KEY = "anthropic_api_key"
     }
 
@@ -58,6 +60,10 @@ class SettingsDataStore @Inject constructor(
         preferences[Keys.AI_MODEL] ?: AnthropicService.DEFAULT_MODEL
     }
 
+    val keepScreenOn: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[Keys.KEEP_SCREEN_ON] ?: true
+    }
+
     suspend fun setAnthropicApiKey(apiKey: String) {
         withContext(Dispatchers.IO) {
             encryptedPrefs.edit().putString(Keys.ENCRYPTED_API_KEY, apiKey).apply()
@@ -75,6 +81,12 @@ class SettingsDataStore @Inject constructor(
     suspend fun setAiModel(model: String) {
         context.dataStore.edit { preferences ->
             preferences[Keys.AI_MODEL] = model
+        }
+    }
+
+    suspend fun setKeepScreenOn(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.KEEP_SCREEN_ON] = enabled
         }
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,6 +51,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
@@ -84,6 +86,16 @@ fun RecipeDetailScreen(
     val usedInstructionIngredients by viewModel.usedInstructionIngredients.collectAsStateWithLifecycle()
     val globalIngredientUsage by viewModel.globalIngredientUsage.collectAsStateWithLifecycle()
     val highlightedInstructionStep by viewModel.highlightedInstructionStep.collectAsStateWithLifecycle()
+    val keepScreenOn by viewModel.keepScreenOn.collectAsStateWithLifecycle()
+
+    // Keep screen on while viewing a recipe if the setting is enabled
+    val view = LocalView.current
+    DisposableEffect(keepScreenOn) {
+        view.keepScreenOn = keepScreenOn
+        onDispose {
+            view.keepScreenOn = false
+        }
+    }
 
     var showDeleteDialog by remember { mutableStateOf(false) }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.lionotter.recipes.ui.screens.recipedetail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.repository.RecipeRepository
 import com.lionotter.recipes.domain.model.Ingredient
 import com.lionotter.recipes.domain.model.MeasurementPreference
@@ -57,7 +58,8 @@ class RecipeDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     getRecipeByIdUseCase: GetRecipeByIdUseCase,
     private val deleteRecipeUseCase: DeleteRecipeUseCase,
-    private val recipeRepository: RecipeRepository
+    private val recipeRepository: RecipeRepository,
+    settingsDataStore: SettingsDataStore
 ) : ViewModel() {
 
     private val recipeId: String
@@ -75,6 +77,13 @@ class RecipeDetailViewModel @Inject constructor(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
             initialValue = null
+        )
+
+    val keepScreenOn: StateFlow<Boolean> = settingsDataStore.keepScreenOn
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = true
         )
 
     private val _scale = MutableStateFlow(1.0)

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -75,6 +76,7 @@ fun SettingsScreen(
     val apiKey by viewModel.apiKey.collectAsStateWithLifecycle()
     val apiKeyInput by viewModel.apiKeyInput.collectAsStateWithLifecycle()
     val aiModel by viewModel.aiModel.collectAsStateWithLifecycle()
+    val keepScreenOn by viewModel.keepScreenOn.collectAsStateWithLifecycle()
     val saveState by viewModel.saveState.collectAsStateWithLifecycle()
     val driveUiState by googleDriveViewModel.uiState.collectAsStateWithLifecycle()
 
@@ -143,6 +145,14 @@ fun SettingsScreen(
             ModelSelectionSection(
                 currentModel = aiModel,
                 onModelChange = viewModel::setAiModel
+            )
+
+            HorizontalDivider()
+
+            // Display Section
+            DisplaySection(
+                keepScreenOn = keepScreenOn,
+                onKeepScreenOnChange = viewModel::setKeepScreenOn
             )
 
             HorizontalDivider()
@@ -348,6 +358,41 @@ private fun ModelSelectionSection(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun DisplaySection(
+    keepScreenOn: Boolean,
+    onKeepScreenOnChange: (Boolean) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = "Display",
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Keep screen on",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    text = "Prevent the screen from turning off while viewing a recipe.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = keepScreenOn,
+                onCheckedChange = onKeepScreenOnChange
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -32,6 +32,13 @@ class SettingsViewModel @Inject constructor(
             initialValue = AnthropicService.DEFAULT_MODEL
         )
 
+    val keepScreenOn: StateFlow<Boolean> = settingsDataStore.keepScreenOn
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = true
+        )
+
     private val _apiKeyInput = MutableStateFlow("")
     val apiKeyInput: StateFlow<String> = _apiKeyInput.asStateFlow()
 
@@ -72,6 +79,12 @@ class SettingsViewModel @Inject constructor(
     fun setAiModel(model: String) {
         viewModelScope.launch {
             settingsDataStore.setAiModel(model)
+        }
+    }
+
+    fun setKeepScreenOn(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsDataStore.setKeepScreenOn(enabled)
         }
     }
 

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
@@ -2,6 +2,7 @@ package com.lionotter.recipes.ui.screens.recipedetail
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.repository.RecipeRepository
 import com.lionotter.recipes.domain.model.Ingredient
 import com.lionotter.recipes.domain.model.IngredientSection
@@ -42,6 +43,7 @@ class RecipeDetailViewModelTest {
     private lateinit var getRecipeByIdUseCase: GetRecipeByIdUseCase
     private lateinit var deleteRecipeUseCase: DeleteRecipeUseCase
     private lateinit var recipeRepository: RecipeRepository
+    private lateinit var settingsDataStore: SettingsDataStore
     private lateinit var viewModel: RecipeDetailViewModel
     private val testDispatcher = StandardTestDispatcher()
 
@@ -74,9 +76,11 @@ class RecipeDetailViewModelTest {
         getRecipeByIdUseCase = mockk()
         deleteRecipeUseCase = mockk()
         recipeRepository = mockk()
+        settingsDataStore = mockk()
 
         // Default mock setup
         every { getRecipeByIdUseCase.execute("recipe-1") } returns flowOf(createTestRecipe())
+        every { settingsDataStore.keepScreenOn } returns flowOf(true)
     }
 
     @After
@@ -89,7 +93,8 @@ class RecipeDetailViewModelTest {
             savedStateHandle = savedStateHandle,
             getRecipeByIdUseCase = getRecipeByIdUseCase,
             deleteRecipeUseCase = deleteRecipeUseCase,
-            recipeRepository = recipeRepository
+            recipeRepository = recipeRepository,
+            settingsDataStore = settingsDataStore
         )
     }
 

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -31,6 +31,7 @@ class SettingsViewModelTest {
 
     private val apiKeyFlow = MutableStateFlow<String?>(null)
     private val aiModelFlow = MutableStateFlow(AnthropicService.DEFAULT_MODEL)
+    private val keepScreenOnFlow = MutableStateFlow(true)
 
     @Before
     fun setup() {
@@ -38,6 +39,7 @@ class SettingsViewModelTest {
         settingsDataStore = mockk()
         every { settingsDataStore.anthropicApiKey } returns apiKeyFlow
         every { settingsDataStore.aiModel } returns aiModelFlow
+        every { settingsDataStore.keepScreenOn } returns keepScreenOnFlow
         viewModel = SettingsViewModel(settingsDataStore)
     }
 

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -284,7 +284,7 @@ app: {
       entity: RecipeEntity
       settings: {
         label: SettingsDataStore
-        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings"
+        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, keep screen on)"
       }
 
       dao -> room
@@ -332,6 +332,7 @@ app: {
   }
 
   # Connections within app
+  ui.viewmodels.detail_vm -> data.local.settings: keep screen on
   ui.viewmodels.add_vm -> background.worker: enqueue work
   ui.viewmodels.drive_vm -> background.worker.export_worker: export
   ui.viewmodels.drive_vm -> background.worker.drive_import_worker: import


### PR DESCRIPTION
## Summary
- Adds a **"Keep screen on"** toggle in Settings > Display that prevents the screen from turning off while viewing a recipe
- Setting defaults to **enabled** and is persisted via DataStore preferences
- Uses `View.keepScreenOn` via a `DisposableEffect` in `RecipeDetailScreen` that properly cleans up when leaving the screen
- Updated architecture documentation to reflect the new dependency

## Changes
- **SettingsDataStore**: Added `keepScreenOn` boolean preference (defaults to `true`) with getter flow and setter
- **SettingsViewModel**: Exposed `keepScreenOn` StateFlow and `setKeepScreenOn()` function
- **SettingsScreen**: Added "Display" section with a Switch toggle between Model Selection and Google Drive sections
- **RecipeDetailViewModel**: Injects `SettingsDataStore` and exposes `keepScreenOn` StateFlow
- **RecipeDetailScreen**: Uses `DisposableEffect` to set/clear `View.keepScreenOn` based on the setting
- **Tests**: Updated `RecipeDetailViewModelTest` and `SettingsViewModelTest` to mock the new `keepScreenOn` flow
- **docs/architecture.d2**: Updated SettingsDataStore tooltip and added detail_vm -> settings connection

Closes #65

## Test plan
- [ ] Open Settings and verify "Display" section appears with "Keep screen on" toggle
- [ ] Toggle the switch off and verify it persists across app restarts
- [ ] Open a recipe with keep screen on enabled and verify screen stays on
- [ ] Open a recipe with keep screen on disabled and verify screen dims normally
- [ ] Navigate away from recipe and verify screen wake lock is released
- [ ] Run unit tests (`./gradlew testDebugUnitTest`) - all 164 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)