### PR TITLE
feat: add dark mode with configurable theme setting

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
@@ -9,16 +9,24 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.lionotter.recipes.data.local.SettingsDataStore
+import com.lionotter.recipes.domain.model.ThemeMode
 import com.lionotter.recipes.ui.navigation.NavGraph
 import com.lionotter.recipes.ui.theme.LionOtterTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val sharedIntentViewModel: SharedIntentViewModel by viewModels()
+
+    @Inject
+    lateinit var settingsDataStore: SettingsDataStore
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,7 +42,10 @@ class MainActivity : ComponentActivity() {
         }
 
         setContent {
-            LionOtterTheme {
+            val themeMode by settingsDataStore.themeMode
+                .collectAsStateWithLifecycle(initialValue = ThemeMode.AUTO)
+
+            LionOtterTheme(themeMode = themeMode) {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import com.lionotter.recipes.data.remote.AnthropicService
+import com.lionotter.recipes.domain.model.ThemeMode
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,6 +31,7 @@ class SettingsDataStore @Inject constructor(
     private object Keys {
         val AI_MODEL = stringPreferencesKey("ai_model")
         val KEEP_SCREEN_ON = booleanPreferencesKey("keep_screen_on")
+        val THEME_MODE = stringPreferencesKey("theme_mode")
         const val ENCRYPTED_API_KEY = "anthropic_api_key"
     }
 
@@ -64,6 +66,15 @@ class SettingsDataStore @Inject constructor(
         preferences[Keys.KEEP_SCREEN_ON] ?: true
     }
 
+    val themeMode: Flow<ThemeMode> = context.dataStore.data.map { preferences ->
+        val value = preferences[Keys.THEME_MODE]
+        if (value != null) {
+            try { ThemeMode.valueOf(value) } catch (_: IllegalArgumentException) { ThemeMode.AUTO }
+        } else {
+            ThemeMode.AUTO
+        }
+    }
+
     suspend fun setAnthropicApiKey(apiKey: String) {
         withContext(Dispatchers.IO) {
             encryptedPrefs.edit().putString(Keys.ENCRYPTED_API_KEY, apiKey).apply()
@@ -87,6 +98,12 @@ class SettingsDataStore @Inject constructor(
     suspend fun setKeepScreenOn(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[Keys.KEEP_SCREEN_ON] = enabled
+        }
+    }
+
+    suspend fun setThemeMode(mode: ThemeMode) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.THEME_MODE] = mode.name
         }
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/ThemeMode.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/ThemeMode.kt
@@ -1,0 +1,7 @@
+package com.lionotter.recipes.domain.model
+
+enum class ThemeMode {
+    AUTO,
+    LIGHT,
+    DARK
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -28,6 +28,7 @@ import com.lionotter.recipes.ui.screens.settings.components.ApiKeySection
 import com.lionotter.recipes.ui.screens.settings.components.DisplaySection
 import com.lionotter.recipes.ui.screens.settings.components.GoogleDriveSection
 import com.lionotter.recipes.ui.screens.settings.components.ModelSelectionSection
+import com.lionotter.recipes.ui.screens.settings.components.ThemeSection
 
 @Composable
 fun SettingsScreen(
@@ -39,6 +40,7 @@ fun SettingsScreen(
     val apiKeyInput by viewModel.apiKeyInput.collectAsStateWithLifecycle()
     val aiModel by viewModel.aiModel.collectAsStateWithLifecycle()
     val keepScreenOn by viewModel.keepScreenOn.collectAsStateWithLifecycle()
+    val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
     val saveState by viewModel.saveState.collectAsStateWithLifecycle()
     val driveUiState by googleDriveViewModel.uiState.collectAsStateWithLifecycle()
 
@@ -98,6 +100,14 @@ fun SettingsScreen(
             ModelSelectionSection(
                 currentModel = aiModel,
                 onModelChange = viewModel::setAiModel
+            )
+
+            HorizontalDivider()
+
+            // Theme Section
+            ThemeSection(
+                currentThemeMode = themeMode,
+                onThemeModeChange = viewModel::setThemeMode
             )
 
             HorizontalDivider()

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.remote.AnthropicService
+import com.lionotter.recipes.domain.model.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -37,6 +38,13 @@ class SettingsViewModel @Inject constructor(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = true
+        )
+
+    val themeMode: StateFlow<ThemeMode> = settingsDataStore.themeMode
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = ThemeMode.AUTO
         )
 
     private val _apiKeyInput = MutableStateFlow("")
@@ -85,6 +93,12 @@ class SettingsViewModel @Inject constructor(
     fun setKeepScreenOn(enabled: Boolean) {
         viewModelScope.launch {
             settingsDataStore.setKeepScreenOn(enabled)
+        }
+    }
+
+    fun setThemeMode(mode: ThemeMode) {
+        viewModelScope.launch {
+            settingsDataStore.setThemeMode(mode)
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ThemeSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ThemeSection.kt
@@ -1,0 +1,81 @@
+package com.lionotter.recipes.ui.screens.settings.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.lionotter.recipes.R
+import com.lionotter.recipes.domain.model.ThemeMode
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ThemeSection(
+    currentThemeMode: ThemeMode,
+    onThemeModeChange: (ThemeMode) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    val options = listOf(
+        ThemeMode.AUTO to stringResource(R.string.theme_auto),
+        ThemeMode.LIGHT to stringResource(R.string.theme_light),
+        ThemeMode.DARK to stringResource(R.string.theme_dark)
+    )
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = stringResource(R.string.theme),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Text(
+            text = stringResource(R.string.theme_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = !expanded }
+        ) {
+            OutlinedTextField(
+                value = options.find { it.first == currentThemeMode }?.second ?: currentThemeMode.name,
+                onValueChange = {},
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                readOnly = true,
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) }
+            )
+
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }
+            ) {
+                options.forEach { (mode, displayName) ->
+                    DropdownMenuItem(
+                        text = { Text(displayName) },
+                        onClick = {
+                            onThemeModeChange(mode)
+                            expanded = false
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/theme/Color.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/theme/Color.kt
@@ -38,11 +38,11 @@ val md_theme_light_onSurfaceVariant = Color(0xFF49454F)
 val md_theme_light_outline = Color(0xFF79747E)
 val md_theme_light_outlineVariant = Color(0xFFCAC4D0)
 
-// Dark theme
-val md_theme_dark_primary = Color(0xFF7DD3E8)
-val md_theme_dark_onPrimary = Color(0xFF003544)
-val md_theme_dark_primaryContainer = OtterBlue
-val md_theme_dark_onPrimaryContainer = OtterLight
+// Dark theme (warm accents — red tones, no blue — to avoid disrupting sleep)
+val md_theme_dark_primary = Color(0xFFE8907D) // Warm coral-red (replaces cyan/blue)
+val md_theme_dark_onPrimary = Color(0xFF442017)
+val md_theme_dark_primaryContainer = Color(0xFF5C2E22) // Deep warm red container
+val md_theme_dark_onPrimaryContainer = Color(0xFFFFDAD3)
 val md_theme_dark_secondary = Color(0xFFFFD180)
 val md_theme_dark_onSecondary = Color(0xFF3F2E00)
 val md_theme_dark_secondaryContainer = Color(0xFF5A4300)

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/theme/Theme.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import com.lionotter.recipes.domain.model.ThemeMode
 
 private val LightColorScheme = lightColorScheme(
     primary = md_theme_light_primary,
@@ -66,10 +67,16 @@ private val DarkColorScheme = darkColorScheme(
 
 @Composable
 fun LionOtterTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    themeMode: ThemeMode = ThemeMode.AUTO,
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
+    val darkTheme = when (themeMode) {
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+        ThemeMode.AUTO -> isSystemInDarkTheme()
+    }
+
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,11 @@
     <string name="get_api_key">Get an API Key from Anthropic</string>
     <string name="ai_model">AI Model</string>
     <string name="ai_model_description">Choose the Claude model to use for parsing recipes. Better models may provide more accurate results but cost more.</string>
+    <string name="theme">Theme</string>
+    <string name="theme_description">Choose the app theme. Auto follows your system setting.</string>
+    <string name="theme_auto">Auto (System)</string>
+    <string name="theme_light">Light</string>
+    <string name="theme_dark">Dark</string>
     <string name="display">Display</string>
     <string name="keep_screen_on">Keep screen on</string>
     <string name="keep_screen_on_description">Prevent the screen from turning off while viewing a recipe.</string>

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package com.lionotter.recipes.ui.screens.settings
 import app.cash.turbine.test
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.remote.AnthropicService
+import com.lionotter.recipes.domain.model.ThemeMode
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -32,6 +33,7 @@ class SettingsViewModelTest {
     private val apiKeyFlow = MutableStateFlow<String?>(null)
     private val aiModelFlow = MutableStateFlow(AnthropicService.DEFAULT_MODEL)
     private val keepScreenOnFlow = MutableStateFlow(true)
+    private val themeModeFlow = MutableStateFlow(ThemeMode.AUTO)
 
     @Before
     fun setup() {
@@ -40,6 +42,7 @@ class SettingsViewModelTest {
         every { settingsDataStore.anthropicApiKey } returns apiKeyFlow
         every { settingsDataStore.aiModel } returns aiModelFlow
         every { settingsDataStore.keepScreenOn } returns keepScreenOnFlow
+        every { settingsDataStore.themeMode } returns themeModeFlow
         viewModel = SettingsViewModel(settingsDataStore)
     }
 

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -326,7 +326,7 @@ app: {
       entity: RecipeEntity
       settings: {
         label: SettingsDataStore
-        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, keep screen on)"
+        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, keep screen on, theme mode)"
       }
 
       dao -> room


### PR DESCRIPTION
## Summary
- Adds a **Theme** selector in Settings with three options: **Auto** (default, follows system), **Light**, and **Dark**
- Dark mode accent colors use warm coral-red tones (`#E8907D`) instead of blue/cyan (`#7DD3E8`) to avoid disrupting sleep
- Theme preference persisted via DataStore, applied at the Activity level so it wraps the entire UI

## Changes
- **New**: `ThemeMode` enum (`AUTO`, `LIGHT`, `DARK`) in domain model
- **New**: `ThemeSection` composable for the settings dropdown
- **Modified**: `SettingsDataStore` — added `themeMode` flow and `setThemeMode()`
- **Modified**: `SettingsViewModel` — exposed `themeMode` state and `setThemeMode()` action
- **Modified**: `SettingsScreen` — added Theme section between Model Selection and Display
- **Modified**: `Theme.kt` — `LionOtterTheme` now accepts `ThemeMode` instead of raw `Boolean`
- **Modified**: `Color.kt` — dark mode primary changed from cyan to warm coral-red, containers updated accordingly
- **Modified**: `MainActivity` — injects `SettingsDataStore`, observes `themeMode`, passes it to `LionOtterTheme`
- **Modified**: `architecture.d2` — updated `SettingsDataStore` tooltip to mention theme mode

## Test plan
- [ ] Verify Auto mode follows system dark/light setting
- [ ] Verify Light mode forces light theme regardless of system
- [ ] Verify Dark mode forces dark theme regardless of system
- [ ] Verify dark mode accent colors are warm red, not blue
- [ ] Verify theme preference persists across app restarts
- [ ] Verify theme change takes effect immediately

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)