### PR TITLE
fix: replace mutable sort state with reactive runningFold

### DIFF
--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -398,7 +398,7 @@ legend: {
   }
   fav1: "Recipes can be starred/favorited from list or detail view"
   fav2: "Favorites are sorted first in the recipe list"
-  fav3: "Re-sorting only occurs on filter/tag/search changes to avoid jarring UI"
+  fav3: "Re-sorting only occurs on filter/search/ID-set changes via runningFold"
 
   fav1 -> fav2 -> fav3
 }


### PR DESCRIPTION
## Summary
- Replaced fragile `lastSortedIds` mutable var and `_sortTrigger` counter with `runningFold`, which carries sort state forward between flow emissions in a thread-safe, reactive way
- Removed redundant `_sortTrigger` — search query and selected tag are already `combine` inputs and trigger recomputation naturally
- Sort-stability behavior is preserved: re-sorting only occurs when filters change or the visible recipe ID set changes, not when toggling favorites

## Test plan
- [ ] Verify recipe list displays correctly with favorites sorted first
- [ ] Toggle a favorite and confirm the recipe stays in place (no jarring re-sort)
- [ ] Change search query and confirm list re-sorts properly
- [ ] Select/deselect a tag filter and confirm list re-sorts properly
- [ ] Add a new recipe and confirm it appears in the correct sorted position
- [ ] Delete a recipe and confirm the list updates without issues

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)