### PR TITLE
fix: stop prefilling import URL with literal {url}

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
@@ -71,7 +71,7 @@ fun NavGraph(
                     navController.navigate(Screen.RecipeDetail.createRoute(recipeId))
                 },
                 onAddRecipeClick = {
-                    navController.navigate(Screen.AddRecipe.route)
+                    navController.navigate(Screen.AddRecipe.createRoute())
                 },
                 onSettingsClick = {
                     navController.navigate(Screen.Settings.route)


### PR DESCRIPTION
## Summary
- Fixed the import screen prefilling the URL input with a literal `{url}` string
- Changed navigation from `Screen.AddRecipe.route` (which contains the template `"add-recipe?url={url}"`) to `Screen.AddRecipe.createRoute()` (which returns `"add-recipe"` without a query parameter), allowing the nav argument to correctly default to `null`

Fixes #101

## Test plan
- [ ] Open the app and tap the add recipe button
- [ ] Verify the URL input field is empty (not prefilled with `{url}`)
- [ ] Verify importing via shared URL still works (URL is passed correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)