### PR TITLE
feat: support folder selection for Google Drive sync

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -176,4 +176,10 @@ class SettingsDataStore @Inject constructor(
             preferences[Keys.IMPORT_DEBUGGING_ENABLED] = enabled
         }
     }
+
+    suspend fun clearGoogleDriveLastSyncTimestamp() {
+        context.dataStore.edit { preferences ->
+            preferences.remove(Keys.GOOGLE_DRIVE_LAST_SYNC_TIMESTAMP)
+        }
+    }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import com.lionotter.recipes.ui.screens.settings.components.AboutSection
 import com.lionotter.recipes.ui.screens.settings.components.ApiKeySection
 import com.lionotter.recipes.ui.screens.settings.components.BackupRestoreSection
 import com.lionotter.recipes.ui.screens.settings.components.DisplaySection
+import com.lionotter.recipes.ui.screens.settings.components.FolderPickerDialog
 import com.lionotter.recipes.ui.screens.settings.components.GoogleDriveSection
 import com.lionotter.recipes.ui.screens.settings.components.ImportDebuggingSection
 import com.lionotter.recipes.ui.screens.settings.components.ModelSelectionSection
@@ -53,8 +54,11 @@ fun SettingsScreen(
     val saveState by viewModel.saveState.collectAsStateWithLifecycle()
     val driveUiState by googleDriveViewModel.uiState.collectAsStateWithLifecycle()
     val syncEnabled by googleDriveViewModel.syncEnabled.collectAsStateWithLifecycle()
+    val syncFolderName by googleDriveViewModel.syncFolderName.collectAsStateWithLifecycle()
     val lastSyncTimestamp by googleDriveViewModel.lastSyncTimestamp.collectAsStateWithLifecycle()
     val operationState by googleDriveViewModel.operationState.collectAsStateWithLifecycle()
+    val showFolderPicker by googleDriveViewModel.showFolderPicker.collectAsStateWithLifecycle()
+    val folderPickerState by googleDriveViewModel.folderPickerState.collectAsStateWithLifecycle()
     val zipOperationState by zipViewModel.operationState.collectAsStateWithLifecycle()
     val importDebuggingEnabled by viewModel.importDebuggingEnabled.collectAsStateWithLifecycle()
 
@@ -204,6 +208,7 @@ fun SettingsScreen(
             GoogleDriveSection(
                 uiState = driveUiState,
                 syncEnabled = syncEnabled,
+                syncFolderName = syncFolderName,
                 lastSyncTimestamp = lastSyncTimestamp,
                 operationState = operationState,
                 onSignInClick = {
@@ -212,8 +217,18 @@ fun SettingsScreen(
                 onSignOutClick = googleDriveViewModel::signOut,
                 onEnableSyncClick = googleDriveViewModel::enableSync,
                 onDisableSyncClick = googleDriveViewModel::disableSync,
-                onSyncNowClick = googleDriveViewModel::triggerSync
+                onSyncNowClick = googleDriveViewModel::triggerSync,
+                onChangeFolderClick = googleDriveViewModel::changeSyncFolder
             )
+
+            // Folder picker dialog
+            if (showFolderPicker && folderPickerState != null) {
+                FolderPickerDialog(
+                    state = folderPickerState!!,
+                    onDismiss = googleDriveViewModel::dismissFolderPicker,
+                    onConfirm = googleDriveViewModel::onFolderSelected
+                )
+            }
 
             HorizontalDivider()
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/FolderPickerDialog.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/FolderPickerDialog.kt
@@ -1,0 +1,173 @@
+package com.lionotter.recipes.ui.screens.settings.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CreateNewFolder
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.lionotter.recipes.R
+import com.lionotter.recipes.data.remote.DriveFolder
+
+sealed class FolderPickerState {
+    object Loading : FolderPickerState()
+    data class Loaded(val folders: List<DriveFolder>) : FolderPickerState()
+    data class Error(val message: String) : FolderPickerState()
+}
+
+sealed class FolderSelection {
+    object CreateNew : FolderSelection()
+    data class Existing(val folder: DriveFolder) : FolderSelection()
+}
+
+@Composable
+fun FolderPickerDialog(
+    state: FolderPickerState,
+    onDismiss: () -> Unit,
+    onConfirm: (FolderSelection) -> Unit
+) {
+    var selection by remember { mutableStateOf<FolderSelection>(FolderSelection.CreateNew) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.select_sync_folder)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = stringResource(R.string.select_sync_folder_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                when (state) {
+                    is FolderPickerState.Loading -> {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            horizontalArrangement = Arrangement.Center,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            CircularProgressIndicator()
+                            Text(
+                                text = stringResource(R.string.loading_folders),
+                                modifier = Modifier.padding(start = 12.dp),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+
+                    is FolderPickerState.Loaded -> {
+                        // "Create new folder" option
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { selection = FolderSelection.CreateNew }
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = selection is FolderSelection.CreateNew,
+                                onClick = { selection = FolderSelection.CreateNew }
+                            )
+                            Icon(
+                                imageVector = Icons.Default.CreateNewFolder,
+                                contentDescription = null,
+                                modifier = Modifier.padding(horizontal = 8.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Text(
+                                text = stringResource(R.string.create_new_folder),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+
+                        // Existing folders
+                        if (state.folders.isNotEmpty()) {
+                            LazyColumn {
+                                items(state.folders) { folder ->
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .clickable {
+                                                selection = FolderSelection.Existing(folder)
+                                            }
+                                            .padding(vertical = 8.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        RadioButton(
+                                            selected = selection is FolderSelection.Existing &&
+                                                (selection as FolderSelection.Existing).folder.id == folder.id,
+                                            onClick = {
+                                                selection = FolderSelection.Existing(folder)
+                                            }
+                                        )
+                                        Icon(
+                                            imageVector = Icons.Default.Folder,
+                                            contentDescription = null,
+                                            modifier = Modifier.padding(horizontal = 8.dp),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                        Text(
+                                            text = folder.name,
+                                            style = MaterialTheme.typography.bodyMedium
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    is FolderPickerState.Error -> {
+                        Text(
+                            text = state.message,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            val enabled = state is FolderPickerState.Loaded
+            TextButton(
+                onClick = { onConfirm(selection) },
+                enabled = enabled
+            ) {
+                Text(
+                    if (selection is FolderSelection.CreateNew) {
+                        stringResource(R.string.create_new_folder)
+                    } else {
+                        stringResource(R.string.use_selected_folder)
+                    }
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/GoogleDriveSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/GoogleDriveSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -17,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,13 +35,15 @@ import com.lionotter.recipes.ui.screens.googledrive.OperationState
 fun GoogleDriveSection(
     uiState: GoogleDriveUiState,
     syncEnabled: Boolean,
+    syncFolderName: String?,
     lastSyncTimestamp: String?,
     operationState: OperationState,
     onSignInClick: () -> Unit,
     onSignOutClick: () -> Unit,
     onEnableSyncClick: () -> Unit,
     onDisableSyncClick: () -> Unit,
-    onSyncNowClick: () -> Unit
+    onSyncNowClick: () -> Unit,
+    onChangeFolderClick: () -> Unit
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
@@ -133,6 +137,38 @@ fun GoogleDriveSection(
                         }
 
                         if (syncEnabled) {
+                            // Sync folder info
+                            if (syncFolderName != null) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Row(
+                                        modifier = Modifier.weight(1f),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Default.Folder,
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.padding(end = 4.dp)
+                                        )
+                                        Text(
+                                            text = stringResource(R.string.sync_folder_label, syncFolderName),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                    TextButton(onClick = onChangeFolderClick) {
+                                        Text(
+                                            text = stringResource(R.string.change_folder),
+                                            style = MaterialTheme.typography.bodySmall
+                                        )
+                                    }
+                                }
+                            }
+
                             // Last sync info
                             Text(
                                 text = if (lastSyncTimestamp != null) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,15 @@
     <string name="synced_recipes">Synced: %1$d uploaded, %2$d downloaded, %3$d updated</string>
     <string name="sync_no_changes">Everything is up to date</string>
     <string name="not_connected">Not connected</string>
+    <string name="select_sync_folder">Select Sync Folder</string>
+    <string name="select_sync_folder_description">Choose an existing folder or create a new one for syncing recipes.</string>
+    <string name="create_new_folder">Create new folder</string>
+    <string name="use_selected_folder">Use Selected Folder</string>
+    <string name="loading_folders">Loading folders\u2026</string>
+    <string name="no_folders_found">No existing folders found</string>
+    <string name="failed_to_load_folders">Failed to load folders</string>
+    <string name="sync_folder_label">Sync folder: %1$s</string>
+    <string name="change_folder">Change Folder</string>
     <string name="connect_to_google_drive">Connect to Google Drive</string>
     <string name="try_again">Try Again</string>
     <string name="about">About</string>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -117,7 +117,7 @@ app: {
       settings_vm: SettingsViewModel
       drive_vm: {
         label: GoogleDriveViewModel
-        tooltip: "Manages Google Drive sign-in state and sync enable/disable/trigger"
+        tooltip: "Manages Google Drive sign-in state, folder selection (via folder picker dialog), and sync enable/disable/trigger"
       }
       zip_vm: {
         label: ZipExportImportViewModel
@@ -407,7 +407,7 @@ app: {
       }
       google_drive_svc: {
         label: GoogleDriveService
-        tooltip: "Handles Google Sign-In, folder operations, file upload/download/update/delete for Drive sync"
+        tooltip: "Handles Google Sign-In, folder listing/creation/selection, file upload/download/update/delete for Drive sync"
       }
     }
 
@@ -528,9 +528,9 @@ legend: {
       bold: true
     }
   }
-  drive1: "Bidirectional sync on startup + every 6 hours (latest timestamp wins)"
-  drive2: "Uploads new local recipes, downloads new remote recipes"
-  drive3: "Updates changed recipes, deletes remotely-deleted recipes"
+  drive1: "User selects existing folder or creates new one via folder picker dialog"
+  drive2: "Bidirectional sync on startup + every 6 hours (latest timestamp wins)"
+  drive3: "Uploads new local recipes, downloads new remote recipes, updates changed"
 
   drive1 -> drive2 -> drive3
 


### PR DESCRIPTION
## Summary
- When enabling Google Drive sync, users now see a folder picker dialog that lets them select an existing folder or create a new one
- This allows users who previously used the app to reconnect to their existing sync folder and have their recipes imported via the normal sync process
- Shows the current sync folder name in the settings UI with a "Change Folder" button
- Changing folders clears the last sync timestamp so the first sync with the new folder downloads existing recipes instead of treating them as deleted

## Changes
- **New file:** `FolderPickerDialog.kt` - Composable dialog with radio buttons for "Create new folder" and listing existing Drive folders
- **`GoogleDriveViewModel.kt`** - Added folder picker state management, folder listing via `GoogleDriveService.listFolders()`, and folder selection handling
- **`GoogleDriveSection.kt`** - Added sync folder name display with folder icon and "Change Folder" button
- **`SettingsScreen.kt`** - Wire up folder picker dialog and pass new `syncFolderName` parameter
- **`SettingsDataStore.kt`** - Added `clearGoogleDriveLastSyncTimestamp()` method
- **`strings.xml`** - Added string resources for folder picker UI
- **`architecture.d2`** - Updated tooltips and sync flow description

## Test plan
- [ ] Sign in to Google Drive and enable sync — folder picker dialog should appear
- [ ] Verify "Create new folder" creates a new folder and starts sync
- [ ] Verify selecting an existing folder uses it and imports recipes from it
- [ ] Verify "Change Folder" button appears when sync is enabled and opens the folder picker
- [ ] Verify changing folders clears last sync timestamp (shows "Never synced")
- [ ] Verify dismissing the folder picker does not enable sync

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)