### PR TITLE
feat: add Baseline Profiles for improved startup performance

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.baselineprofile)
 }
 
 android {
@@ -37,6 +38,12 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+        }
+        create("benchmark") {
+            initWith(buildTypes.getByName("release"))
+            signingConfig = signingConfigs.getByName("debug")
+            matchingFallbacks += listOf("release")
+            isDebuggable = false
         }
     }
 
@@ -132,6 +139,10 @@ dependencies {
     implementation(libs.google.drive.api) {
         exclude(group = "org.apache.httpcomponents")
     }
+
+    // Baseline Profile
+    implementation(libs.androidx.profileinstaller)
+    "baselineProfile"(project(":baselineprofile"))
 
     // Testing
     testImplementation(libs.junit)

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    alias(libs.plugins.android.test)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.baselineprofile)
+}
+
+android {
+    namespace = "com.lionotter.recipes.baselineprofile"
+    compileSdk = 35
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    defaultConfig {
+        minSdk = 28
+        targetSdk = 35
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    targetProjectPath = ":app"
+}
+
+baselineProfile {
+    useConnectedDevices = true
+}
+
+dependencies {
+    implementation(libs.junit)
+    implementation(libs.androidx.test.ext.junit)
+    implementation(libs.androidx.benchmark.macro.junit4)
+    implementation(libs.androidx.uiautomator)
+}

--- a/baselineprofile/src/main/AndroidManifest.xml
+++ b/baselineprofile/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/baselineprofile/src/main/kotlin/com/lionotter/recipes/baselineprofile/BaselineProfileGenerator.kt
+++ b/baselineprofile/src/main/kotlin/com/lionotter/recipes/baselineprofile/BaselineProfileGenerator.kt
@@ -1,0 +1,96 @@
+package com.lionotter.recipes.baselineprofile
+
+import androidx.benchmark.macro.junit4.BaselineProfileRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.Until
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Generates Baseline Profiles for the app by exercising critical user journeys.
+ *
+ * Run this test on a physical device or emulator to generate the profile:
+ * ```
+ * ./gradlew :baselineprofile:pixel6Api31BenchmarkAndroidTest
+ * ```
+ * or with a connected device:
+ * ```
+ * ./gradlew :app:generateBaselineProfile
+ * ```
+ *
+ * The generated profile will be copied to `app/src/main/generated/baselineProfiles/`.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class BaselineProfileGenerator {
+
+    @get:Rule
+    val rule = BaselineProfileRule()
+
+    @Test
+    fun generateStartupProfile() {
+        rule.collect(
+            packageName = PACKAGE_NAME,
+            includeInStartupProfile = true
+        ) {
+            startActivityAndWait()
+        }
+    }
+
+    @Test
+    fun generateRecipeListProfile() {
+        rule.collect(
+            packageName = PACKAGE_NAME
+        ) {
+            startActivityAndWait()
+
+            // Scroll through the recipe list
+            val list = device.findObject(By.scrollable(true))
+            list?.let {
+                it.setGestureMargin(device.displayWidth / 5)
+                it.fling(Direction.DOWN)
+                device.waitForIdle()
+                it.fling(Direction.UP)
+                device.waitForIdle()
+            }
+        }
+    }
+
+    @Test
+    fun generateRecipeDetailProfile() {
+        rule.collect(
+            packageName = PACKAGE_NAME
+        ) {
+            startActivityAndWait()
+
+            // Tap the first recipe to open detail view
+            val recipeCard = device.wait(
+                Until.findObject(By.clickable(true).hasDescendant(By.textContains(""))),
+                TIMEOUT
+            )
+            recipeCard?.click()
+            device.waitForIdle()
+
+            // Scroll through recipe detail
+            val detailScroll = device.findObject(By.scrollable(true))
+            detailScroll?.let {
+                it.setGestureMargin(device.displayWidth / 5)
+                it.fling(Direction.DOWN)
+                device.waitForIdle()
+            }
+
+            // Navigate back
+            device.pressBack()
+            device.waitForIdle()
+        }
+    }
+
+    companion object {
+        private const val PACKAGE_NAME = "com.lionotter.recipes"
+        private const val TIMEOUT = 5_000L
+    }
+}

--- a/baselineprofile/src/main/kotlin/com/lionotter/recipes/baselineprofile/StartupBenchmark.kt
+++ b/baselineprofile/src/main/kotlin/com/lionotter/recipes/baselineprofile/StartupBenchmark.kt
@@ -1,0 +1,60 @@
+package com.lionotter.recipes.baselineprofile
+
+import androidx.benchmark.macro.BaselineProfileMode
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Benchmarks app startup with and without Baseline Profiles to measure improvement.
+ *
+ * Run on a physical device:
+ * ```
+ * ./gradlew :baselineprofile:connectedBenchmarkAndroidTest
+ * ```
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class StartupBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun startupWithoutCompilation() {
+        benchmarkRule.measureRepeated(
+            packageName = PACKAGE_NAME,
+            metrics = listOf(StartupTimingMetric()),
+            compilationMode = CompilationMode.None(),
+            iterations = 5,
+            startupMode = StartupMode.COLD
+        ) {
+            startActivityAndWait()
+        }
+    }
+
+    @Test
+    fun startupWithBaselineProfile() {
+        benchmarkRule.measureRepeated(
+            packageName = PACKAGE_NAME,
+            metrics = listOf(StartupTimingMetric()),
+            compilationMode = CompilationMode.Partial(
+                baselineProfileMode = BaselineProfileMode.Require
+            ),
+            iterations = 5,
+            startupMode = StartupMode.COLD
+        ) {
+            startActivityAndWait()
+        }
+    }
+
+    companion object {
+        private const val PACKAGE_NAME = "com.lionotter.recipes"
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,10 @@
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.test) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.baselineprofile) apply false
 }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -349,6 +349,27 @@ app: {
     repository.repo -> local.settings
   }
 
