### PR TITLE
refactor: extract ingredient usage calculation to domain layer

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/IngredientUsage.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/IngredientUsage.kt
@@ -1,0 +1,21 @@
+package com.lionotter.recipes.domain.model
+
+/**
+ * Represents the usage status of a global ingredient based on instruction step usage.
+ */
+data class IngredientUsageStatus(
+    val totalAmount: Double?,
+    val usedAmount: Double,
+    val unit: String?,
+    val isFullyUsed: Boolean,
+    val remainingAmount: Double?
+)
+
+/**
+ * Key to uniquely identify an ingredient in an instruction step.
+ * Format: "sectionIndex-stepIndex-ingredientIndex"
+ */
+typealias InstructionIngredientKey = String
+
+fun createInstructionIngredientKey(sectionIndex: Int, stepIndex: Int, ingredientIndex: Int): InstructionIngredientKey =
+    "$sectionIndex-$stepIndex-$ingredientIndex"

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/CalculateIngredientUsageUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/CalculateIngredientUsageUseCase.kt
@@ -1,0 +1,108 @@
+package com.lionotter.recipes.domain.usecase
+
+import com.lionotter.recipes.domain.model.Ingredient
+import com.lionotter.recipes.domain.model.IngredientUsageStatus
+import com.lionotter.recipes.domain.model.InstructionIngredientKey
+import com.lionotter.recipes.domain.model.MeasurementPreference
+import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.model.createInstructionIngredientKey
+import javax.inject.Inject
+
+/**
+ * Calculates ingredient usage status by comparing global ingredient totals
+ * against amounts used in checked instruction steps.
+ */
+class CalculateIngredientUsageUseCase @Inject constructor() {
+
+    fun execute(
+        recipe: Recipe,
+        usedInstructionIngredients: Set<InstructionIngredientKey>,
+        scale: Double,
+        measurementPreference: MeasurementPreference
+    ): Map<String, IngredientUsageStatus> {
+        val globalTotals = buildGlobalTotals(recipe, scale, measurementPreference)
+        val usedAmounts = buildUsedAmounts(recipe, usedInstructionIngredients, scale, measurementPreference)
+
+        return globalTotals.mapValues { (key, totalPair) ->
+            val (total, unit) = totalPair
+            val used = usedAmounts[key] ?: 0.0
+            val remaining = total?.let { it - used }
+            val isFullyUsed = when {
+                total == null -> used > 0
+                total <= 0 -> used > 0
+                else -> used >= total
+            }
+            IngredientUsageStatus(
+                totalAmount = total,
+                usedAmount = used,
+                unit = unit,
+                isFullyUsed = isFullyUsed,
+                remainingAmount = remaining?.coerceAtLeast(0.0)
+            )
+        }
+    }
+
+    private fun buildGlobalTotals(
+        recipe: Recipe,
+        scale: Double,
+        preference: MeasurementPreference
+    ): Map<String, Pair<Double?, String?>> {
+        val globalTotals = mutableMapOf<String, Pair<Double?, String?>>()
+        recipe.ingredientSections.forEach { section ->
+            section.ingredients.forEach { ingredient ->
+                addIngredientTotal(ingredient, globalTotals, scale, preference)
+                ingredient.alternates.forEach { alt ->
+                    addIngredientTotal(alt, globalTotals, scale, preference)
+                }
+            }
+        }
+        return globalTotals
+    }
+
+    private fun addIngredientTotal(
+        ingredient: Ingredient,
+        totals: MutableMap<String, Pair<Double?, String?>>,
+        scale: Double,
+        preference: MeasurementPreference
+    ) {
+        val key = ingredient.name.lowercase()
+        val measurement = ingredient.getPreferredMeasurement(preference)
+        val value = measurement?.value?.let { it * scale }
+        totals[key] = Pair(value, measurement?.unit)
+    }
+
+    private fun buildUsedAmounts(
+        recipe: Recipe,
+        usedKeys: Set<InstructionIngredientKey>,
+        scale: Double,
+        preference: MeasurementPreference
+    ): Map<String, Double> {
+        val usedAmounts = mutableMapOf<String, Double>()
+        recipe.instructionSections.forEachIndexed { sectionIndex, section ->
+            section.steps.forEachIndexed { stepIndex, step ->
+                step.ingredients.forEachIndexed { ingredientIndex, ingredient ->
+                    val stepKey = createInstructionIngredientKey(sectionIndex, stepIndex, ingredientIndex)
+                    if (stepKey in usedKeys) {
+                        addIngredientUsage(ingredient, usedAmounts, scale, preference)
+                        ingredient.alternates.forEach { alt ->
+                            addIngredientUsage(alt, usedAmounts, scale, preference)
+                        }
+                    }
+                }
+            }
+        }
+        return usedAmounts
+    }
+
+    private fun addIngredientUsage(
+        ingredient: Ingredient,
+        usedAmounts: MutableMap<String, Double>,
+        scale: Double,
+        preference: MeasurementPreference
+    ) {
+        val key = ingredient.name.lowercase()
+        val measurement = ingredient.getPreferredMeasurement(preference)
+        val amount = measurement?.value?.let { it * scale } ?: 0.0
+        usedAmounts[key] = (usedAmounts[key] ?: 0.0) + amount
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -61,10 +61,13 @@ import android.net.Uri
 import androidx.core.net.toUri
 import coil.compose.AsyncImage
 import com.lionotter.recipes.domain.model.IngredientSection
+import com.lionotter.recipes.domain.model.IngredientUsageStatus
+import com.lionotter.recipes.domain.model.InstructionIngredientKey
 import com.lionotter.recipes.domain.model.InstructionSection
 import com.lionotter.recipes.domain.model.MeasurementPreference
 import com.lionotter.recipes.domain.model.MeasurementType
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.model.createInstructionIngredientKey
 import com.lionotter.recipes.ui.components.DeleteConfirmationDialog
 import com.lionotter.recipes.ui.components.RecipeTopAppBar
 import com.lionotter.recipes.util.pluralize

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
@@ -12,6 +12,8 @@ import com.lionotter.recipes.domain.model.Measurement
 import com.lionotter.recipes.domain.model.MeasurementPreference
 import com.lionotter.recipes.domain.model.MeasurementType
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.model.createInstructionIngredientKey
+import com.lionotter.recipes.domain.usecase.CalculateIngredientUsageUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -86,7 +88,8 @@ class RecipeDetailViewModelTest {
         return RecipeDetailViewModel(
             savedStateHandle = savedStateHandle,
             recipeRepository = recipeRepository,
-            settingsDataStore = settingsDataStore
+            settingsDataStore = settingsDataStore,
+            calculateIngredientUsage = CalculateIngredientUsageUseCase()
         )
     }
 

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -203,6 +203,10 @@ app: {
         tooltip: "Imports from Drive: tries JSON first, falls back to HTML parsing. Reuses ParseHtmlUseCase."
       }
       tags: GetTagsUseCase
+      calc_usage: {
+        label: CalculateIngredientUsageUseCase
+        tooltip: "Pure domain logic for calculating ingredient usage status from checked instruction steps, scale, and measurement preference."
+      }
     }
 
     util: {
@@ -239,6 +243,10 @@ app: {
       measurement: Measurement
       measurement_type: MeasurementType
       measurement_pref: MeasurementPreference
+      usage_status: {
+        label: IngredientUsageStatus
+        tooltip: "Fields: totalAmount, usedAmount, unit, isFullyUsed, remainingAmount"
+      }
 
       recipe -> section
       section -> ingredient
@@ -348,6 +356,7 @@ app: {
   ui.viewmodels.list_vm -> data.repository.repo: recipes, delete
   ui.viewmodels.list_vm -> domain.usecases.tags: top tags
   ui.viewmodels.detail_vm -> data.repository.repo: recipe, delete, favorite
+  ui.viewmodels.detail_vm -> domain.usecases.calc_usage: ingredient usage
   ui.viewmodels.detail_vm -> data.local.settings: keep screen on
   ui.viewmodels.add_vm -> background.worker: enqueue work
   ui.viewmodels.drive_vm -> background.worker.export_worker: export


### PR DESCRIPTION
## Summary
- Extracted ~70 lines of ingredient usage calculation logic from `RecipeDetailViewModel` into a new `CalculateIngredientUsageUseCase` domain use case
- Moved `IngredientUsageStatus`, `InstructionIngredientKey`, and `createInstructionIngredientKey` from the UI layer to `domain/model/IngredientUsage.kt` since they represent domain concepts
- Updated `RecipeDetailViewModel` to inject and delegate to the use case, keeping only the reactive `combine` wiring
- Updated architecture diagram with the new use case and model

## Test plan
- [x] All existing unit tests pass (no behavior change)
- [x] Debug build compiles successfully
- [ ] Verify ingredient usage tracking works correctly in the recipe detail screen (checking/unchecking instruction ingredients updates the ingredient list status)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)