### PR TITLE
feat: add Claude Opus 4.6 model support

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -112,7 +112,7 @@ class AnthropicService @Inject constructor(
     companion object {
         private const val ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
         private const val ANTHROPIC_VERSION = "2023-06-01"
-        const val DEFAULT_MODEL = "claude-opus-4-5"
+        const val DEFAULT_MODEL = "claude-opus-4-6"
         private const val API_KEY_PREFIX = "sk-ant-"
 
         /**

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ModelSelectionSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ModelSelectionSection.kt
@@ -30,6 +30,7 @@ fun ModelSelectionSection(
     var expanded by remember { mutableStateOf(false) }
 
     val models = listOf(
+        "claude-opus-4-6" to stringResource(R.string.model_opus_4_6),
         "claude-opus-4-5" to stringResource(R.string.model_opus),
         "claude-sonnet-4-5" to stringResource(R.string.model_sonnet),
         "claude-haiku-4-5" to stringResource(R.string.model_haiku)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,7 +120,8 @@
     <string name="oauth_not_configured">App not configured. Please set up OAuth in Google Cloud Console with your app\'s SHA-1 fingerprint.</string>
 
     <!-- Model names -->
-    <string name="model_opus">Claude Opus 4.5 (Best quality)</string>
+    <string name="model_opus_4_6">Claude Opus 4.6 (Best quality)</string>
+    <string name="model_opus">Claude Opus 4.5</string>
     <string name="model_sonnet">Claude Sonnet 4.5 (Balanced)</string>
     <string name="model_haiku">Claude Haiku 4.5 (Fastest)</string>
 

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -343,7 +343,7 @@ app: {
 
       anthropic_svc: {
         label: AnthropicService
-        tooltip: "Uses extended thinking to parse recipes with volume/weight conversions, step-level ingredient extraction, and optional field detection. Supports Opus 4.5, Sonnet 4.5, and Haiku 4.5"
+        tooltip: "Uses extended thinking to parse recipes with volume/weight conversions, step-level ingredient extraction, and optional field detection. Supports Opus 4.6, Opus 4.5, Sonnet 4.5, and Haiku 4.5"
       }
       scraper: {
         label: WebScraperService


### PR DESCRIPTION
## Summary
- Added Claude Opus 4.6 (`claude-opus-4-6`) to the model selection dropdown in Settings
- Set Opus 4.6 as the new default model (previously Opus 4.5)
- Opus 4.5 remains available but no longer carries the "(Best quality)" label — that distinction moves to Opus 4.6

Closes #102

## Test plan
- [ ] Verify the model dropdown in Settings shows all four models: Opus 4.6, Opus 4.5, Sonnet 4.5, Haiku 4.5
- [ ] Verify Opus 4.6 is selected by default for new installations
- [ ] Verify existing users with Opus 4.5 selected retain their selection
- [ ] Verify recipe import works with the Opus 4.6 model

🤖 Generated with [Claude Code](https://claude.com/claude-code)