### PR TITLE
refactor: extract BaseRecipeWorker to deduplicate worker code

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/worker/BaseRecipeWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/BaseRecipeWorker.kt
@@ -1,0 +1,59 @@
+package com.lionotter.recipes.worker
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.lionotter.recipes.notification.RecipeNotificationHelper
+
+/**
+ * Base class for recipe workers that share common foreground notification
+ * and error result handling patterns.
+ */
+abstract class BaseRecipeWorker(
+    context: Context,
+    workerParams: WorkerParameters,
+    protected val notificationHelper: RecipeNotificationHelper
+) : CoroutineWorker(context, workerParams) {
+
+    protected abstract val notificationTitle: String
+
+    protected suspend fun setForegroundProgress(message: String) {
+        setForeground(notificationHelper.createForegroundInfo(notificationTitle, message))
+    }
+
+    protected fun errorResult(
+        errorNotificationTitle: String,
+        resultTypeKey: String,
+        errorMessageKey: String,
+        errorType: String,
+        errorMessage: String,
+        vararg extraData: Pair<String, Any?>
+    ): Result {
+        notificationHelper.showErrorNotification(errorNotificationTitle, errorMessage)
+        return Result.failure(
+            workDataOf(
+                resultTypeKey to errorType,
+                errorMessageKey to errorMessage,
+                *extraData
+            )
+        )
+    }
+
+    protected fun notAvailableResult(
+        resultTypeKey: String,
+        errorMessageKey: String,
+        resultType: String,
+        errorMessage: String,
+        vararg extraData: Pair<String, Any?>
+    ): Result {
+        notificationHelper.cancelProgressNotification()
+        return Result.failure(
+            workDataOf(
+                resultTypeKey to resultType,
+                errorMessageKey to errorMessage,
+                *extraData
+            )
+        )
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/GoogleDriveExportWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/GoogleDriveExportWorker.kt
@@ -2,7 +2,6 @@ package com.lionotter.recipes.worker
 
 import android.content.Context
 import androidx.hilt.work.HiltWorker
-import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
@@ -16,8 +15,10 @@ class GoogleDriveExportWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted workerParams: WorkerParameters,
     private val exportToGoogleDriveUseCase: ExportToGoogleDriveUseCase,
-    private val notificationHelper: RecipeNotificationHelper
-) : CoroutineWorker(context, workerParams) {
+    notificationHelper: RecipeNotificationHelper
+) : BaseRecipeWorker(context, workerParams, notificationHelper) {
+
+    override val notificationTitle = "Exporting to Google Drive"
 
     companion object {
         const val TAG_DRIVE_EXPORT = "google_drive_export"
@@ -56,7 +57,7 @@ class GoogleDriveExportWorker @AssistedInject constructor(
         val parentFolderId = inputData.getString(KEY_PARENT_FOLDER_ID)
         val folderName = inputData.getString(KEY_FOLDER_NAME) ?: "Lion+Otter Recipes Export"
 
-        setForeground(notificationHelper.createForegroundInfo("Exporting to Google Drive", "Starting export..."))
+        setForegroundProgress("Starting export...")
 
         val result = exportToGoogleDriveUseCase.exportAllRecipes(
             parentFolderId = parentFolderId,
@@ -85,7 +86,7 @@ class GoogleDriveExportWorker @AssistedInject constructor(
                     }
                     is ExportToGoogleDriveUseCase.ExportProgress.Complete -> "Complete!"
                 }
-                setForeground(notificationHelper.createForegroundInfo("Exporting to Google Drive", progressMessage))
+                setForegroundProgress(progressMessage)
             }
         )
 
@@ -103,24 +104,19 @@ class GoogleDriveExportWorker @AssistedInject constructor(
                     )
                 )
             }
-            is ExportToGoogleDriveUseCase.ExportResult.Error -> {
-                notificationHelper.showErrorNotification("Export Failed", result.message)
-                Result.failure(
-                    workDataOf(
-                        KEY_RESULT_TYPE to RESULT_ERROR,
-                        KEY_ERROR_MESSAGE to result.message
-                    )
-                )
-            }
-            ExportToGoogleDriveUseCase.ExportResult.NotSignedIn -> {
-                notificationHelper.cancelProgressNotification()
-                Result.failure(
-                    workDataOf(
-                        KEY_RESULT_TYPE to RESULT_NOT_SIGNED_IN,
-                        KEY_ERROR_MESSAGE to "Not signed in to Google Drive"
-                    )
-                )
-            }
+            is ExportToGoogleDriveUseCase.ExportResult.Error -> errorResult(
+                errorNotificationTitle = "Export Failed",
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                errorType = RESULT_ERROR,
+                errorMessage = result.message
+            )
+            ExportToGoogleDriveUseCase.ExportResult.NotSignedIn -> notAvailableResult(
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                resultType = RESULT_NOT_SIGNED_IN,
+                errorMessage = "Not signed in to Google Drive"
+            )
         }
     }
 }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -144,6 +144,10 @@ app: {
         fill: "#ffffff"
       }
 
+      base_worker: {
+        label: BaseRecipeWorker
+        tooltip: "Abstract base class providing shared foreground notification management and error/unavailable result handling for all recipe workers."
+      }
       import_worker: {
         label: RecipeImportWorker
         tooltip: "CoroutineWorker that handles recipe import in background. Survives app closure and shows progress notifications. Supports queue of multiple imports."
@@ -156,6 +160,9 @@ app: {
         label: GoogleDriveImportWorker
         tooltip: "Imports recipes from Google Drive. Tries JSON first, falls back to HTML parsing via AI."
       }
+      import_worker -> base_worker: extends
+      export_worker -> base_worker: extends
+      drive_import_worker -> base_worker: extends
       work_ext: {
         label: "observeWorkByTag()"
         tooltip: "WorkManager extension function that encapsulates the common pattern of observing work by tag and filtering to a specific work ID. Used by AddRecipeViewModel and GoogleDriveViewModel."


### PR DESCRIPTION
## Summary
- Introduces `BaseRecipeWorker` abstract base class that all three worker classes now extend
- Extracts shared `setForegroundProgress()` helper that encapsulates the foreground notification update pattern (each worker just provides a `notificationTitle`)
- Extracts `errorResult()` and `notAvailableResult()` helpers for the duplicated error/not-signed-in/no-api-key result handling
- Updates architecture diagram to reflect the new base class

Fixes #67

## Test plan
- [x] Project compiles successfully
- [x] Unit tests pass
- [x] Lint checks pass
- [ ] Verify recipe import still shows correct progress notifications
- [ ] Verify Google Drive export shows correct progress/error notifications
- [ ] Verify Google Drive import shows correct progress/error notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)