### PR TITLE
fix: omit null thinking field from API requests

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicModels.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicModels.kt
@@ -3,32 +3,6 @@ package com.lionotter.recipes.data.remote
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/**
- * Configuration for extended thinking capability.
- */
-@Serializable
-data class ThinkingConfig(
-    val type: String = "enabled",
-    @SerialName("budget_tokens")
-    val budgetTokens: Int = 8000
-)
-
-@Serializable
-data class AnthropicRequest(
-    val model: String,
-    @SerialName("max_tokens")
-    val maxTokens: Int,
-    val messages: List<AnthropicMessage>,
-    val system: String? = null,
-    val thinking: ThinkingConfig? = null
-)
-
-@Serializable
-data class AnthropicMessage(
-    val role: String,
-    val content: String
-)
-
 @Serializable
 data class AnthropicResponse(
     val id: String,


### PR DESCRIPTION
## Summary
- When extended thinking is disabled in settings, the JSON serializer was including `"thinking": null` in API requests, which the Anthropic API rejected with a validation error
- Instead of relying on global Json serializer config, the fix builds the request JSON manually using `buildJsonObject`, so the `thinking` key is simply never added when extended thinking is off
- Removed unused `AnthropicRequest`, `ThinkingConfig`, and `AnthropicMessage` model classes that are no longer needed

## Test plan
- [x] Build compiles successfully
- [x] All unit tests pass
- [ ] Manually disable extended thinking in settings and verify recipe imports work without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)