### PR TITLE
Fix missing contentDescription on icons for accessibility

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
@@ -185,7 +185,7 @@ private fun IdleContent(
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.Error,
-                        contentDescription = null,
+                        contentDescription = "Error",
                         tint = MaterialTheme.colorScheme.onErrorContainer,
                         modifier = Modifier.size(24.dp)
                     )
@@ -262,7 +262,7 @@ private fun LoadingContent(
 
         Icon(
             imageVector = icon,
-            contentDescription = null,
+            contentDescription = message,
             modifier = Modifier.size(64.dp),
             tint = MaterialTheme.colorScheme.primary
         )
@@ -322,7 +322,7 @@ private fun NoApiKeyContent(onNavigateToSettings: () -> Unit) {
     ) {
         Icon(
             imageVector = Icons.Default.Warning,
-            contentDescription = null,
+            contentDescription = "Warning",
             modifier = Modifier.size(64.dp),
             tint = MaterialTheme.colorScheme.error
         )

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
@@ -297,7 +297,7 @@ fun RecipeListScreen(
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Default.Search,
-                        contentDescription = null
+                        contentDescription = "Search"
                     )
                 },
                 singleLine = true
@@ -434,7 +434,7 @@ private fun FolderPickerDialog(
                 ) {
                     Icon(
                         imageVector = Icons.Default.FolderOpen,
-                        contentDescription = null,
+                        contentDescription = "Current folder",
                         modifier = Modifier.size(20.dp),
                         tint = MaterialTheme.colorScheme.primary
                     )
@@ -503,7 +503,7 @@ private fun FolderPickerDialog(
                                         ) {
                                             Icon(
                                                 imageVector = Icons.Default.Folder,
-                                                contentDescription = null,
+                                                contentDescription = "Go back",
                                                 tint = MaterialTheme.colorScheme.onSurfaceVariant
                                             )
                                             Spacer(modifier = Modifier.width(12.dp))
@@ -551,7 +551,7 @@ private fun FolderPickerDialog(
                                     ) {
                                         Icon(
                                             imageVector = Icons.Default.Folder,
-                                            contentDescription = null,
+                                            contentDescription = "Folder",
                                             tint = MaterialTheme.colorScheme.primary
                                         )
                                         Spacer(modifier = Modifier.width(12.dp))

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -216,7 +216,7 @@ private fun ApiKeySection(
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Icon(
                                 imageVector = Icons.Default.Check,
-                                contentDescription = null,
+                                contentDescription = "API key configured",
                                 tint = MaterialTheme.colorScheme.primary
                             )
                             Text(
@@ -455,7 +455,7 @@ private fun GoogleDriveSection(
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Icon(
                                     imageVector = Icons.Default.Cloud,
-                                    contentDescription = null,
+                                    contentDescription = "Connected to Google Drive",
                                     tint = MaterialTheme.colorScheme.primary
                                 )
                                 Text(
@@ -497,7 +497,7 @@ private fun GoogleDriveSection(
                     ) {
                         Icon(
                             imageVector = Icons.Default.CloudOff,
-                            contentDescription = null,
+                            contentDescription = "Not connected to Google Drive",
                             tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         Text(


### PR DESCRIPTION
## Summary
- Added meaningful `contentDescription` values to all icons that were previously `null` but convey information or are part of interactive elements
- Fixes search icon, folder icons, error/progress/warning icons, and connection status icons across three screens
- Icons that are truly decorative (e.g., leading icons in dropdown menu items where the text already describes the action) are left as-is

## Files changed
- `RecipeListScreen.kt`: Search icon, folder open breadcrumb icon, back folder icon, folder list item icons
- `AddRecipeScreen.kt`: Error icon, progress state icons (reuses the progress message string), warning icon
- `SettingsScreen.kt`: Checkmark icon, cloud connected icon, cloud-off disconnected icon

## Test plan
- [ ] Verify screen reader (TalkBack) announces the new content descriptions correctly
- [ ] Confirm no visual regressions on any of the three screens

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)