### PR TITLE
Replace string errors with typed RepositoryError

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/RepositoryError.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/RepositoryError.kt
@@ -1,0 +1,17 @@
+package com.lionotter.recipes.data.repository
+
+/**
+ * Typed errors emitted by [RecipeRepository].
+ * The UI layer is responsible for mapping these to user-facing strings.
+ */
+sealed class RepositoryError {
+    /**
+     * One or more fields of a stored recipe could not be parsed from JSON.
+     * The recipe will still be returned but with empty data for the affected fields.
+     */
+    data class ParseError(
+        val recipeId: String,
+        val recipeName: String,
+        val failedFields: List<String>
+    ) : RepositoryError()
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
@@ -70,6 +70,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.lionotter.recipes.data.remote.DriveFolder
+import com.lionotter.recipes.data.repository.RepositoryError
 import com.lionotter.recipes.domain.model.Recipe
 import com.lionotter.recipes.ui.components.DeleteConfirmationDialog
 import com.lionotter.recipes.ui.components.ProgressCard
@@ -111,7 +112,11 @@ fun RecipeListScreen(
     // Show snackbar for repository errors (e.g., corrupted recipe data)
     LaunchedEffect(Unit) {
         viewModel.repositoryErrors.collect { error ->
-            snackbarHostState.showSnackbar(error)
+            val message = when (error) {
+                is RepositoryError.ParseError ->
+                    "Some data for recipe '${error.recipeName}' could not be loaded. The recipe may appear incomplete."
+            }
+            snackbarHostState.showSnackbar(message)
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListViewModel.kt
@@ -3,6 +3,7 @@ package com.lionotter.recipes.ui.screens.recipelist
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.data.repository.RepositoryError
 import com.lionotter.recipes.domain.usecase.GetTagsUseCase
 import com.lionotter.recipes.ui.state.InProgressRecipeManager
 import com.lionotter.recipes.ui.state.RecipeListItem
@@ -27,9 +28,9 @@ class RecipeListViewModel @Inject constructor(
 ) : ViewModel() {
 
     /**
-     * Errors from the repository (e.g., JSON parse failures) to be displayed to the user.
+     * Errors from the repository mapped to user-facing strings.
      */
-    val repositoryErrors: SharedFlow<String> = recipeRepository.errors
+    val repositoryErrors: SharedFlow<RepositoryError> = recipeRepository.errors
 
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()


### PR DESCRIPTION
## Summary
- Introduces a `RepositoryError` sealed class with a `ParseError` variant that carries `recipeId`, `recipeName`, and `failedFields`
- Updates `RecipeRepository` to emit typed errors instead of raw strings, removing the layer violation
- Moves error-to-string mapping to the UI layer (`RecipeListScreen`), where presentation concerns belong

Fixes #73

## Test plan
- [ ] Build succeeds (verified locally)
- [ ] Open a recipe with corrupted JSON data and verify the snackbar still displays a user-friendly message
- [ ] Verify normal recipe loading is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)