+  # Performance
+  performance: {
+    label: Performance
+    style: {
+      fill: "#fff9c4"
+      stroke: "#f9a825"
+    }
+
+    baseline_profile: {
+      label: Baseline Profiles
+      tooltip: "Pre-compiled critical code paths for faster startup and smoother scrolling. Generated via :baselineprofile macrobenchmark module."
+    }
+
+    profile_installer: {
+      label: ProfileInstaller
+      tooltip: "Installs Baseline Profiles at app install time for AOT compilation of critical paths."
+    }
+
+    baseline_profile -> profile_installer: generates rules for
+  }
+
   # DI
   di: {
     label: Hilt DI

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,10 @@ jsoup = "1.18.1"
 playServicesAuth = "21.2.0"
 googleApiClient = "2.7.0"
 googleDriveApi = "v3-rev20241206-2.0.0"
+benchmarkMacroJunit4 = "1.4.1"
+profileinstaller = "1.4.1"
+uiautomator = "2.3.0"
+androidxTestExtJunit = "1.2.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -85,6 +89,12 @@ play-services-auth = { group = "com.google.android.gms", name = "play-services-a
 google-api-client = { group = "com.google.api-client", name = "google-api-client-android", version.ref = "googleApiClient" }
 google-drive-api = { group = "com.google.apis", name = "google-api-services-drive", version.ref = "googleDriveApi" }
 
+# Baseline Profile
+androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmarkMacroJunit4" }
+androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
+androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
+
 # Testing
 junit = { group = "junit", name = "junit", version = "4.13.2" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.9.0" }
@@ -93,6 +103,8 @@ turbine = { group = "app.cash.turbine", name = "turbine", version = "1.2.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-test = { id = "com.android.test", version.ref = "agp" }
+baselineprofile = { id = "androidx.baselineprofile", version.ref = "benchmarkMacroJunit4" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,3 +34,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "LionOtterRecipes"
 include(":app")
+include(":baselineprofile")


### PR DESCRIPTION
## Summary

- Add `:baselineprofile` macrobenchmark module with profile generators for critical user journeys (app startup, recipe list scrolling, recipe detail navigation)
- Add `ProfileInstaller` dependency to `:app` for Baseline Profile installation during app install
- Add `benchmark` build type and Baseline Profile Gradle plugin configuration
- Update architecture diagram with performance section

## Details

Baseline Profiles pre-compile critical code paths ahead of time during app installation, bypassing JIT compilation on first launch. This typically provides 15-30% faster cold startup and smoother scrolling.

### What's included

**BaselineProfileGenerator** - exercises three critical user journeys:
1. App startup (included in startup profile)
2. Recipe list scrolling (fling down/up)
3. Recipe detail navigation (tap recipe, scroll detail, navigate back)

**StartupBenchmark** - measures cold startup with and without baseline profiles to verify improvement

### How to generate profiles

On a physical device or emulator:
```bash
./gradlew :app:generateBaselineProfile
```

The generated profile is automatically copied to `app/src/main/generated/baselineProfiles/`.

### How to benchmark

```bash
./gradlew :baselineprofile:connectedBenchmarkAndroidTest
```

Closes #62

## Test plan

- [x] Verify `./gradlew :app:assembleDebug` builds successfully
- [x] Verify lint passes with no new warnings
- [ ] Run `./gradlew :app:generateBaselineProfile` on a physical device to generate profile
- [ ] Run startup benchmark to measure improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)