### PR TITLE
feat: add import debugging feature

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/ImportDebugDao.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/ImportDebugDao.kt
@@ -1,0 +1,22 @@
+package com.lionotter.recipes.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ImportDebugDao {
+    @Query("SELECT * FROM import_debug ORDER BY createdAt DESC")
+    fun getAllDebugEntries(): Flow<List<ImportDebugEntity>>
+
+    @Query("SELECT * FROM import_debug WHERE id = :id")
+    suspend fun getDebugEntryById(id: String): ImportDebugEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertDebugEntry(entry: ImportDebugEntity)
+
+    @Query("DELETE FROM import_debug")
+    suspend fun deleteAllDebugEntries()
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/ImportDebugEntity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/ImportDebugEntity.kt
@@ -1,0 +1,26 @@
+package com.lionotter.recipes.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "import_debug")
+data class ImportDebugEntity(
+    @PrimaryKey
+    val id: String,
+    val sourceUrl: String?,
+    val originalHtml: String?,
+    val cleanedContent: String?,
+    val aiOutputJson: String?,
+    val originalLength: Int,
+    val cleanedLength: Int,
+    val inputTokens: Long?,
+    val outputTokens: Long?,
+    val aiModel: String?,
+    val thinkingEnabled: Boolean,
+    val recipeId: String?,
+    val recipeName: String?,
+    val errorMessage: String?,
+    val isError: Boolean,
+    val durationMs: Long?,
+    val createdAt: Long
+)

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
@@ -6,17 +6,49 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
-    entities = [RecipeEntity::class],
-    version = 2,
+    entities = [RecipeEntity::class, ImportDebugEntity::class],
+    version = 4,
     exportSchema = true
 )
 abstract class RecipeDatabase : RoomDatabase() {
     abstract fun recipeDao(): RecipeDao
+    abstract fun importDebugDao(): ImportDebugDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE recipes ADD COLUMN isFavorite INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS import_debug (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        sourceUrl TEXT,
+                        originalHtml TEXT,
+                        cleanedContent TEXT,
+                        aiOutputJson TEXT,
+                        originalLength INTEGER NOT NULL,
+                        cleanedLength INTEGER NOT NULL,
+                        inputTokens INTEGER,
+                        outputTokens INTEGER,
+                        aiModel TEXT,
+                        thinkingEnabled INTEGER NOT NULL,
+                        recipeId TEXT,
+                        recipeName TEXT,
+                        errorMessage TEXT,
+                        isError INTEGER NOT NULL,
+                        createdAt INTEGER NOT NULL
+                    )
+                """.trimIndent())
+            }
+        }
+
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE import_debug ADD COLUMN durationMs INTEGER")
             }
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -37,6 +37,7 @@ class SettingsDataStore @Inject constructor(
         val GOOGLE_DRIVE_SYNC_FOLDER_ID = stringPreferencesKey("google_drive_sync_folder_id")
         val GOOGLE_DRIVE_SYNC_FOLDER_NAME = stringPreferencesKey("google_drive_sync_folder_name")
         val GOOGLE_DRIVE_LAST_SYNC_TIMESTAMP = stringPreferencesKey("google_drive_last_sync_timestamp")
+        val IMPORT_DEBUGGING_ENABLED = booleanPreferencesKey("import_debugging_enabled")
         const val ENCRYPTED_API_KEY = "anthropic_api_key"
     }
 
@@ -98,6 +99,10 @@ class SettingsDataStore @Inject constructor(
 
     val googleDriveLastSyncTimestamp: Flow<String?> = context.dataStore.data.map { preferences ->
         preferences[Keys.GOOGLE_DRIVE_LAST_SYNC_TIMESTAMP]
+    }
+
+    val importDebuggingEnabled: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[Keys.IMPORT_DEBUGGING_ENABLED] ?: false
     }
 
     suspend fun setAnthropicApiKey(apiKey: String) {
@@ -163,6 +168,12 @@ class SettingsDataStore @Inject constructor(
     suspend fun setGoogleDriveLastSyncTimestamp(timestamp: String) {
         context.dataStore.edit { preferences ->
             preferences[Keys.GOOGLE_DRIVE_LAST_SYNC_TIMESTAMP] = timestamp
+        }
+    }
+
+    suspend fun setImportDebuggingEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.IMPORT_DEBUGGING_ENABLED] = enabled
         }
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/ImportDebugRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/ImportDebugRepository.kt
@@ -1,0 +1,28 @@
+package com.lionotter.recipes.data.repository
+
+import com.lionotter.recipes.data.local.ImportDebugDao
+import com.lionotter.recipes.data.local.ImportDebugEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ImportDebugRepository @Inject constructor(
+    private val importDebugDao: ImportDebugDao
+) {
+    fun getAllDebugEntries(): Flow<List<ImportDebugEntity>> {
+        return importDebugDao.getAllDebugEntries()
+    }
+
+    suspend fun getDebugEntryById(id: String): ImportDebugEntity? {
+        return importDebugDao.getDebugEntryById(id)
+    }
+
+    suspend fun saveDebugEntry(entry: ImportDebugEntity) {
+        importDebugDao.insertDebugEntry(entry)
+    }
+
+    suspend fun deleteAllDebugEntries() {
+        importDebugDao.deleteAllDebugEntries()
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
@@ -2,6 +2,7 @@ package com.lionotter.recipes.di
 
 import android.content.Context
 import androidx.room.Room
+import com.lionotter.recipes.data.local.ImportDebugDao
 import com.lionotter.recipes.data.local.RecipeDao
 import com.lionotter.recipes.data.local.RecipeDatabase
 import dagger.Module
@@ -25,7 +26,7 @@ object DatabaseModule {
             RecipeDatabase::class.java,
             "recipes.db"
         )
-            .addMigrations(RecipeDatabase.MIGRATION_1_2)
+            .addMigrations(RecipeDatabase.MIGRATION_1_2, RecipeDatabase.MIGRATION_2_3, RecipeDatabase.MIGRATION_3_4)
             .build()
     }
 
@@ -33,5 +34,11 @@ object DatabaseModule {
     @Singleton
     fun provideRecipeDao(database: RecipeDatabase): RecipeDao {
         return database.recipeDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideImportDebugDao(database: RecipeDatabase): ImportDebugDao {
+        return database.importDebugDao()
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportPaprikaUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportPaprikaUseCase.kt
@@ -149,7 +149,7 @@ class ImportPaprikaUseCase @Inject constructor(
             if (parseResult.isFailure) {
                 return null
             }
-            val parsed = parseResult.getOrThrow()
+            val parsed = parseResult.getOrThrow().result
 
             // Determine image URL:
             // 1. If Paprika has photo_data, we don't have a way to store raw image bytes in our model

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
@@ -9,6 +9,8 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.lionotter.recipes.SharedIntentViewModel
 import com.lionotter.recipes.ui.screens.addrecipe.AddRecipeScreen
+import com.lionotter.recipes.ui.screens.importdebug.ImportDebugDetailScreen
+import com.lionotter.recipes.ui.screens.importdebug.ImportDebugListScreen
 import com.lionotter.recipes.ui.screens.recipedetail.RecipeDetailScreen
 import com.lionotter.recipes.ui.screens.recipelist.RecipeListScreen
 import com.lionotter.recipes.ui.screens.settings.SettingsScreen
@@ -25,6 +27,10 @@ sealed class Screen(val route: String) {
             else "add-recipe"
     }
     object Settings : Screen("settings")
+    object ImportDebugList : Screen("import-debug")
+    object ImportDebugDetail : Screen("import-debug/{debugEntryId}") {
+        fun createRoute(debugEntryId: String) = "import-debug/$debugEntryId"
+    }
 }
 
 @Composable
@@ -126,7 +132,33 @@ fun NavGraph(
 
         composable(Screen.Settings.route) {
             SettingsScreen(
-                onBackClick = navigateBack
+                onBackClick = navigateBack,
+                onNavigateToImportDebug = {
+                    navController.navigate(Screen.ImportDebugList.route)
+                }
+            )
+        }
+
+        composable(Screen.ImportDebugList.route) {
+            ImportDebugListScreen(
+                onBackClick = navigateBack,
+                onEntryClick = { debugEntryId ->
+                    navController.navigate(Screen.ImportDebugDetail.createRoute(debugEntryId))
+                }
+            )
+        }
+
+        composable(
+            route = Screen.ImportDebugDetail.route,
+            arguments = listOf(
+                navArgument("debugEntryId") { type = NavType.StringType }
+            )
+        ) {
+            ImportDebugDetailScreen(
+                onBackClick = navigateBack,
+                onNavigateToRecipe = { recipeId ->
+                    navController.navigate(Screen.RecipeDetail.createRoute(recipeId))
+                }
             )
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugDetailScreen.kt
@@ -1,0 +1,475 @@
+package com.lionotter.recipes.ui.screens.importdebug
+
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lionotter.recipes.R
+import com.lionotter.recipes.data.local.ImportDebugEntity
+import com.lionotter.recipes.ui.components.RecipeTopAppBar
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+@Composable
+fun ImportDebugDetailScreen(
+    onBackClick: () -> Unit,
+    onNavigateToRecipe: ((String) -> Unit)? = null,
+    viewModel: ImportDebugDetailViewModel = hiltViewModel()
+) {
+    val entry by viewModel.entry.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            RecipeTopAppBar(
+                title = entry?.recipeName ?: entry?.sourceUrl ?: stringResource(R.string.import_debug_data),
+                onBackClick = onBackClick
+            )
+        }
+    ) { paddingValues ->
+        val currentEntry = entry
+        if (currentEntry == null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            DebugDetailContent(
+                entry = currentEntry,
+                onNavigateToRecipe = onNavigateToRecipe,
+                modifier = Modifier.padding(paddingValues)
+            )
+        }
+    }
+}
+
+@Composable
+private fun DebugDetailContent(
+    entry: ImportDebugEntity,
+    onNavigateToRecipe: ((String) -> Unit)?,
+    modifier: Modifier = Modifier
+) {
+    var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
+    val tabs = listOf(
+        stringResource(R.string.summary),
+        stringResource(R.string.original_content),
+        stringResource(R.string.cleaned_content),
+        stringResource(R.string.ai_output)
+    )
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TabRow(selectedTabIndex = selectedTabIndex) {
+            tabs.forEachIndexed { index, title ->
+                Tab(
+                    selected = selectedTabIndex == index,
+                    onClick = { selectedTabIndex = index },
+                    text = { Text(title) }
+                )
+            }
+        }
+
+        when (selectedTabIndex) {
+            0 -> SummaryTab(entry = entry, onNavigateToRecipe = onNavigateToRecipe)
+            1 -> HtmlContentTab(content = entry.originalHtml)
+            2 -> HtmlContentTab(content = entry.cleanedContent)
+            3 -> AiOutputTab(jsonString = entry.aiOutputJson)
+        }
+    }
+}
+
+@Composable
+private fun SummaryTab(
+    entry: ImportDebugEntity,
+    onNavigateToRecipe: ((String) -> Unit)?
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        SummaryRow(
+            label = stringResource(R.string.source_url_label),
+            value = entry.sourceUrl ?: stringResource(R.string.not_available)
+        )
+
+        HorizontalDivider()
+
+        SummaryRow(
+            label = stringResource(R.string.source_length_raw),
+            value = stringResource(R.string.characters_count, formatNumber(entry.originalLength))
+        )
+
+        SummaryRow(
+            label = stringResource(R.string.source_length_cleaned),
+            value = stringResource(R.string.characters_count, formatNumber(entry.cleanedLength))
+        )
+
+        HorizontalDivider()
+
+        SummaryRow(
+            label = stringResource(R.string.input_tokens_label),
+            value = if (entry.inputTokens != null) {
+                stringResource(R.string.tokens_count, formatNumber(entry.inputTokens))
+            } else {
+                stringResource(R.string.not_available)
+            }
+        )
+
+        SummaryRow(
+            label = stringResource(R.string.output_tokens_label),
+            value = if (entry.outputTokens != null) {
+                stringResource(R.string.tokens_count, formatNumber(entry.outputTokens))
+            } else {
+                stringResource(R.string.not_available)
+            }
+        )
+
+        HorizontalDivider()
+
+        SummaryRow(
+            label = stringResource(R.string.ai_model_label),
+            value = entry.aiModel ?: stringResource(R.string.not_available)
+        )
+
+        SummaryRow(
+            label = stringResource(R.string.thinking_mode_label),
+            value = if (entry.thinkingEnabled) stringResource(R.string.enabled) else stringResource(R.string.disabled)
+        )
+
+        if (entry.inputTokens != null && entry.outputTokens != null && entry.aiModel != null) {
+            SummaryRow(
+                label = stringResource(R.string.ai_cost_label),
+                value = estimateCost(entry.aiModel, entry.inputTokens, entry.outputTokens, entry.thinkingEnabled)
+            )
+        }
+
+        if (entry.durationMs != null) {
+            SummaryRow(
+                label = stringResource(R.string.ai_duration_label),
+                value = formatDuration(entry.durationMs)
+            )
+        }
+
+        HorizontalDivider()
+
+        if (entry.isError) {
+            SummaryRow(
+                label = stringResource(R.string.error_message_label),
+                value = entry.errorMessage ?: stringResource(R.string.not_available)
+            )
+        } else if (entry.recipeId != null) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.imported_recipe_label),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = entry.recipeName ?: entry.recipeId,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                if (onNavigateToRecipe != null) {
+                    TextButton(onClick = { onNavigateToRecipe(entry.recipeId) }) {
+                        Text(text = stringResource(R.string.recipe))
+                    }
+                }
+            }
+        }
+
+        SummaryRow(
+            label = "Timestamp",
+            value = formatTimestamp(entry.createdAt)
+        )
+    }
+}
+
+@Composable
+private fun SummaryRow(label: String, value: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Composable
+private fun HtmlContentTab(content: String?) {
+    if (content.isNullOrBlank()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(R.string.not_available),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        return
+    }
+
+    var showSource by rememberSaveable { mutableStateOf(false) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.End
+        ) {
+            TextButton(onClick = { showSource = !showSource }) {
+                Text(
+                    text = if (showSource) stringResource(R.string.show_rendered) else stringResource(R.string.show_source)
+                )
+            }
+        }
+
+        if (showSource) {
+            Text(
+                text = content,
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .horizontalScroll(rememberScrollState())
+                    .padding(16.dp)
+            )
+        } else {
+            val isHtml = content.contains("<") && content.contains(">")
+            if (isHtml) {
+                AndroidView(
+                    factory = { context ->
+                        WebView(context).apply {
+                            webViewClient = WebViewClient()
+                            settings.javaScriptEnabled = false
+                            loadDataWithBaseURL(null, content, "text/html", "UTF-8", null)
+                        }
+                    },
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                Text(
+                    text = content,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AiOutputTab(jsonString: String?) {
+    if (jsonString.isNullOrBlank()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(R.string.not_available),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        return
+    }
+
+    val jsonElement = remember(jsonString) {
+        try {
+            Json.parseToJsonElement(jsonString)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .horizontalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        if (jsonElement != null) {
+            JsonTreeView(element = jsonElement, depth = 0)
+        } else {
+            Text(
+                text = jsonString,
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace)
+            )
+        }
+    }
+}
+
+@Composable
+private fun JsonTreeView(
+    element: JsonElement,
+    depth: Int,
+    key: String? = null
+) {
+    val indent = "  ".repeat(depth)
+    when (element) {
+        is JsonObject -> {
+            if (key != null) {
+                Text(
+                    text = "$indent\"$key\": {",
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    color = MaterialTheme.colorScheme.primary
+                )
+            } else {
+                Text(
+                    text = "$indent{",
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace)
+                )
+            }
+            element.entries.forEach { (k, v) ->
+                JsonTreeView(element = v, depth = depth + 1, key = k)
+            }
+            Text(
+                text = "$indent}",
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace)
+            )
+        }
+        is JsonArray -> {
+            if (key != null) {
+                Text(
+                    text = "$indent\"$key\": [",
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    color = MaterialTheme.colorScheme.primary
+                )
+            } else {
+                Text(
+                    text = "$indent[",
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace)
+                )
+            }
+            element.forEach { item ->
+                JsonTreeView(element = item, depth = depth + 1)
+            }
+            Text(
+                text = "$indent]",
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace)
+            )
+        }
+        is JsonPrimitive -> {
+            val valueStr = element.toString()
+            val text = if (key != null) {
+                "$indent\"$key\": $valueStr"
+            } else {
+                "$indent$valueStr"
+            }
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = if (key != null) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.secondary
+            )
+        }
+        is JsonNull -> {
+            val text = if (key != null) "$indent\"$key\": null" else "${indent}null"
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private fun formatNumber(value: Long): String {
+    return String.format("%,d", value)
+}
+
+private fun formatNumber(value: Int): String {
+    return String.format("%,d", value)
+}
+
+private fun formatTimestamp(epochMillis: Long): String {
+    val instant = Instant.fromEpochMilliseconds(epochMillis)
+    val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
+    return "${localDateTime.year}-${localDateTime.monthNumber.toString().padStart(2, '0')}-${localDateTime.dayOfMonth.toString().padStart(2, '0')} ${localDateTime.hour.toString().padStart(2, '0')}:${localDateTime.minute.toString().padStart(2, '0')}:${localDateTime.second.toString().padStart(2, '0')}"
+}
+
+private fun estimateCost(model: String, inputTokens: Long, outputTokens: Long, thinkingEnabled: Boolean): String {
+    // Pricing per million tokens from https://platform.claude.com/docs/en/about-claude/pricing
+    val (inputCostPerM, outputCostPerM) = when {
+        model.contains("opus-4-5") || model.contains("opus-4-6") -> 5.0 to 25.0
+        model.contains("opus") -> 15.0 to 75.0
+        model.contains("sonnet") -> 3.0 to 15.0
+        model.contains("haiku-4-5") -> 1.0 to 5.0
+        model.contains("haiku-3-5") -> 0.80 to 4.0
+        model.contains("haiku") -> 0.25 to 1.25
+        else -> 3.0 to 15.0
+    }
+    val inputCost = (inputTokens / 1_000_000.0) * inputCostPerM
+    val outputCost = (outputTokens / 1_000_000.0) * outputCostPerM
+    val totalCost = inputCost + outputCost
+    return "$${String.format("%.4f", totalCost)}"
+}
+
+private fun formatDuration(durationMs: Long): String {
+    val seconds = durationMs / 1000.0
+    return if (seconds >= 60) {
+        val minutes = (seconds / 60).toInt()
+        val remainingSeconds = seconds % 60
+        "${minutes}m ${String.format("%.1f", remainingSeconds)}s"
+    } else {
+        "${String.format("%.1f", seconds)}s"
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugDetailViewModel.kt
@@ -1,0 +1,31 @@
+package com.lionotter.recipes.ui.screens.importdebug
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lionotter.recipes.data.local.ImportDebugEntity
+import com.lionotter.recipes.data.repository.ImportDebugRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ImportDebugDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val importDebugRepository: ImportDebugRepository
+) : ViewModel() {
+
+    private val entryId: String = checkNotNull(savedStateHandle["debugEntryId"])
+
+    private val _entry = MutableStateFlow<ImportDebugEntity?>(null)
+    val entry: StateFlow<ImportDebugEntity?> = _entry.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _entry.value = importDebugRepository.getDebugEntryById(entryId)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugListScreen.kt
@@ -1,0 +1,163 @@
+package com.lionotter.recipes.ui.screens.importdebug
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lionotter.recipes.R
+import com.lionotter.recipes.data.local.ImportDebugEntity
+import com.lionotter.recipes.ui.components.RecipeTopAppBar
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+@Composable
+fun ImportDebugListScreen(
+    onBackClick: () -> Unit,
+    onEntryClick: (String) -> Unit,
+    viewModel: ImportDebugListViewModel = hiltViewModel()
+) {
+    val entries by viewModel.debugEntries.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            RecipeTopAppBar(
+                title = stringResource(R.string.import_debug_data),
+                onBackClick = onBackClick
+            )
+        }
+    ) { paddingValues ->
+        if (entries.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.no_debug_entries),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = stringResource(R.string.no_debug_entries_description),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 16.dp)
+            ) {
+                items(entries, key = { it.id }) { entry ->
+                    DebugEntryCard(
+                        entry = entry,
+                        onClick = { onEntryClick(entry.id) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DebugEntryCard(
+    entry: ImportDebugEntity,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = if (entry.isError) {
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.errorContainer
+            )
+        } else {
+            CardDefaults.cardColors()
+        }
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = entry.recipeName ?: entry.sourceUrl ?: stringResource(R.string.unknown_import),
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = if (entry.isError) stringResource(R.string.debug_entry_error) else stringResource(R.string.debug_entry_success),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (entry.isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+                )
+            }
+
+            if (entry.sourceUrl != null) {
+                Text(
+                    text = entry.sourceUrl,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            Text(
+                text = formatTimestamp(entry.createdAt),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            if (entry.aiModel != null) {
+                Text(
+                    text = entry.aiModel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+private fun formatTimestamp(epochMillis: Long): String {
+    val instant = Instant.fromEpochMilliseconds(epochMillis)
+    val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
+    return "${localDateTime.year}-${localDateTime.monthNumber.toString().padStart(2, '0')}-${localDateTime.dayOfMonth.toString().padStart(2, '0')} ${localDateTime.hour.toString().padStart(2, '0')}:${localDateTime.minute.toString().padStart(2, '0')}"
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugListViewModel.kt
@@ -1,0 +1,24 @@
+package com.lionotter.recipes.ui.screens.importdebug
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lionotter.recipes.data.local.ImportDebugEntity
+import com.lionotter.recipes.data.repository.ImportDebugRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class ImportDebugListViewModel @Inject constructor(
+    importDebugRepository: ImportDebugRepository
+) : ViewModel() {
+
+    val debugEntries: StateFlow<List<ImportDebugEntity>> = importDebugRepository.getAllDebugEntries()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -32,12 +32,14 @@ import com.lionotter.recipes.ui.screens.settings.components.ApiKeySection
 import com.lionotter.recipes.ui.screens.settings.components.BackupRestoreSection
 import com.lionotter.recipes.ui.screens.settings.components.DisplaySection
 import com.lionotter.recipes.ui.screens.settings.components.GoogleDriveSection
+import com.lionotter.recipes.ui.screens.settings.components.ImportDebuggingSection
 import com.lionotter.recipes.ui.screens.settings.components.ModelSelectionSection
 import com.lionotter.recipes.ui.screens.settings.components.ThemeSection
 
 @Composable
 fun SettingsScreen(
     onBackClick: () -> Unit,
+    onNavigateToImportDebug: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
     googleDriveViewModel: GoogleDriveViewModel = hiltViewModel(),
     zipViewModel: ZipExportImportViewModel = hiltViewModel()
@@ -54,6 +56,7 @@ fun SettingsScreen(
     val lastSyncTimestamp by googleDriveViewModel.lastSyncTimestamp.collectAsStateWithLifecycle()
     val operationState by googleDriveViewModel.operationState.collectAsStateWithLifecycle()
     val zipOperationState by zipViewModel.operationState.collectAsStateWithLifecycle()
+    val importDebuggingEnabled by viewModel.importDebuggingEnabled.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
@@ -210,6 +213,15 @@ fun SettingsScreen(
                 onEnableSyncClick = googleDriveViewModel::enableSync,
                 onDisableSyncClick = googleDriveViewModel::disableSync,
                 onSyncNowClick = googleDriveViewModel::triggerSync
+            )
+
+            HorizontalDivider()
+
+            // Import Debugging Section
+            ImportDebuggingSection(
+                importDebuggingEnabled = importDebuggingEnabled,
+                onImportDebuggingChange = viewModel::setImportDebuggingEnabled,
+                onViewDebugDataClick = onNavigateToImportDebug
             )
 
             HorizontalDivider()

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.remote.AnthropicService
+import com.lionotter.recipes.data.repository.ImportDebugRepository
 import com.lionotter.recipes.domain.model.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +17,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    private val settingsDataStore: SettingsDataStore
+    private val settingsDataStore: SettingsDataStore,
+    private val importDebugRepository: ImportDebugRepository
 ) : ViewModel() {
 
     val apiKey: StateFlow<String?> = settingsDataStore.anthropicApiKey
@@ -52,6 +54,13 @@ class SettingsViewModel @Inject constructor(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = ThemeMode.AUTO
+        )
+
+    val importDebuggingEnabled: StateFlow<Boolean> = settingsDataStore.importDebuggingEnabled
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false
         )
 
     private val _apiKeyInput = MutableStateFlow("")
@@ -112,6 +121,15 @@ class SettingsViewModel @Inject constructor(
     fun setThemeMode(mode: ThemeMode) {
         viewModelScope.launch {
             settingsDataStore.setThemeMode(mode)
+        }
+    }
+
+    fun setImportDebuggingEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsDataStore.setImportDebuggingEnabled(enabled)
+            if (!enabled) {
+                importDebugRepository.deleteAllDebugEntries()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ImportDebuggingSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ImportDebuggingSection.kt
@@ -1,0 +1,61 @@
+package com.lionotter.recipes.ui.screens.settings.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.lionotter.recipes.R
+
+@Composable
+fun ImportDebuggingSection(
+    importDebuggingEnabled: Boolean,
+    onImportDebuggingChange: (Boolean) -> Unit,
+    onViewDebugDataClick: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = stringResource(R.string.import_debugging),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.import_debugging),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    text = stringResource(R.string.import_debugging_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = importDebuggingEnabled,
+                onCheckedChange = onImportDebuggingChange
+            )
+        }
+
+        if (importDebuggingEnabled) {
+            Button(
+                onClick = onViewDebugDataClick,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = stringResource(R.string.view_import_debug_data))
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,4 +150,37 @@
     <string name="paprika_import_cancelled">Import Cancelled</string>
     <string name="paprika_import_cancelled_result">Successfully imported %1$d recipes before cancellation</string>
     <string name="done">Done</string>
+
+    <!-- Import Debugging -->
+    <string name="import_debugging">Import Debugging</string>
+    <string name="import_debugging_description">Save detailed information about recipe imports for debugging purposes.</string>
+    <string name="view_import_debug_data">View Import Debug Data</string>
+    <string name="import_debug_data">Import Debug Data</string>
+    <string name="no_debug_entries">No import debug entries yet</string>
+    <string name="no_debug_entries_description">Import a recipe with debugging enabled to see debug data here.</string>
+    <string name="debug_entry_success">Success</string>
+    <string name="debug_entry_error">Error</string>
+    <string name="summary">Summary</string>
+    <string name="original_content">Original Content</string>
+    <string name="cleaned_content">Cleaned Content</string>
+    <string name="ai_output">AI Output</string>
+    <string name="source_url_label">Source URL</string>
+    <string name="source_length_raw">Source Length (Raw)</string>
+    <string name="source_length_cleaned">Source Length (Cleaned)</string>
+    <string name="input_tokens_label">Input Tokens</string>
+    <string name="output_tokens_label">Output Tokens</string>
+    <string name="ai_model_label">AI Model</string>
+    <string name="thinking_mode_label">Thinking Mode</string>
+    <string name="ai_cost_label">Estimated Cost</string>
+    <string name="ai_duration_label">Response Time</string>
+    <string name="imported_recipe_label">Imported Recipe</string>
+    <string name="error_message_label">Error</string>
+    <string name="characters_count">%1$s characters</string>
+    <string name="tokens_count">%1$s tokens</string>
+    <string name="enabled">Enabled</string>
+    <string name="disabled">Disabled</string>
+    <string name="show_source">Show Source</string>
+    <string name="show_rendered">Show Rendered</string>
+    <string name="not_available">N/A</string>
+    <string name="unknown_import">Unknown Import</string>
 </resources>

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package com.lionotter.recipes.ui.screens.settings
 import app.cash.turbine.test
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.remote.AnthropicService
+import com.lionotter.recipes.data.repository.ImportDebugRepository
 import com.lionotter.recipes.domain.model.ThemeMode
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -27,6 +28,7 @@ import org.junit.Test
 class SettingsViewModelTest {
 
     private lateinit var settingsDataStore: SettingsDataStore
+    private lateinit var importDebugRepository: ImportDebugRepository
     private lateinit var viewModel: SettingsViewModel
     private val testDispatcher = StandardTestDispatcher()
 
@@ -35,17 +37,20 @@ class SettingsViewModelTest {
     private val extendedThinkingFlow = MutableStateFlow(true)
     private val keepScreenOnFlow = MutableStateFlow(true)
     private val themeModeFlow = MutableStateFlow(ThemeMode.AUTO)
+    private val importDebuggingEnabledFlow = MutableStateFlow(false)
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         settingsDataStore = mockk()
+        importDebugRepository = mockk()
         every { settingsDataStore.anthropicApiKey } returns apiKeyFlow
         every { settingsDataStore.aiModel } returns aiModelFlow
         every { settingsDataStore.extendedThinkingEnabled } returns extendedThinkingFlow
         every { settingsDataStore.keepScreenOn } returns keepScreenOnFlow
         every { settingsDataStore.themeMode } returns themeModeFlow
-        viewModel = SettingsViewModel(settingsDataStore)
+        every { settingsDataStore.importDebuggingEnabled } returns importDebuggingEnabledFlow
+        viewModel = SettingsViewModel(settingsDataStore, importDebugRepository)
     }
 
     @After

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -69,11 +69,22 @@ app: {
       detail: RecipeDetailScreen
       add: AddRecipeScreen
       settings: SettingsScreen
+      import_debug_list: {
+        label: ImportDebugListScreen
+        tooltip: "Lists all import debug entries with status, timestamp, and model info. Only accessible when import debugging is enabled."
+      }
+      import_debug_detail: {
+        label: ImportDebugDetailScreen
+        tooltip: "Tabbed detail view for a single import debug entry. Tabs: Summary (URL, lengths, tokens, model, cost, recipe link), Original Content (HTML with source toggle), Cleaned Content (HTML with source toggle), AI Output (JSON tree view)."
+      }
 
       list -> detail: tap recipe
       list -> add: tap +
       list -> settings: tap gear
       add -> settings: no API key
+      settings -> import_debug_list: view debug data
+      import_debug_list -> import_debug_detail: tap entry
+      import_debug_detail -> detail: view recipe
     }
 
     components: {
@@ -109,6 +120,14 @@ app: {
         label: ZipExportImportViewModel
         tooltip: "Manages ZIP file export/import operations via WorkManager. Handles file picker integration and work status observation."
       }
+      import_debug_list_vm: {
+        label: ImportDebugListViewModel
+        tooltip: "Observes all import debug entries from the repository as a StateFlow."
+      }
+      import_debug_detail_vm: {
+        label: ImportDebugDetailViewModel
+        tooltip: "Loads a single import debug entry by ID from SavedStateHandle."
+      }
     }
 
     state: {
@@ -129,6 +148,8 @@ app: {
     screens.settings -> viewmodels.settings_vm
     screens.settings -> viewmodels.drive_vm: sign in/out
     screens.settings -> viewmodels.zip_vm: backup/restore
+    screens.import_debug_list -> viewmodels.import_debug_list_vm
+    screens.import_debug_detail -> viewmodels.import_debug_detail_vm
     viewmodels.list_vm -> state.in_progress_mgr: observes
     viewmodels.add_vm -> state.in_progress_mgr: adds entries
     state.in_progress_mgr -> background.worker: observes status
@@ -298,6 +319,7 @@ app: {
     }
 
     usecases.import -> usecases.parse_html: uses
+    usecases.parse_html -> data.repository.import_debug_repo: save debug data
     usecases.sync_drive -> util.serializer: serialize
     usecases.export_zip -> util.serializer: serialize
     usecases.import_zip -> util.serializer: deserialize
@@ -318,6 +340,10 @@ app: {
       }
 
       repo: RecipeRepository
+      import_debug_repo: {
+        label: ImportDebugRepository
+        tooltip: "CRUD operations for import debug entries. Supports listing all, getting by ID, saving, and deleting all entries."
+      }
     }
 
     local: {
@@ -344,13 +370,20 @@ app: {
       }
       dao: RecipeDao
       entity: RecipeEntity
+      import_debug_dao: ImportDebugDao
+      import_debug_entity: {
+        label: ImportDebugEntity
+        tooltip: "Room entity storing import debug data: source URL, original/cleaned HTML, AI output JSON, token counts, model, error info, linked recipe ID"
+      }
       settings: {
         label: SettingsDataStore
-        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, extended thinking enabled, keep screen on, theme mode, Google Drive sync enabled/folder/last sync timestamp)"
+        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, extended thinking enabled, keep screen on, theme mode, import debugging enabled, Google Drive sync enabled/folder/last sync timestamp)"
       }
 
       dao -> room
       entity -> room
+      import_debug_dao -> room
+      import_debug_entity -> room
       settings -> datastore: non-sensitive settings
       settings -> encrypted_prefs: API key
     }
@@ -393,6 +426,7 @@ app: {
 
     repository.repo -> local.dao
     repository.repo -> local.settings
+    repository.import_debug_repo -> local.import_debug_dao
   }
 
   # Performance
@@ -444,6 +478,9 @@ app: {
   ui.viewmodels.zip_vm -> background.worker.zip_export_worker: export
   ui.viewmodels.zip_vm -> background.worker.zip_import_worker: import
   ui.viewmodels.zip_vm -> background.worker.work_ext: observe export/import
+  ui.viewmodels.settings_vm -> data.repository.import_debug_repo: delete debug data
+  ui.viewmodels.import_debug_list_vm -> data.repository.import_debug_repo: list entries
+  ui.viewmodels.import_debug_detail_vm -> data.repository.import_debug_repo: get entry
   background.worker.import_worker -> domain.usecases.import: execute
   background.worker.paprika_import_worker -> domain.usecases.import_paprika: execute
   background.worker.sync_worker -> domain.usecases.sync_drive: execute


### PR DESCRIPTION
## Summary
- Adds a new "Import Debugging" setting (default off) that saves detailed information about each recipe import to a dedicated Room database table
- Includes a debug data list screen and a detail screen with four tabs: Summary, Original Content, Cleaned Content, and AI Output
- Disabling import debugging deletes all stored debug data

## Changes

### Data Layer
- **ImportDebugEntity**: New Room entity storing source URL, original/cleaned HTML, AI output JSON, token counts, model, cost, error info, and linked recipe ID
- **ImportDebugDao**: DAO with CRUD operations for debug entries
- **ImportDebugRepository**: Repository wrapping the DAO
- **RecipeDatabase**: Bumped to version 3 with migration adding the `import_debug` table
- **DatabaseModule**: Registers migration 2→3 and provides `ImportDebugDao`
- **SettingsDataStore**: Added `importDebuggingEnabled` preference
- **AnthropicService**: Returns `ParseResultWithUsage` including input/output token counts and raw AI JSON output

### Domain Layer
- **ParseHtmlUseCase**: When debugging is enabled, saves debug entries on both success and failure
- **ImportPaprikaUseCase**: Updated to handle the new `ParseResultWithUsage` return type

### UI Layer
- **SettingsScreen/ViewModel**: Added Import Debugging toggle section with button to view debug data
- **ImportDebuggingSection**: Settings component with switch and "View Import Debug Data" button (only visible when enabled)
- **ImportDebugListScreen**: Lists all debug entries with status indicators, timestamps, and model info
- **ImportDebugDetailScreen**: Tabbed detail view with:
  - **Summary**: Source URL, raw/cleaned lengths, token counts, model, thinking mode, estimated cost, link to imported recipe or error message
  - **Original Content**: HTML view with source toggle
  - **Cleaned Content**: HTML view with source toggle
  - **AI Output**: JSON tree view with all nodes expanded
- **NavGraph**: Added routes for `import-debug` list and `import-debug/{id}` detail

### Other
- Added string resources for all new UI text
- Updated architecture diagram (`docs/architecture.d2`)

## Test plan
- [ ] Enable Import Debugging in Settings
- [ ] Import a recipe from a URL and verify debug entry appears in the list
- [ ] Tap debug entry to view detail screen with all four tabs
- [ ] Verify Summary tab shows correct metrics (URL, lengths, tokens, model, cost)
- [ ] Verify Original Content tab shows HTML and source toggle works
- [ ] Verify Cleaned Content tab shows cleaned text and source toggle works  
- [ ] Verify AI Output tab shows the parsed JSON tree
- [ ] Verify "View Recipe" link navigates to the imported recipe
- [ ] Import a recipe that fails and verify error debug entry is created
- [ ] Disable Import Debugging and verify all debug data is deleted
- [ ] Re-enable and verify the list is empty

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)