### PR TITLE
Configure Room schema export directory for migration testing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,10 @@ android {
     }
 }
 
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 dependencies {
     // Core Android
     implementation(libs.androidx.core.ktx)

--- a/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/2.json
+++ b/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/2.json
@@ -1,0 +1,124 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "47be0e01be4e17d02e49cf1cce8fc1c1",
+    "entities": [
+      {
+        "tableName": "recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sourceUrl` TEXT, `story` TEXT, `servings` INTEGER, `prepTime` TEXT, `cookTime` TEXT, `totalTime` TEXT, `ingredientSectionsJson` TEXT NOT NULL, `instructionSectionsJson` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `imageUrl` TEXT, `originalHtml` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "story",
+            "columnName": "story",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "prepTime",
+            "columnName": "prepTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cookTime",
+            "columnName": "cookTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalTime",
+            "columnName": "totalTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ingredientSectionsJson",
+            "columnName": "ingredientSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructionSectionsJson",
+            "columnName": "instructionSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '47be0e01be4e17d02e49cf1cce8fc1c1')"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `room.schemaLocation` KSP argument to `app/build.gradle.kts` pointing to `app/schemas/`
- Include the generated schema JSON for database version 2

This enables automated migration testing and provides a schema version history for debugging.

Fixes #61

## Test plan
- [x] Build succeeds with `./gradlew :app:kspDebugKotlin`
- [x] Schema JSON file generated at `app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/2.json`
- [x] Schema content matches expected table structure (recipes table with all columns including isFavorite from migration 1→2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)