### PR TITLE
feat: make extended thinking configurable in settings

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -30,6 +30,7 @@ class SettingsDataStore @Inject constructor(
 ) {
     private object Keys {
         val AI_MODEL = stringPreferencesKey("ai_model")
+        val EXTENDED_THINKING_ENABLED = booleanPreferencesKey("extended_thinking_enabled")
         val KEEP_SCREEN_ON = booleanPreferencesKey("keep_screen_on")
         val THEME_MODE = stringPreferencesKey("theme_mode")
         val GOOGLE_DRIVE_SYNC_ENABLED = booleanPreferencesKey("google_drive_sync_enabled")
@@ -64,6 +65,10 @@ class SettingsDataStore @Inject constructor(
 
     val aiModel: Flow<String> = context.dataStore.data.map { preferences ->
         preferences[Keys.AI_MODEL] ?: AnthropicService.DEFAULT_MODEL
+    }
+
+    val extendedThinkingEnabled: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[Keys.EXTENDED_THINKING_ENABLED] ?: true
     }
 
     val keepScreenOn: Flow<Boolean> = context.dataStore.data.map { preferences ->
@@ -112,6 +117,12 @@ class SettingsDataStore @Inject constructor(
     suspend fun setAiModel(model: String) {
         context.dataStore.edit { preferences ->
             preferences[Keys.AI_MODEL] = model
+        }
+    }
+
+    suspend fun setExtendedThinkingEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.EXTENDED_THINKING_ENABLED] = enabled
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -27,7 +27,8 @@ class AnthropicService @Inject constructor(
     suspend fun parseRecipe(
         html: String,
         apiKey: String,
-        model: String = DEFAULT_MODEL
+        model: String = DEFAULT_MODEL,
+        extendedThinking: Boolean = true
     ): Result<RecipeParseResult> {
         return try {
             val request = AnthropicRequest(
@@ -40,10 +41,11 @@ class AnthropicService @Inject constructor(
                         content = "Parse this recipe webpage and extract the structured data:\n\n$html"
                     )
                 ),
-                thinking = ThinkingConfig(
-                    type = "enabled",
-                    budgetTokens = 8000
-                )
+                thinking = if (extendedThinking) {
+                    ThinkingConfig(type = "enabled", budgetTokens = 8000)
+                } else {
+                    null
+                }
             )
 
             val response = httpClient.post(ANTHROPIC_API_URL) {

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportPaprikaUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportPaprikaUseCase.kt
@@ -76,6 +76,7 @@ class ImportPaprikaUseCase @Inject constructor(
         }
 
         val model = settingsDataStore.aiModel.first()
+        val extendedThinking = settingsDataStore.extendedThinkingEnabled.first()
 
         // Parse the export file
         onProgress(ImportProgress.Parsing)
@@ -107,7 +108,7 @@ class ImportPaprikaUseCase @Inject constructor(
                     )
                 )
 
-                val result = importSingleRecipe(paprikaRecipe, apiKey, model)
+                val result = importSingleRecipe(paprikaRecipe, apiKey, model, extendedThinking)
                 if (result != null) {
                     importedCount++
                 } else {
@@ -136,14 +137,15 @@ class ImportPaprikaUseCase @Inject constructor(
     private suspend fun importSingleRecipe(
         paprikaRecipe: PaprikaRecipe,
         apiKey: String,
-        model: String
+        model: String,
+        extendedThinking: Boolean
     ): Recipe? {
         return try {
             // Format the Paprika recipe content for AI parsing
             val contentForAi = paprikaParser.formatForAi(paprikaRecipe)
 
             // Parse with AI
-            val parseResult = anthropicService.parseRecipe(contentForAi, apiKey, model)
+            val parseResult = anthropicService.parseRecipe(contentForAi, apiKey, model, extendedThinking)
             if (parseResult.isFailure) {
                 return null
             }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -60,6 +60,7 @@ class ParseHtmlUseCase @Inject constructor(
         }
 
         val model = settingsDataStore.aiModel.first()
+        val extendedThinking = settingsDataStore.extendedThinkingEnabled.first()
 
         // Extract content from HTML
         onProgress(ParseProgress.ExtractingContent)
@@ -68,7 +69,7 @@ class ParseHtmlUseCase @Inject constructor(
 
         // Parse with AI
         onProgress(ParseProgress.ParsingRecipe)
-        val parseResult = anthropicService.parseRecipe(extractedContent, apiKey, model)
+        val parseResult = anthropicService.parseRecipe(extractedContent, apiKey, model, extendedThinking)
         if (parseResult.isFailure) {
             return ParseResult.Error("Failed to parse recipe: ${parseResult.exceptionOrNull()?.message}")
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -39,6 +39,7 @@ fun SettingsScreen(
     val apiKey by viewModel.apiKey.collectAsStateWithLifecycle()
     val apiKeyInput by viewModel.apiKeyInput.collectAsStateWithLifecycle()
     val aiModel by viewModel.aiModel.collectAsStateWithLifecycle()
+    val extendedThinkingEnabled by viewModel.extendedThinkingEnabled.collectAsStateWithLifecycle()
     val keepScreenOn by viewModel.keepScreenOn.collectAsStateWithLifecycle()
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
     val saveState by viewModel.saveState.collectAsStateWithLifecycle()
@@ -102,7 +103,9 @@ fun SettingsScreen(
             // Model Selection Section
             ModelSelectionSection(
                 currentModel = aiModel,
-                onModelChange = viewModel::setAiModel
+                onModelChange = viewModel::setAiModel,
+                extendedThinkingEnabled = extendedThinkingEnabled,
+                onExtendedThinkingChange = viewModel::setExtendedThinkingEnabled
             )
 
             HorizontalDivider()

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -33,6 +33,13 @@ class SettingsViewModel @Inject constructor(
             initialValue = AnthropicService.DEFAULT_MODEL
         )
 
+    val extendedThinkingEnabled: StateFlow<Boolean> = settingsDataStore.extendedThinkingEnabled
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = true
+        )
+
     val keepScreenOn: StateFlow<Boolean> = settingsDataStore.keepScreenOn
         .stateIn(
             scope = viewModelScope,
@@ -87,6 +94,12 @@ class SettingsViewModel @Inject constructor(
     fun setAiModel(model: String) {
         viewModelScope.launch {
             settingsDataStore.setAiModel(model)
+        }
+    }
+
+    fun setExtendedThinkingEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsDataStore.setExtendedThinkingEnabled(enabled)
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ModelSelectionSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ModelSelectionSection.kt
@@ -2,6 +2,7 @@ package com.lionotter.recipes.ui.screens.settings.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -10,12 +11,14 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -25,7 +28,9 @@ import com.lionotter.recipes.R
 @Composable
 fun ModelSelectionSection(
     currentModel: String,
-    onModelChange: (String) -> Unit
+    onModelChange: (String) -> Unit,
+    extendedThinkingEnabled: Boolean,
+    onExtendedThinkingChange: (Boolean) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -76,6 +81,28 @@ fun ModelSelectionSection(
                     )
                 }
             }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.extended_thinking),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    text = stringResource(R.string.extended_thinking_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = extendedThinkingEnabled,
+                onCheckedChange = onExtendedThinkingChange
+            )
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,8 @@
     <string name="get_api_key">Get an API Key from Anthropic</string>
     <string name="ai_model">AI Model</string>
     <string name="ai_model_description">Choose the Claude model to use for parsing recipes. Better models may provide more accurate results but cost more.</string>
+    <string name="extended_thinking">Extended thinking</string>
+    <string name="extended_thinking_description">Allow the AI to think through complex recipes before responding. Improves accuracy but increases cost and import time.</string>
     <string name="theme">Theme</string>
     <string name="theme_description">Choose the app theme. Auto follows your system setting.</string>
     <string name="theme_auto">Auto (System)</string>

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -32,6 +32,7 @@ class SettingsViewModelTest {
 
     private val apiKeyFlow = MutableStateFlow<String?>(null)
     private val aiModelFlow = MutableStateFlow(AnthropicService.DEFAULT_MODEL)
+    private val extendedThinkingFlow = MutableStateFlow(true)
     private val keepScreenOnFlow = MutableStateFlow(true)
     private val themeModeFlow = MutableStateFlow(ThemeMode.AUTO)
 
@@ -41,6 +42,7 @@ class SettingsViewModelTest {
         settingsDataStore = mockk()
         every { settingsDataStore.anthropicApiKey } returns apiKeyFlow
         every { settingsDataStore.aiModel } returns aiModelFlow
+        every { settingsDataStore.extendedThinkingEnabled } returns extendedThinkingFlow
         every { settingsDataStore.keepScreenOn } returns keepScreenOnFlow
         every { settingsDataStore.themeMode } returns themeModeFlow
         viewModel = SettingsViewModel(settingsDataStore)
@@ -216,6 +218,31 @@ class SettingsViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             assertEquals("sk-ant-stored-key", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setExtendedThinkingEnabled calls datastore`() = runTest {
+        coEvery { settingsDataStore.setExtendedThinkingEnabled(any()) } just runs
+
+        viewModel.setExtendedThinkingEnabled(false)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { settingsDataStore.setExtendedThinkingEnabled(false) }
+    }
+
+    @Test
+    fun `extendedThinkingEnabled flow reflects datastore value`() = runTest {
+        viewModel.extendedThinkingEnabled.test {
+            // Initial value (default: true)
+            assertEquals(true, awaitItem())
+
+            // Update the underlying flow
+            extendedThinkingFlow.value = false
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(false, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -337,7 +337,7 @@ app: {
       entity: RecipeEntity
       settings: {
         label: SettingsDataStore
-        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, keep screen on, theme mode, Google Drive sync enabled/folder/last sync timestamp)"
+        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, extended thinking enabled, keep screen on, theme mode, Google Drive sync enabled/folder/last sync timestamp)"
       }
 
       dao -> room
@@ -354,7 +354,7 @@ app: {
 
       anthropic_svc: {
         label: AnthropicService
-        tooltip: "Uses extended thinking to parse recipes with volume/weight conversions, step-level ingredient extraction, and optional field detection. Supports Opus 4.6, Opus 4.5, Sonnet 4.5, and Haiku 4.5"
+        tooltip: "Parses recipes with volume/weight conversions, step-level ingredient extraction, and optional field detection. Extended thinking is configurable via settings. Supports Opus 4.6, Opus 4.5, Sonnet 4.5, and Haiku 4.5"
       }
       scraper: {
         label: WebScraperService


### PR DESCRIPTION
## Summary
- Adds a toggle in the AI Model settings section to enable/disable extended thinking for recipe parsing
- When disabled, the `thinking` parameter is omitted from Anthropic API requests, reducing cost and import time
- Extended thinking defaults to enabled (preserving current behavior)
- Setting flows through SettingsDataStore → SettingsViewModel → AnthropicService for all import paths (URL, Paprika, Google Drive HTML fallback)

Closes #112

## Test plan
- [ ] Verify the toggle appears in Settings under the AI Model section
- [ ] Import a recipe with extended thinking enabled — confirm it works as before
- [ ] Disable extended thinking and import a recipe — confirm it completes faster and still parses correctly
- [ ] Verify the setting persists across app restarts
- [ ] Run unit tests (`SettingsViewModelTest`) to confirm new test cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)