### PR TITLE
feat: support folder selection for Google Drive sync

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -149,6 +149,13 @@ class SettingsDataStore @Inject constructor(
         }
     }
 
+    suspend fun clearGoogleDriveSyncFolderOnly() {
+        context.dataStore.edit { preferences ->
+            preferences.remove(Keys.GOOGLE_DRIVE_SYNC_FOLDER_ID)
+            preferences.remove(Keys.GOOGLE_DRIVE_SYNC_FOLDER_NAME)
+        }
+    }
+
     suspend fun setGoogleDriveLastSyncTimestamp(timestamp: String) {
         context.dataStore.edit { preferences ->
             preferences[Keys.GOOGLE_DRIVE_LAST_SYNC_TIMESTAMP] = timestamp

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
@@ -345,6 +345,7 @@ fun RecipeListScreen(
                 when (folderPickerMode) {
                     FolderPickerMode.EXPORT -> googleDriveViewModel.exportToGoogleDrive(folderId)
                     FolderPickerMode.IMPORT -> folderId?.let { googleDriveViewModel.importFromGoogleDrive(it) }
+                    FolderPickerMode.SYNC -> {} // Sync folder selection is handled in SettingsScreen
                 }
             },
             onDismiss = { showFolderPicker = false },
@@ -359,5 +360,5 @@ fun RecipeListScreen(
 }
 
 enum class FolderPickerMode {
-    EXPORT, IMPORT
+    EXPORT, IMPORT, SYNC
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/FolderPickerDialog.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/FolderPickerDialog.kt
@@ -58,6 +58,7 @@ fun FolderPickerDialog(
                 text = when (mode) {
                     FolderPickerMode.EXPORT -> stringResource(R.string.export_to_google_drive)
                     FolderPickerMode.IMPORT -> stringResource(R.string.import_from_google_drive)
+                    FolderPickerMode.SYNC -> stringResource(R.string.select_sync_folder)
                 }
             )
         },
@@ -91,6 +92,7 @@ fun FolderPickerDialog(
                     text = when (mode) {
                         FolderPickerMode.EXPORT -> stringResource(R.string.folder_picker_export_hint)
                         FolderPickerMode.IMPORT -> stringResource(R.string.folder_picker_import_hint)
+                        FolderPickerMode.SYNC -> stringResource(R.string.folder_picker_sync_hint)
                     },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -220,6 +222,7 @@ fun FolderPickerDialog(
                     when (mode) {
                         FolderPickerMode.EXPORT -> if (isAtRoot) stringResource(R.string.export_to_root) else stringResource(R.string.export_here)
                         FolderPickerMode.IMPORT -> if (isAtRoot) stringResource(R.string.import_from_root) else stringResource(R.string.import_from_here)
+                        FolderPickerMode.SYNC -> if (isAtRoot) stringResource(R.string.sync_to_root) else stringResource(R.string.sync_this_folder)
                     }
                 )
             }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/GoogleDriveSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/GoogleDriveSection.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -17,6 +19,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,13 +36,15 @@ import com.lionotter.recipes.ui.screens.googledrive.OperationState
 fun GoogleDriveSection(
     uiState: GoogleDriveUiState,
     syncEnabled: Boolean,
+    syncFolderName: String?,
     lastSyncTimestamp: String?,
     operationState: OperationState,
     onSignInClick: () -> Unit,
     onSignOutClick: () -> Unit,
     onEnableSyncClick: () -> Unit,
     onDisableSyncClick: () -> Unit,
-    onSyncNowClick: () -> Unit
+    onSyncNowClick: () -> Unit,
+    onChangeSyncFolderClick: () -> Unit
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
@@ -133,6 +138,38 @@ fun GoogleDriveSection(
                         }
 
                         if (syncEnabled) {
+                            // Sync folder info
+                            if (syncFolderName != null) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        modifier = Modifier.weight(1f)
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Default.FolderOpen,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(16.dp),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                        Text(
+                                            text = "  " + syncFolderName,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                    TextButton(onClick = onChangeSyncFolderClick) {
+                                        Text(
+                                            stringResource(R.string.change_folder),
+                                            style = MaterialTheme.typography.bodySmall
+                                        )
+                                    }
+                                }
+                            }
+
                             // Last sync info
                             Text(
                                 text = if (lastSyncTimestamp != null) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,11 @@
     <string name="export_here">Export Here</string>
     <string name="import_from_root">Import from Root</string>
     <string name="import_from_here">Import from Here</string>
+    <string name="sync_to_root">Use Default Folder</string>
+    <string name="sync_this_folder">Sync This Folder</string>
+    <string name="select_sync_folder">Select Sync Folder</string>
+    <string name="folder_picker_sync_hint">Select an existing folder to sync with, or use the default to create a new \"Lion+Otter Recipes\" folder.</string>
+    <string name="change_folder">Change Folder</string>
 
     <!-- Recipe Detail Screen -->
     <string name="recipe">Recipe</string>


### PR DESCRIPTION
## Summary
- When enabling sync, a folder picker dialog now appears so users can select an existing Google Drive folder instead of always creating a new one
- Users who previously used the app can select their existing recipes folder, which will import those recipes on first sync
- Added a "Change Folder" button in the sync settings to switch the sync folder after initial setup
- Added `SYNC` mode to the folder picker dialog with appropriate labels and hints

## Test plan
- [ ] Enable sync on a fresh setup → verify folder picker appears
- [ ] Select an existing folder with recipes → verify recipes are imported on first sync
- [ ] Select "Use Default Folder" at root → verify a new "Lion+Otter Recipes" folder is created
- [ ] After sync is enabled, tap "Change Folder" → verify folder picker appears and folder can be changed
- [ ] Disable and re-enable sync → verify folder picker appears again
- [ ] Verify export and import folder pickers still work as before

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)