### PR TITLE
feat: add cancellation support for Paprika imports

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
@@ -144,6 +144,15 @@ fun AddRecipeScreen(
                         }
                     )
                 }
+                is AddRecipeUiState.PaprikaImportCancelled -> {
+                    PaprikaImportCancelledContent(
+                        importedCount = state.importedCount,
+                        onDoneClick = {
+                            viewModel.resetState()
+                            onPaprikaImportComplete()
+                        }
+                    )
+                }
             }
         }
     }
@@ -363,6 +372,48 @@ private fun PaprikaImportCompleteContent(
         }
         Text(
             text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(onClick = onDoneClick) {
+            Text(stringResource(R.string.done))
+        }
+    }
+}
+
+@Composable
+private fun PaprikaImportCancelledContent(
+    importedCount: Int,
+    onDoneClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.Warning,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.tertiary
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = stringResource(R.string.paprika_import_cancelled),
+            style = MaterialTheme.typography.titleLarge,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = stringResource(R.string.paprika_import_cancelled_result, importedCount),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/PaprikaImportWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/PaprikaImportWorker.kt
@@ -34,6 +34,8 @@ class PaprikaImportWorker @AssistedInject constructor(
         const val KEY_CURRENT = "current"
         const val KEY_TOTAL = "total"
         const val KEY_RECIPE_NAME = "recipe_name"
+        const val KEY_PROGRESS_IMPORTED_COUNT = "progress_imported_count"
+        const val KEY_PROGRESS_FAILED_COUNT = "progress_failed_count"
 
         const val RESULT_SUCCESS = "success"
         const val RESULT_ERROR = "error"
@@ -91,7 +93,9 @@ class PaprikaImportWorker @AssistedInject constructor(
                                     KEY_PROGRESS to PROGRESS_IMPORTING,
                                     KEY_RECIPE_NAME to progress.recipeName,
                                     KEY_CURRENT to progress.current,
-                                    KEY_TOTAL to progress.total
+                                    KEY_TOTAL to progress.total,
+                                    KEY_PROGRESS_IMPORTED_COUNT to progress.importedSoFar,
+                                    KEY_PROGRESS_FAILED_COUNT to progress.failedSoFar
                                 )
                             )
                             "Importing ${progress.current}/${progress.total}: ${progress.recipeName}"
@@ -124,6 +128,16 @@ class PaprikaImportWorker @AssistedInject constructor(
                 errorType = RESULT_ERROR,
                 errorMessage = result.message
             )
+            is ImportPaprikaUseCase.ImportResult.Cancelled -> {
+                notificationHelper.cancelProgressNotification()
+                Result.success(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_SUCCESS,
+                        KEY_IMPORTED_COUNT to result.importedCount,
+                        KEY_FAILED_COUNT to result.failedCount
+                    )
+                )
+            }
             ImportPaprikaUseCase.ImportResult.NoApiKey -> notAvailableResult(
                 resultTypeKey = KEY_RESULT_TYPE,
                 errorMessageKey = KEY_ERROR_MESSAGE,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,5 +138,7 @@
     <string name="paprika_import_complete">Paprika Import Complete</string>
     <string name="paprika_import_result">Successfully imported %1$d recipes</string>
     <string name="paprika_import_result_with_failures">Imported %1$d recipes (%2$d failed)</string>
+    <string name="paprika_import_cancelled">Import Cancelled</string>
+    <string name="paprika_import_cancelled_result">Successfully imported %1$d recipes before cancellation</string>
     <string name="done">Done</string>
 </resources>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -221,7 +221,7 @@ app: {
       }
       import_paprika: {
         label: ImportPaprikaUseCase
-        tooltip: "Imports recipes from Paprika export (.paprikarecipes). Parses export, sends recipe content (not source URL) through AI, resolves images from Paprika data or source page."
+        tooltip: "Imports recipes from Paprika export (.paprikarecipes). Parses export, sends recipe content (not source URL) through AI, resolves images from Paprika data or source page. Supports cooperative cancellation — checks coroutine state between recipes and preserves already-imported recipes on cancel."
       }
       tags: GetTagsUseCase
       calc_usage: {
@@ -486,7 +486,7 @@ legend: {
   pap1 -> pap2 -> pap3 -> pap4 -> pap5
 
   note: {
-    label: "Import runs in background via WorkManager. Supports multiple concurrent imports. Google Drive export/import and Paprika import run in background with progress notifications."
+    label: "Import runs in background via WorkManager. Supports multiple concurrent imports. Google Drive export/import and Paprika import run in background with progress notifications. Paprika import can be cancelled mid-way, keeping already-imported recipes."
     style: {
       font-size: 12
       italic: true


### PR DESCRIPTION
## Summary
- Adds cooperative cancellation to the Paprika import flow, allowing users to stop a batch import mid-way while keeping all recipes that were already successfully imported
- When cancelled, displays a summary screen showing how many recipes were imported before cancellation
- Ensures `CancellationException` propagates correctly through the use case (not swallowed by catch blocks)

Closes #103

## Changes
- **ImportPaprikaUseCase**: Checks `ensureActive()` between recipes for responsive cancellation; adds `Cancelled` result type with partial counts; rethrows `CancellationException` from `importSingleRecipe`; includes running `importedSoFar`/`failedSoFar` counts in progress callbacks
- **PaprikaImportWorker**: Emits running imported/failed counts in WorkManager progress data so the ViewModel can report partial results
- **AddRecipeViewModel**: Tracks running import counts from progress data; shows `PaprikaImportCancelled` state (with imported count) instead of `Idle` when a Paprika import is cancelled
- **AddRecipeScreen**: Adds `PaprikaImportCancelledContent` composable showing cancellation result with "Done" button
- **strings.xml**: Adds `paprika_import_cancelled` and `paprika_import_cancelled_result` string resources
- **architecture.d2**: Documents cancellation support in the ImportPaprikaUseCase tooltip and legend note

## Test plan
- [ ] Start a Paprika import with multiple recipes
- [ ] Cancel the import while it is in progress (after at least one recipe has been imported)
- [ ] Verify the cancellation screen shows the correct number of imported recipes
- [ ] Verify the imported recipes are visible in the recipe list
- [ ] Cancel an import before any recipes are imported — should return to idle state
- [ ] Cancel a URL import — should still return to idle state (no regression)
- [ ] Verify existing unit tests pass (`./gradlew test` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)