### PR TITLE
refactor: rename and consolidate notification helper

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/LionOtterApp.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/LionOtterApp.kt
@@ -3,7 +3,7 @@ package com.lionotter.recipes
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
-import com.lionotter.recipes.notification.ImportNotificationHelper
+import com.lionotter.recipes.notification.RecipeNotificationHelper
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -14,11 +14,11 @@ class LionOtterApp : Application(), Configuration.Provider {
     lateinit var workerFactory: HiltWorkerFactory
 
     @Inject
-    lateinit var importNotificationHelper: ImportNotificationHelper
+    lateinit var recipeNotificationHelper: RecipeNotificationHelper
 
     override fun onCreate() {
         super.onCreate()
-        importNotificationHelper.createNotificationChannel()
+        recipeNotificationHelper.createNotificationChannel()
     }
 
     override val workManagerConfiguration: Configuration

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeImportWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeImportWorker.kt
@@ -1,17 +1,13 @@
 package com.lionotter.recipes.worker
 
 import android.content.Context
-import android.content.pm.ServiceInfo
-import android.os.Build
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.Data
-import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
-import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.usecase.ImportRecipeUseCase
-import com.lionotter.recipes.notification.ImportNotificationHelper
+import com.lionotter.recipes.notification.RecipeNotificationHelper
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
@@ -20,7 +16,7 @@ class RecipeImportWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted workerParams: WorkerParameters,
     private val importRecipeUseCase: ImportRecipeUseCase,
-    private val notificationHelper: ImportNotificationHelper
+    private val notificationHelper: RecipeNotificationHelper
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -61,7 +57,7 @@ class RecipeImportWorker @AssistedInject constructor(
         val importId = inputData.getString(KEY_IMPORT_ID) ?: id.toString()
 
         // Set as foreground service for long-running work
-        setForeground(createForegroundInfo("Starting import..."))
+        setForeground(notificationHelper.createForegroundInfo("Importing Recipe", "Starting import..."))
 
         val result = importRecipeUseCase.execute(
             url = url,
@@ -98,7 +94,7 @@ class RecipeImportWorker @AssistedInject constructor(
                     }
                     is ImportRecipeUseCase.ImportProgress.Complete -> "Complete!"
                 }
-                setForeground(createForegroundInfo(progressMessage))
+                setForeground(notificationHelper.createForegroundInfo("Importing Recipe", progressMessage))
             }
         )
 
@@ -118,7 +114,7 @@ class RecipeImportWorker @AssistedInject constructor(
                 )
             }
             is ImportRecipeUseCase.ImportResult.Error -> {
-                notificationHelper.showErrorNotification(result.message)
+                notificationHelper.showErrorNotification("Import Failed", result.message)
                 Result.failure(
                     workDataOf(
                         KEY_IMPORT_ID to importId,
@@ -137,33 +133,6 @@ class RecipeImportWorker @AssistedInject constructor(
                     )
                 )
             }
-        }
-    }
-
-    private fun createForegroundInfo(progress: String): ForegroundInfo {
-        val notification = androidx.core.app.NotificationCompat.Builder(
-            context,
-            ImportNotificationHelper.CHANNEL_ID
-        )
-            .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle("Importing Recipe")
-            .setContentText(progress)
-            .setPriority(androidx.core.app.NotificationCompat.PRIORITY_LOW)
-            .setOngoing(true)
-            .setProgress(0, 0, true)
-            .build()
-
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            ForegroundInfo(
-                ImportNotificationHelper.NOTIFICATION_ID_PROGRESS,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-            )
-        } else {
-            ForegroundInfo(
-                ImportNotificationHelper.NOTIFICATION_ID_PROGRESS,
-                notification
-            )
         }
     }
 }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -149,8 +149,8 @@ app: {
       }
 
       helper: {
-        label: ImportNotificationHelper
-        tooltip: "Manages notification channel and shows progress/success/error notifications for recipe imports and Google Drive operations"
+        label: RecipeNotificationHelper
+        tooltip: "Manages notification channel, foreground info for workers, and shows progress/success/error notifications for recipe imports and Google Drive operations"
       }
     }
 


### PR DESCRIPTION
## Summary
- Renames `ImportNotificationHelper` to `RecipeNotificationHelper` since it handles both import and export notifications
- Extracts a `baseNotification()` private builder to eliminate duplicated `NotificationCompat.Builder` boilerplate across all 6 notification methods
- Adds `createForegroundInfo(title, progress)` to the helper so all three workers delegate foreground notification construction instead of each building their own independently
- Consolidates `showErrorNotification` and `showExportErrorNotification` into a single `showErrorNotification(title, message)` method

Closes #79

## Test plan
- [ ] Verify app builds successfully
- [ ] Test URL recipe import shows progress and success/error notifications
- [ ] Test Google Drive export shows progress and success/error notifications
- [ ] Test Google Drive import shows progress and success/error notifications
- [ ] Verify notification tap-to-open still works for single recipe imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)