### PR TITLE
feat: add ZIP file export/import for manual backups

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportToZipUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportToZipUseCase.kt
@@ -1,0 +1,101 @@
+package com.lionotter.recipes.domain.usecase
+
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.util.RecipeSerializer
+import kotlinx.coroutines.flow.first
+import java.io.OutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.inject.Inject
+
+/**
+ * Use case for exporting recipes to a ZIP file.
+ * Uses the same folder structure as Google Drive export:
+ * - recipe-name/recipe.json
+ * - recipe-name/original.html (if available)
+ * - recipe-name/recipe.md
+ */
+class ExportToZipUseCase @Inject constructor(
+    private val recipeRepository: RecipeRepository,
+    private val recipeSerializer: RecipeSerializer
+) {
+    sealed class ExportResult {
+        data class Success(val exportedCount: Int, val failedCount: Int) : ExportResult()
+        data class Error(val message: String) : ExportResult()
+    }
+
+    sealed class ExportProgress {
+        object Starting : ExportProgress()
+        data class ExportingRecipe(
+            val recipeName: String,
+            val current: Int,
+            val total: Int
+        ) : ExportProgress()
+        data class Complete(val result: ExportResult) : ExportProgress()
+    }
+
+    /**
+     * Export all recipes to a ZIP file written to the given output stream.
+     */
+    suspend fun exportAllRecipes(
+        outputStream: OutputStream,
+        onProgress: suspend (ExportProgress) -> Unit = {}
+    ): ExportResult {
+        onProgress(ExportProgress.Starting)
+
+        val recipes = recipeRepository.getAllRecipes().first()
+        if (recipes.isEmpty()) {
+            return ExportResult.Error("No recipes to export")
+        }
+
+        var exportedCount = 0
+        var failedCount = 0
+
+        try {
+            ZipOutputStream(outputStream).use { zipOut ->
+                recipes.forEachIndexed { index, recipe ->
+                    onProgress(
+                        ExportProgress.ExportingRecipe(
+                            recipeName = recipe.name,
+                            current = index + 1,
+                            total = recipes.size
+                        )
+                    )
+
+                    try {
+                        val originalHtml = recipeRepository.getOriginalHtml(recipe.id)
+                        val files = recipeSerializer.serializeRecipe(recipe, originalHtml)
+                        val prefix = files.folderName
+
+                        // Write recipe.json
+                        zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_JSON_FILENAME}"))
+                        zipOut.write(files.recipeJson.toByteArray(Charsets.UTF_8))
+                        zipOut.closeEntry()
+
+                        // Write original.html (if available)
+                        if (files.originalHtml != null) {
+                            zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_HTML_FILENAME}"))
+                            zipOut.write(files.originalHtml.toByteArray(Charsets.UTF_8))
+                            zipOut.closeEntry()
+                        }
+
+                        // Write recipe.md
+                        zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_MARKDOWN_FILENAME}"))
+                        zipOut.write(files.recipeMarkdown.toByteArray(Charsets.UTF_8))
+                        zipOut.closeEntry()
+
+                        exportedCount++
+                    } catch (e: Exception) {
+                        failedCount++
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            return ExportResult.Error("Failed to create ZIP file: ${e.message}")
+        }
+
+        val result = ExportResult.Success(exportedCount = exportedCount, failedCount = failedCount)
+        onProgress(ExportProgress.Complete(result))
+        return result
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportFromGoogleDriveUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportFromGoogleDriveUseCase.kt
@@ -5,6 +5,7 @@ import com.lionotter.recipes.data.remote.DriveFolder
 import com.lionotter.recipes.data.remote.GoogleDriveService
 import com.lionotter.recipes.data.repository.RecipeRepository
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.util.RecipeSerializer
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
@@ -142,7 +143,7 @@ class ImportFromGoogleDriveUseCase @Inject constructor(
         // Try to find recipe.json first
         val jsonFile = googleDriveService.findFileInFolder(
             folderId = folder.id,
-            fileName = GoogleDriveService.RECIPE_JSON_FILENAME
+            fileName = RecipeSerializer.RECIPE_JSON_FILENAME
         )
 
         if (jsonFile != null) {
@@ -157,7 +158,7 @@ class ImportFromGoogleDriveUseCase @Inject constructor(
         // Try HTML fallback
         val htmlFile = googleDriveService.findFileInFolder(
             folderId = folder.id,
-            fileName = GoogleDriveService.RECIPE_HTML_FILENAME
+            fileName = RecipeSerializer.RECIPE_HTML_FILENAME
         )
 
         if (htmlFile != null) {

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeSerializer.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeSerializer.kt
@@ -1,0 +1,68 @@
+package com.lionotter.recipes.domain.util
+
+import com.lionotter.recipes.domain.model.Recipe
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+
+/**
+ * Shared logic for serializing and deserializing recipes in the standard
+ * folder export format. Each recipe is represented as a folder containing:
+ * - recipe.json: The structured recipe data
+ * - original.html: The original HTML page (if available)
+ * - recipe.md: A human-readable Markdown version
+ *
+ * This is used by both Google Drive export/import and ZIP export/import
+ * to ensure a consistent format.
+ */
+class RecipeSerializer @Inject constructor(
+    private val json: Json
+) {
+    companion object {
+        const val RECIPE_JSON_FILENAME = "recipe.json"
+        const val RECIPE_HTML_FILENAME = "original.html"
+        const val RECIPE_MARKDOWN_FILENAME = "recipe.md"
+    }
+
+    /**
+     * Files that represent a single recipe in the export folder structure.
+     */
+    data class RecipeFiles(
+        val folderName: String,
+        val recipeJson: String,
+        val originalHtml: String?,
+        val recipeMarkdown: String
+    )
+
+    /**
+     * Serialize a recipe into the standard export files.
+     */
+    fun serializeRecipe(recipe: Recipe, originalHtml: String?): RecipeFiles {
+        return RecipeFiles(
+            folderName = sanitizeFolderName(recipe.name),
+            recipeJson = json.encodeToString(recipe),
+            originalHtml = originalHtml,
+            recipeMarkdown = RecipeMarkdownFormatter.format(recipe)
+        )
+    }
+
+    /**
+     * Deserialize a recipe from its JSON representation.
+     */
+    fun deserializeRecipe(jsonContent: String): Recipe {
+        return json.decodeFromString<Recipe>(jsonContent)
+    }
+
+    /**
+     * Sanitize a recipe name for use as a folder/directory name.
+     * Replaces invalid characters and normalizes whitespace.
+     */
+    fun sanitizeFolderName(name: String): String {
+        return name
+            .replace(Regex("[/\\\\:*?\"<>|]"), "_")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+            .take(100)
+            .ifEmpty { "Untitled Recipe" }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/notification/RecipeNotificationHelper.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/notification/RecipeNotificationHelper.kt
@@ -197,6 +197,52 @@ class RecipeNotificationHelper @Inject constructor(
     }
 
     @SuppressLint("MissingPermission")
+    fun showZipExportSuccessNotification(exportedCount: Int, failedCount: Int) {
+        if (!notificationManager.areNotificationsEnabled()) return
+
+        notificationManager.cancel(NOTIFICATION_ID_PROGRESS)
+
+        val message = if (failedCount > 0) {
+            "Exported $exportedCount recipes ($failedCount failed)"
+        } else {
+            "Exported $exportedCount recipes to ZIP file"
+        }
+
+        val notification = baseNotification()
+            .setContentTitle("Export Complete")
+            .setContentText(message)
+            .build()
+
+        notificationManager.notify(NOTIFICATION_ID_COMPLETE, notification)
+    }
+
+    @SuppressLint("MissingPermission")
+    fun showZipImportSuccessNotification(importedCount: Int, failedCount: Int, skippedCount: Int = 0) {
+        if (!notificationManager.areNotificationsEnabled()) return
+
+        notificationManager.cancel(NOTIFICATION_ID_PROGRESS)
+
+        val message = buildString {
+            append("Imported $importedCount recipes")
+            if (skippedCount > 0 || failedCount > 0) {
+                append(" (")
+                val parts = mutableListOf<String>()
+                if (skippedCount > 0) parts.add("$skippedCount skipped")
+                if (failedCount > 0) parts.add("$failedCount failed")
+                append(parts.joinToString(", "))
+                append(")")
+            }
+        }
+
+        val notification = baseNotification()
+            .setContentTitle("Import Complete")
+            .setContentText(message)
+            .build()
+
+        notificationManager.notify(NOTIFICATION_ID_COMPLETE, notification)
+    }
+
+    @SuppressLint("MissingPermission")
     fun showPaprikaImportSuccessNotification(importedCount: Int, failedCount: Int) {
         if (!notificationManager.areNotificationsEnabled()) return
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/ZipExportImportViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/ZipExportImportViewModel.kt
@@ -1,0 +1,126 @@
+package com.lionotter.recipes.ui.screens.settings
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.lionotter.recipes.worker.ZipExportWorker
+import com.lionotter.recipes.worker.ZipImportWorker
+import com.lionotter.recipes.worker.observeWorkByTag
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class ZipExportImportViewModel @Inject constructor(
+    private val workManager: WorkManager
+) : ViewModel() {
+
+    private val _operationState = MutableStateFlow<ZipOperationState>(ZipOperationState.Idle)
+    val operationState: StateFlow<ZipOperationState> = _operationState.asStateFlow()
+
+    private var currentWorkId: UUID? = null
+
+    init {
+        observeWorkStatus()
+    }
+
+    fun exportToZip(fileUri: Uri) {
+        val workRequest = OneTimeWorkRequestBuilder<ZipExportWorker>()
+            .setInputData(ZipExportWorker.createInputData(fileUri))
+            .addTag(ZipExportWorker.TAG_ZIP_EXPORT)
+            .build()
+
+        currentWorkId = workRequest.id
+        workManager.enqueue(workRequest)
+        _operationState.value = ZipOperationState.Exporting
+    }
+
+    fun importFromZip(fileUri: Uri) {
+        val workRequest = OneTimeWorkRequestBuilder<ZipImportWorker>()
+            .setInputData(ZipImportWorker.createInputData(fileUri))
+            .addTag(ZipImportWorker.TAG_ZIP_IMPORT)
+            .build()
+
+        currentWorkId = workRequest.id
+        workManager.enqueue(workRequest)
+        _operationState.value = ZipOperationState.Importing
+    }
+
+    fun resetOperationState() {
+        _operationState.value = ZipOperationState.Idle
+    }
+
+    private fun observeWorkStatus() {
+        viewModelScope.launch {
+            workManager.observeWorkByTag(ZipExportWorker.TAG_ZIP_EXPORT) { currentWorkId }
+                .collect { handleExportWorkInfo(it) }
+        }
+        viewModelScope.launch {
+            workManager.observeWorkByTag(ZipImportWorker.TAG_ZIP_IMPORT) { currentWorkId }
+                .collect { handleImportWorkInfo(it) }
+        }
+    }
+
+    private fun handleExportWorkInfo(workInfo: WorkInfo) {
+        when (workInfo.state) {
+            WorkInfo.State.RUNNING -> {
+                _operationState.value = ZipOperationState.Exporting
+            }
+            WorkInfo.State.SUCCEEDED -> {
+                val exported = workInfo.outputData.getInt(ZipExportWorker.KEY_EXPORTED_COUNT, 0)
+                val failed = workInfo.outputData.getInt(ZipExportWorker.KEY_FAILED_COUNT, 0)
+                _operationState.value = ZipOperationState.ExportComplete(exported, failed)
+                currentWorkId = null
+                workManager.pruneWork()
+            }
+            WorkInfo.State.FAILED -> {
+                val error = workInfo.outputData.getString(ZipExportWorker.KEY_ERROR_MESSAGE)
+                    ?: "Export failed"
+                _operationState.value = ZipOperationState.Error(error)
+                currentWorkId = null
+                workManager.pruneWork()
+            }
+            else -> {}
+        }
+    }
+
+    private fun handleImportWorkInfo(workInfo: WorkInfo) {
+        when (workInfo.state) {
+            WorkInfo.State.RUNNING -> {
+                _operationState.value = ZipOperationState.Importing
+            }
+            WorkInfo.State.SUCCEEDED -> {
+                val imported = workInfo.outputData.getInt(ZipImportWorker.KEY_IMPORTED_COUNT, 0)
+                val failed = workInfo.outputData.getInt(ZipImportWorker.KEY_FAILED_COUNT, 0)
+                val skipped = workInfo.outputData.getInt(ZipImportWorker.KEY_SKIPPED_COUNT, 0)
+                _operationState.value = ZipOperationState.ImportComplete(imported, failed, skipped)
+                currentWorkId = null
+                workManager.pruneWork()
+            }
+            WorkInfo.State.FAILED -> {
+                val error = workInfo.outputData.getString(ZipImportWorker.KEY_ERROR_MESSAGE)
+                    ?: "Import failed"
+                _operationState.value = ZipOperationState.Error(error)
+                currentWorkId = null
+                workManager.pruneWork()
+            }
+            else -> {}
+        }
+    }
+}
+
+sealed class ZipOperationState {
+    object Idle : ZipOperationState()
+    object Exporting : ZipOperationState()
+    object Importing : ZipOperationState()
+    data class ExportComplete(val exportedCount: Int, val failedCount: Int) : ZipOperationState()
+    data class ImportComplete(val importedCount: Int, val failedCount: Int, val skippedCount: Int) : ZipOperationState()
+    data class Error(val message: String) : ZipOperationState()
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/BackupRestoreSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/BackupRestoreSection.kt
@@ -1,0 +1,82 @@
+package com.lionotter.recipes.ui.screens.settings.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FileDownload
+import androidx.compose.material.icons.filled.FileUpload
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.lionotter.recipes.R
+import com.lionotter.recipes.ui.components.ProgressCard
+import com.lionotter.recipes.ui.screens.settings.ZipOperationState
+
+@Composable
+fun BackupRestoreSection(
+    operationState: ZipOperationState,
+    onExportClick: () -> Unit,
+    onImportClick: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = stringResource(R.string.backup_restore),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Text(
+            text = stringResource(R.string.backup_restore_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        val isOperating = operationState is ZipOperationState.Exporting ||
+                operationState is ZipOperationState.Importing
+
+        if (isOperating) {
+            ProgressCard(
+                message = if (operationState is ZipOperationState.Exporting) {
+                    stringResource(R.string.exporting_recipes)
+                } else {
+                    stringResource(R.string.importing_recipes)
+                }
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedButton(
+                onClick = onExportClick,
+                enabled = !isOperating,
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.FileUpload,
+                    contentDescription = null
+                )
+                Text("  " + stringResource(R.string.export_to_zip))
+            }
+
+            OutlinedButton(
+                onClick = onImportClick,
+                enabled = !isOperating,
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.FileDownload,
+                    contentDescription = null
+                )
+                Text("  " + stringResource(R.string.import_from_zip))
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/ZipExportWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/ZipExportWorker.kt
@@ -1,0 +1,126 @@
+package com.lionotter.recipes.worker
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.hilt.work.HiltWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.lionotter.recipes.domain.usecase.ExportToZipUseCase
+import com.lionotter.recipes.notification.RecipeNotificationHelper
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class ZipExportWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val exportToZipUseCase: ExportToZipUseCase,
+    notificationHelper: RecipeNotificationHelper
+) : BaseRecipeWorker(context, workerParams, notificationHelper) {
+
+    override val notificationTitle = "Exporting recipes"
+
+    companion object {
+        const val TAG_ZIP_EXPORT = "zip_export"
+
+        const val KEY_FILE_URI = "file_uri"
+        const val KEY_RESULT_TYPE = "result_type"
+        const val KEY_EXPORTED_COUNT = "exported_count"
+        const val KEY_FAILED_COUNT = "failed_count"
+        const val KEY_ERROR_MESSAGE = "error_message"
+        const val KEY_PROGRESS = "progress"
+        const val KEY_CURRENT = "current"
+        const val KEY_TOTAL = "total"
+        const val KEY_RECIPE_NAME = "recipe_name"
+
+        const val RESULT_SUCCESS = "success"
+        const val RESULT_ERROR = "error"
+
+        const val PROGRESS_STARTING = "starting"
+        const val PROGRESS_EXPORTING = "exporting"
+
+        fun createInputData(fileUri: Uri): Data {
+            return workDataOf(KEY_FILE_URI to fileUri.toString())
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        val fileUriString = inputData.getString(KEY_FILE_URI)
+            ?: return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "No file URI provided"
+                )
+            )
+
+        val fileUri = fileUriString.toUri()
+        setForegroundProgress("Starting export...")
+
+        val outputStream = try {
+            context.contentResolver.openOutputStream(fileUri)
+                ?: return Result.failure(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_ERROR,
+                        KEY_ERROR_MESSAGE to "Could not open file for writing"
+                    )
+                )
+        } catch (e: Exception) {
+            return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "Failed to open file: ${e.message}"
+                )
+            )
+        }
+
+        val result = outputStream.use { stream ->
+            exportToZipUseCase.exportAllRecipes(
+                outputStream = stream,
+                onProgress = { progress ->
+                    val progressMessage = when (progress) {
+                        is ExportToZipUseCase.ExportProgress.Starting -> {
+                            setProgress(workDataOf(KEY_PROGRESS to PROGRESS_STARTING))
+                            "Starting export..."
+                        }
+                        is ExportToZipUseCase.ExportProgress.ExportingRecipe -> {
+                            setProgress(workDataOf(
+                                KEY_PROGRESS to PROGRESS_EXPORTING,
+                                KEY_RECIPE_NAME to progress.recipeName,
+                                KEY_CURRENT to progress.current,
+                                KEY_TOTAL to progress.total
+                            ))
+                            "Exporting ${progress.current}/${progress.total}: ${progress.recipeName}"
+                        }
+                        is ExportToZipUseCase.ExportProgress.Complete -> "Complete!"
+                    }
+                    setForegroundProgress(progressMessage)
+                }
+            )
+        }
+
+        return when (result) {
+            is ExportToZipUseCase.ExportResult.Success -> {
+                notificationHelper.showZipExportSuccessNotification(
+                    exportedCount = result.exportedCount,
+                    failedCount = result.failedCount
+                )
+                Result.success(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_SUCCESS,
+                        KEY_EXPORTED_COUNT to result.exportedCount,
+                        KEY_FAILED_COUNT to result.failedCount
+                    )
+                )
+            }
+            is ExportToZipUseCase.ExportResult.Error -> errorResult(
+                errorNotificationTitle = "Export Failed",
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                errorType = RESULT_ERROR,
+                errorMessage = result.message
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/ZipImportWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/ZipImportWorker.kt
@@ -1,0 +1,134 @@
+package com.lionotter.recipes.worker
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.hilt.work.HiltWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.lionotter.recipes.domain.usecase.ImportFromZipUseCase
+import com.lionotter.recipes.notification.RecipeNotificationHelper
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class ZipImportWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val importFromZipUseCase: ImportFromZipUseCase,
+    notificationHelper: RecipeNotificationHelper
+) : BaseRecipeWorker(context, workerParams, notificationHelper) {
+
+    override val notificationTitle = "Importing recipes"
+
+    companion object {
+        const val TAG_ZIP_IMPORT = "zip_import"
+
+        const val KEY_FILE_URI = "file_uri"
+        const val KEY_RESULT_TYPE = "result_type"
+        const val KEY_IMPORTED_COUNT = "imported_count"
+        const val KEY_FAILED_COUNT = "failed_count"
+        const val KEY_SKIPPED_COUNT = "skipped_count"
+        const val KEY_ERROR_MESSAGE = "error_message"
+        const val KEY_PROGRESS = "progress"
+        const val KEY_CURRENT = "current"
+        const val KEY_TOTAL = "total"
+        const val KEY_RECIPE_NAME = "recipe_name"
+
+        const val RESULT_SUCCESS = "success"
+        const val RESULT_ERROR = "error"
+
+        const val PROGRESS_STARTING = "starting"
+        const val PROGRESS_READING = "reading"
+        const val PROGRESS_IMPORTING = "importing"
+
+        fun createInputData(fileUri: Uri): Data {
+            return workDataOf(KEY_FILE_URI to fileUri.toString())
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        val fileUriString = inputData.getString(KEY_FILE_URI)
+            ?: return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "No file URI provided"
+                )
+            )
+
+        val fileUri = fileUriString.toUri()
+        setForegroundProgress("Starting import...")
+
+        val inputStream = try {
+            context.contentResolver.openInputStream(fileUri)
+                ?: return Result.failure(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_ERROR,
+                        KEY_ERROR_MESSAGE to "Could not open file"
+                    )
+                )
+        } catch (e: Exception) {
+            return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "Failed to open file: ${e.message}"
+                )
+            )
+        }
+
+        val result = inputStream.use { stream ->
+            importFromZipUseCase.importFromZip(
+                inputStream = stream,
+                onProgress = { progress ->
+                    val progressMessage = when (progress) {
+                        is ImportFromZipUseCase.ImportProgress.Starting -> {
+                            setProgress(workDataOf(KEY_PROGRESS to PROGRESS_STARTING))
+                            "Starting import..."
+                        }
+                        is ImportFromZipUseCase.ImportProgress.ReadingZip -> {
+                            setProgress(workDataOf(KEY_PROGRESS to PROGRESS_READING))
+                            "Reading ZIP file..."
+                        }
+                        is ImportFromZipUseCase.ImportProgress.ImportingRecipe -> {
+                            setProgress(workDataOf(
+                                KEY_PROGRESS to PROGRESS_IMPORTING,
+                                KEY_RECIPE_NAME to progress.recipeName,
+                                KEY_CURRENT to progress.current,
+                                KEY_TOTAL to progress.total
+                            ))
+                            "Importing ${progress.current}/${progress.total}: ${progress.recipeName}"
+                        }
+                        is ImportFromZipUseCase.ImportProgress.Complete -> "Complete!"
+                    }
+                    setForegroundProgress(progressMessage)
+                }
+            )
+        }
+
+        return when (result) {
+            is ImportFromZipUseCase.ImportResult.Success -> {
+                notificationHelper.showZipImportSuccessNotification(
+                    importedCount = result.importedCount,
+                    failedCount = result.failedCount,
+                    skippedCount = result.skippedCount
+                )
+                Result.success(
+                    workDataOf(
+                        KEY_RESULT_TYPE to RESULT_SUCCESS,
+                        KEY_IMPORTED_COUNT to result.importedCount,
+                        KEY_FAILED_COUNT to result.failedCount,
+                        KEY_SKIPPED_COUNT to result.skippedCount
+                    )
+                )
+            }
+            is ImportFromZipUseCase.ImportResult.Error -> errorResult(
+                errorNotificationTitle = "Import Failed",
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                errorType = RESULT_ERROR,
+                errorMessage = result.message
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,6 +150,17 @@
     <string name="skipped_count">%1$d skipped</string>
     <string name="failed_count">%1$d failed</string>
 
+    <!-- Zip Export/Import -->
+    <string name="backup_restore">Backup &amp; Restore</string>
+    <string name="backup_restore_description">Export your recipes to a ZIP file for backup, or import recipes from a previously exported ZIP file.</string>
+    <string name="export_to_zip">Export to ZIP</string>
+    <string name="import_from_zip">Import from ZIP</string>
+    <string name="exporting_recipes">Exporting recipes\u2026</string>
+    <string name="importing_recipes">Importing recipes\u2026</string>
+    <string name="zip_exported_recipes">Exported %1$d recipes to ZIP file</string>
+    <string name="zip_exported_recipes_with_failures">Exported %1$d recipes (%2$d failed)</string>
+    <string name="zip_imported_recipes">Imported %1$d recipes from ZIP file</string>
+
     <!-- Paprika Import -->
     <string name="import_from_paprika">Import from Paprika</string>
     <string name="reading_paprika_export">Reading Paprika export\u2026</string>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -105,6 +105,10 @@ app: {
         label: GoogleDriveViewModel
         tooltip: "Manages Google Drive sign-in state, folder navigation, export/import operations, and sync enable/disable/trigger"
       }
+      zip_vm: {
+        label: ZipExportImportViewModel
+        tooltip: "Manages ZIP file export/import operations via WorkManager. Handles file picker integration and work status observation."
+      }
     }
 
     state: {
@@ -125,6 +129,7 @@ app: {
     screens.add -> viewmodels.add_vm
     screens.settings -> viewmodels.settings_vm
     screens.settings -> viewmodels.drive_vm: sign in/out
+    screens.settings -> viewmodels.zip_vm: backup/restore
     viewmodels.list_vm -> state.in_progress_mgr: observes
     viewmodels.add_vm -> state.in_progress_mgr: adds entries
     state.in_progress_mgr -> background.worker: observes status
@@ -168,14 +173,24 @@ app: {
         label: GoogleDriveSyncWorker
         tooltip: "Bidirectional sync with Google Drive. Runs on app startup and periodically (every 6 hours). Uploads new local recipes, downloads new remote recipes, updates changed recipes using latest-timestamp-wins conflict resolution."
       }
+      zip_export_worker: {
+        label: ZipExportWorker
+        tooltip: "Exports all recipes to a ZIP file. Uses the same folder structure as Google Drive export (recipe.json + original.html + recipe.md per recipe)."
+      }
+      zip_import_worker: {
+        label: ZipImportWorker
+        tooltip: "Imports recipes from a ZIP file. Reads recipe.json from each folder, skips duplicates, optionally restores original HTML."
+      }
       import_worker -> base_worker: extends
       export_worker -> base_worker: extends
       drive_import_worker -> base_worker: extends
       paprika_import_worker -> base_worker: extends
       sync_worker -> base_worker: extends
+      zip_export_worker -> base_worker: extends
+      zip_import_worker -> base_worker: extends
       work_ext: {
         label: "observeWorkByTag()"
-        tooltip: "WorkManager extension function that encapsulates the common pattern of observing work by tag and filtering to a specific work ID. Used by AddRecipeViewModel and GoogleDriveViewModel."
+        tooltip: "WorkManager extension function that encapsulates the common pattern of observing work by tag and filtering to a specific work ID. Used by AddRecipeViewModel, GoogleDriveViewModel, and ZipExportImportViewModel."
       }
     }
 
@@ -196,6 +211,8 @@ app: {
     worker.drive_import_worker -> notification.helper: notify progress
     worker.paprika_import_worker -> notification.helper: notify progress
     worker.sync_worker -> notification.helper: notify progress
+    worker.zip_export_worker -> notification.helper: notify progress
+    worker.zip_import_worker -> notification.helper: notify progress
   }
 
   # Domain Layer
@@ -233,6 +250,14 @@ app: {
         label: SyncToGoogleDriveUseCase
         tooltip: "Bidirectional sync: compares local vs remote recipes, uploads new, downloads new, updates changed (latest timestamp wins). Runs via WorkManager on startup and periodically."
       }
+      export_zip: {
+        label: ExportToZipUseCase
+        tooltip: "Exports all recipes to a ZIP file using RecipeSerializer. Same folder structure as Google Drive export."
+      }
+      import_zip: {
+        label: ImportFromZipUseCase
+        tooltip: "Imports recipes from a ZIP file. Reads recipe.json from each folder, skips duplicates by ID, optionally restores original HTML."
+      }
       tags: GetTagsUseCase
       calc_usage: {
         label: CalculateIngredientUsageUseCase
@@ -250,6 +275,11 @@ app: {
         label: RecipeMarkdownFormatter
         tooltip: "Converts Recipe to human-readable Markdown format for export"
       }
+      serializer: {
+        label: RecipeSerializer
+        tooltip: "Shared logic for serializing/deserializing recipes in the standard folder export format (recipe.json + original.html + recipe.md). Used by Google Drive and ZIP export/import."
+      }
+      serializer -> markdown: format
     }
 
     models: {
@@ -290,8 +320,10 @@ app: {
 
     usecases.import -> usecases.parse_html: uses
     usecases.import_drive -> usecases.parse_html: HTML fallback
-    usecases.export_drive -> util.markdown: format
-    usecases.sync_drive -> util.markdown: format
+    usecases.export_drive -> util.serializer: serialize
+    usecases.sync_drive -> util.serializer: serialize
+    usecases.export_zip -> util.serializer: serialize
+    usecases.import_zip -> util.serializer: deserialize
   }
 
   # Data Layer
@@ -434,11 +466,16 @@ app: {
   ui.viewmodels.drive_vm -> background.worker.sync_worker: sync
   ui.viewmodels.drive_vm -> background.worker.work_ext: observe export/import/sync
   ui.viewmodels.drive_vm -> data.local.settings: sync settings
+  ui.viewmodels.zip_vm -> background.worker.zip_export_worker: export
+  ui.viewmodels.zip_vm -> background.worker.zip_import_worker: import
+  ui.viewmodels.zip_vm -> background.worker.work_ext: observe export/import
   background.worker.import_worker -> domain.usecases.import: execute
   background.worker.export_worker -> domain.usecases.export_drive: execute
   background.worker.drive_import_worker -> domain.usecases.import_drive: execute
   background.worker.paprika_import_worker -> domain.usecases.import_paprika: execute
   background.worker.sync_worker -> domain.usecases.sync_drive: execute
+  background.worker.zip_export_worker -> domain.usecases.export_zip: execute
+  background.worker.zip_import_worker -> domain.usecases.import_zip: execute
   domain.usecases -> data.repository: access data
   domain.usecases.import_paprika -> data.paprika.parser: parse export
   domain.usecases.import_paprika -> data.remote.anthropic_svc: parse recipe content
@@ -485,6 +522,20 @@ legend: {
 
   drive1 -> drive2 -> drive3 -> drive4
 
+  zip_flow: {
+    label: "ZIP Export/Import Flow"
+    style: {
+      font-size: 14
+      bold: true
+    }
+  }
+  zip1: "Export: User picks save location, ZipExportWorker writes ZIP with same folder structure as Drive"
+  zip2: "Import: User picks .zip file, ZipImportWorker reads recipe.json from each folder"
+  zip3: "Uses RecipeSerializer shared with Google Drive for consistent format"
+  zip4: "Skips recipes that already exist locally (by ID)"
+
+  zip1 -> zip2 -> zip3 -> zip4
+
   paprika_flow: {
     label: "Paprika Import Flow"
     style: {
@@ -501,7 +552,7 @@ legend: {
   pap1 -> pap2 -> pap3 -> pap4 -> pap5
 
   note: {
-    label: "Import runs in background via WorkManager. Supports multiple concurrent imports. Google Drive export/import/sync and Paprika import run in background with progress notifications. Sync runs on app startup and every 6 hours when enabled. Paprika import can be cancelled mid-way, keeping already-imported recipes."
+    label: "Import runs in background via WorkManager. Supports multiple concurrent imports. Google Drive export/import/sync, ZIP export/import, and Paprika import run in background with progress notifications. Sync runs on app startup and every 6 hours when enabled. Paprika import can be cancelled mid-way, keeping already-imported recipes. ZIP and Google Drive export share the same folder format via RecipeSerializer."
     style: {
       font-size: 12
       italic: true


### PR DESCRIPTION
## Summary
- Extracts `RecipeSerializer` to share recipe folder serialization logic (recipe.json + original.html + recipe.md) between Google Drive and ZIP export/import, eliminating duplicated code
- Adds `ExportToZipUseCase` and `ImportFromZipUseCase` that produce/consume the same folder structure as Google Drive export
- Adds background workers (`ZipExportWorker`, `ZipImportWorker`), a `ZipExportImportViewModel`, and a "Backup & Restore" section in Settings with Android file picker integration
- Refactors all three Google Drive use cases (`ExportToGoogleDriveUseCase`, `ImportFromGoogleDriveUseCase`, `SyncToGoogleDriveUseCase`) to use the shared `RecipeSerializer` instead of duplicated serialization code
- Updates architecture diagram with new components and data flow

Closes #111

## Test plan
- [ ] Export recipes to ZIP from Settings > Backup & Restore > Export to ZIP
- [ ] Verify ZIP file contains folders with recipe.json, original.html, and recipe.md
- [ ] Import recipes from a previously exported ZIP file
- [ ] Verify duplicate recipes are skipped (by ID)
- [ ] Verify Google Drive export/import/sync still works after refactor
- [ ] Verify progress notifications show during export/import
- [ ] Verify snackbar shows results after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)