### PR TITLE
refactor: deduplicate WorkManager observation pattern

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeViewModel.kt
@@ -8,6 +8,7 @@ import androidx.work.WorkManager
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.ui.state.InProgressRecipeManager
 import com.lionotter.recipes.worker.RecipeImportWorker
+import com.lionotter.recipes.worker.observeWorkByTag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -55,15 +56,8 @@ class AddRecipeViewModel @Inject constructor(
      */
     private fun observeWorkStatus() {
         viewModelScope.launch {
-            workManager.getWorkInfosByTagFlow(RecipeImportWorker.TAG_RECIPE_IMPORT)
-                .collect { workInfos ->
-                    val currentWorkInfo = currentWorkId?.let { workId ->
-                        workInfos.find { it.id == workId }
-                    }
-                    if (currentWorkInfo != null) {
-                        handleWorkInfo(currentWorkInfo)
-                    }
-                }
+            workManager.observeWorkByTag(RecipeImportWorker.TAG_RECIPE_IMPORT) { currentWorkId }
+                .collect { handleWorkInfo(it) }
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/googledrive/GoogleDriveViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/googledrive/GoogleDriveViewModel.kt
@@ -11,6 +11,7 @@ import com.lionotter.recipes.data.remote.DriveFolder
 import com.lionotter.recipes.data.remote.GoogleDriveService
 import com.lionotter.recipes.worker.GoogleDriveExportWorker
 import com.lionotter.recipes.worker.GoogleDriveImportWorker
+import com.lionotter.recipes.worker.observeWorkByTag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -186,26 +187,13 @@ class GoogleDriveViewModel @Inject constructor(
     }
 
     private fun observeWorkStatus() {
-        // Observe export work
         viewModelScope.launch {
-            workManager.getWorkInfosByTagFlow(GoogleDriveExportWorker.TAG_DRIVE_EXPORT)
-                .collect { workInfos ->
-                    val workInfo = currentWorkId?.let { id ->
-                        workInfos.find { it.id == id }
-                    }
-                    workInfo?.let { handleExportWorkInfo(it) }
-                }
+            workManager.observeWorkByTag(GoogleDriveExportWorker.TAG_DRIVE_EXPORT) { currentWorkId }
+                .collect { handleExportWorkInfo(it) }
         }
-
-        // Observe import work
         viewModelScope.launch {
-            workManager.getWorkInfosByTagFlow(GoogleDriveImportWorker.TAG_DRIVE_IMPORT)
-                .collect { workInfos ->
-                    val workInfo = currentWorkId?.let { id ->
-                        workInfos.find { it.id == id }
-                    }
-                    workInfo?.let { handleImportWorkInfo(it) }
-                }
+            workManager.observeWorkByTag(GoogleDriveImportWorker.TAG_DRIVE_IMPORT) { currentWorkId }
+                .collect { handleImportWorkInfo(it) }
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/WorkManagerExt.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/WorkManagerExt.kt
@@ -1,0 +1,25 @@
+package com.lionotter.recipes.worker
+
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
+import java.util.UUID
+
+/**
+ * Observes work status for a specific tag, filtering to a single work request by ID.
+ *
+ * This is the common pattern used across ViewModels that enqueue WorkManager work
+ * and need to track the progress of a specific work request by its [UUID].
+ *
+ * @param tag the WorkManager tag to observe
+ * @param workIdProvider returns the current work ID to filter by, or null to skip
+ */
+fun WorkManager.observeWorkByTag(
+    tag: String,
+    workIdProvider: () -> UUID?
+): Flow<WorkInfo> =
+    getWorkInfosByTagFlow(tag)
+        .mapNotNull { workInfos ->
+            workIdProvider()?.let { id -> workInfos.find { it.id == id } }
+        }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -156,6 +156,10 @@ app: {
         label: GoogleDriveImportWorker
         tooltip: "Imports recipes from Google Drive. Tries JSON first, falls back to HTML parsing via AI."
       }
+      work_ext: {
+        label: "observeWorkByTag()"
+        tooltip: "WorkManager extension function that encapsulates the common pattern of observing work by tag and filtering to a specific work ID. Used by AddRecipeViewModel and GoogleDriveViewModel."
+      }
     }
 
     notification: {
@@ -350,8 +354,10 @@ app: {
   ui.viewmodels.detail_vm -> data.repository.repo: recipe, delete, favorite
   ui.viewmodels.detail_vm -> data.local.settings: keep screen on
   ui.viewmodels.add_vm -> background.worker: enqueue work
+  ui.viewmodels.add_vm -> background.worker.work_ext: observe import
   ui.viewmodels.drive_vm -> background.worker.export_worker: export
   ui.viewmodels.drive_vm -> background.worker.drive_import_worker: import
+  ui.viewmodels.drive_vm -> background.worker.work_ext: observe export/import
   background.worker.import_worker -> domain.usecases.import: execute
   background.worker.export_worker -> domain.usecases.export_drive: execute
   background.worker.drive_import_worker -> domain.usecases.import_drive: execute


### PR DESCRIPTION
## Summary
- Extracts a reusable `WorkManager.observeWorkByTag()` extension function that encapsulates the common pattern of observing work info by tag and filtering to a specific work ID
- Refactors `AddRecipeViewModel` and `GoogleDriveViewModel` to use the shared extension, eliminating duplicated boilerplate
- Updates `architecture.d2` to document the new utility

Closes #69

## Test plan
- [x] `compileDebugKotlin` passes
- [x] `testDebugUnitTest` passes — all existing tests still pass
- [ ] Verify recipe import flow works end-to-end on device
- [ ] Verify Google Drive export/import flow works end-to-end on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)