### PR TITLE
feat: make text selectable, add share and copy buttons

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugDetailScreen.kt
@@ -10,10 +10,16 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
@@ -29,7 +35,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -340,19 +348,49 @@ private fun AiOutputTab(jsonString: String?) {
         }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .horizontalScroll(rememberScrollState())
-            .padding(16.dp)
-    ) {
-        if (jsonElement != null) {
-            JsonTreeView(element = jsonElement, depth = 0)
-        } else {
-            Text(
-                text = jsonString,
-                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace)
+    val clipboardManager = LocalClipboardManager.current
+    val prettyJson = remember(jsonString) {
+        try {
+            val json = Json { prettyPrint = true }
+            val element = json.parseToJsonElement(jsonString)
+            json.encodeToString(JsonElement.serializer(), element)
+        } catch (e: Exception) {
+            jsonString
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .horizontalScroll(rememberScrollState())
+                .padding(16.dp)
+        ) {
+            if (jsonElement != null) {
+                JsonTreeView(element = jsonElement, depth = 0)
+            } else {
+                Text(
+                    text = jsonString,
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace)
+                )
+            }
+        }
+
+        IconButton(
+            onClick = { clipboardManager.setText(AnnotatedString(prettyJson)) },
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(8.dp)
+                .size(40.dp),
+            colors = IconButtonDefaults.iconButtonColors(
+                containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
+                contentColor = MaterialTheme.colorScheme.onSurface
+            )
+        ) {
+            Icon(
+                imageVector = Icons.Default.ContentCopy,
+                contentDescription = stringResource(R.string.copy_json)
             )
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -1,10 +1,12 @@
 package com.lionotter.recipes.ui.screens.recipedetail
 
+import android.content.Intent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.CircularProgressIndicator
@@ -21,11 +23,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lionotter.recipes.R
+import com.lionotter.recipes.domain.util.RecipeMarkdownFormatter
 import com.lionotter.recipes.ui.components.DeleteConfirmationDialog
 import com.lionotter.recipes.ui.components.RecipeTopAppBar
 import com.lionotter.recipes.ui.screens.recipedetail.components.RecipeContent
@@ -75,6 +79,8 @@ fun RecipeDetailScreen(
         )
     }
 
+    val context = LocalContext.current
+
     Scaffold(
         topBar = {
             RecipeTopAppBar(
@@ -82,6 +88,22 @@ fun RecipeDetailScreen(
                 onBackClick = onBackClick,
                 actions = {
                     if (recipe != null) {
+                        IconButton(onClick = {
+                            val markdown = RecipeMarkdownFormatter.format(recipe!!)
+                            val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_SUBJECT, recipe!!.name)
+                                putExtra(Intent.EXTRA_TEXT, markdown)
+                            }
+                            context.startActivity(
+                                Intent.createChooser(shareIntent, null)
+                            )
+                        }) {
+                            Icon(
+                                imageVector = Icons.Default.Share,
+                                contentDescription = stringResource(R.string.share_recipe)
+                            )
+                        }
                         IconButton(onClick = { viewModel.toggleFavorite() }) {
                             Icon(
                                 imageVector = if (recipe!!.isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/theme/Theme.kt
@@ -2,6 +2,7 @@ package com.lionotter.recipes.ui.theme
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -88,7 +89,10 @@ fun LionOtterTheme(
 
     MaterialTheme(
         colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
+        typography = Typography
+    ) {
+        SelectionContainer {
+            content()
+        }
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
 
     <!-- Recipe Detail Screen -->
     <string name="recipe">Recipe</string>
+    <string name="share_recipe">Share recipe</string>
     <string name="delete_recipe_action">Delete recipe</string>
     <string name="ingredients">Ingredients</string>
     <string name="instructions">Instructions</string>
@@ -183,4 +184,5 @@
     <string name="show_rendered">Show Rendered</string>
     <string name="not_available">N/A</string>
     <string name="unknown_import">Unknown Import</string>
+    <string name="copy_json">Copy JSON</string>
 </resources>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -66,7 +66,10 @@ app: {
       }
 
       list: RecipeListScreen
-      detail: RecipeDetailScreen
+      detail: {
+        label: RecipeDetailScreen
+        tooltip: "Displays recipe details with share button (exports as Markdown via Android share sheet). All text is selectable."
+      }
       add: AddRecipeScreen
       settings: SettingsScreen
       import_debug_list: {
@@ -75,7 +78,7 @@ app: {
       }
       import_debug_detail: {
         label: ImportDebugDetailScreen
-        tooltip: "Tabbed detail view for a single import debug entry. Tabs: Summary (URL, lengths, tokens, model, cost, recipe link), Original Content (HTML with source toggle), Cleaned Content (HTML with source toggle), AI Output (JSON tree view)."
+        tooltip: "Tabbed detail view for a single import debug entry. Tabs: Summary (URL, lengths, tokens, model, cost, recipe link), Original Content (HTML with source toggle), Cleaned Content (HTML with source toggle), AI Output (JSON tree view with copy-to-clipboard button). All text is selectable."
       }
 
       list -> detail: tap recipe


### PR DESCRIPTION
## Summary
- Wraps the entire app in Compose `SelectionContainer` so all text is selectable and copyable by default across all screens
- Adds a share button (share icon) to the recipe detail top bar that exports the full recipe as Markdown via Android's standard share sheet
- Adds a floating semi-transparent copy-to-clipboard button on the AI Output (JSON) tab of the import debug detail screen

## Test plan
- [ ] Open a recipe and verify all text (title, story, ingredients, instructions) can be long-pressed to select and copy
- [ ] Tap the share button on a recipe and verify the share sheet opens with the recipe formatted as Markdown
- [ ] Open an import debug entry's AI Output tab and verify the copy button appears in the top right
- [ ] Tap the copy button and verify the pretty-printed JSON is copied to the clipboard
- [ ] Verify text is selectable on the import debug summary and content tabs
- [ ] Verify that interactive elements (buttons, chips, clickable text) still work correctly with SelectionContainer enabled

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)