### PR TITLE
feat: optimize AI recipe import schema to reduce output tokens

### DIFF
--- a/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/4.json
+++ b/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/4.json
@@ -1,0 +1,240 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "8c9fc477b361d83109808f8a148a8a61",
+    "entities": [
+      {
+        "tableName": "recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sourceUrl` TEXT, `story` TEXT, `servings` INTEGER, `prepTime` TEXT, `cookTime` TEXT, `totalTime` TEXT, `ingredientSectionsJson` TEXT NOT NULL, `instructionSectionsJson` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `imageUrl` TEXT, `originalHtml` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "story",
+            "columnName": "story",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "prepTime",
+            "columnName": "prepTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cookTime",
+            "columnName": "cookTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalTime",
+            "columnName": "totalTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ingredientSectionsJson",
+            "columnName": "ingredientSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructionSectionsJson",
+            "columnName": "instructionSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "import_debug",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceUrl` TEXT, `originalHtml` TEXT, `cleanedContent` TEXT, `aiOutputJson` TEXT, `originalLength` INTEGER NOT NULL, `cleanedLength` INTEGER NOT NULL, `inputTokens` INTEGER, `outputTokens` INTEGER, `aiModel` TEXT, `thinkingEnabled` INTEGER NOT NULL, `recipeId` TEXT, `recipeName` TEXT, `errorMessage` TEXT, `isError` INTEGER NOT NULL, `durationMs` INTEGER, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cleanedContent",
+            "columnName": "cleanedContent",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "aiOutputJson",
+            "columnName": "aiOutputJson",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalLength",
+            "columnName": "originalLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanedLength",
+            "columnName": "cleanedLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "aiModel",
+            "columnName": "aiModel",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thinkingEnabled",
+            "columnName": "thinkingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recipeName",
+            "columnName": "recipeName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isError",
+            "columnName": "isError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8c9fc477b361d83109808f8a148a8a61')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeEntity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeEntity.kt
@@ -2,7 +2,6 @@ package com.lionotter.recipes.data.local
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.lionotter.recipes.domain.model.IngredientSection
 import com.lionotter.recipes.domain.model.InstructionSection
 import com.lionotter.recipes.domain.model.Recipe
 import kotlinx.datetime.Instant
@@ -28,7 +27,6 @@ data class RecipeEntity(
     val isFavorite: Boolean = false
 ) {
     fun toRecipe(
-        ingredientSections: List<IngredientSection>,
         instructionSections: List<InstructionSection>,
         tags: List<String>
     ): Recipe {
@@ -41,7 +39,6 @@ data class RecipeEntity(
             prepTime = prepTime,
             cookTime = cookTime,
             totalTime = totalTime,
-            ingredientSections = ingredientSections,
             instructionSections = instructionSections,
             tags = tags,
             imageUrl = imageUrl,
@@ -54,7 +51,6 @@ data class RecipeEntity(
     companion object {
         fun fromRecipe(
             recipe: Recipe,
-            ingredientSectionsJson: String,
             instructionSectionsJson: String,
             tagsJson: String,
             originalHtml: String? = null
@@ -68,7 +64,7 @@ data class RecipeEntity(
                 prepTime = recipe.prepTime,
                 cookTime = recipe.cookTime,
                 totalTime = recipe.totalTime,
-                ingredientSectionsJson = ingredientSectionsJson,
+                ingredientSectionsJson = "[]",
                 instructionSectionsJson = instructionSectionsJson,
                 tagsJson = tagsJson,
                 imageUrl = recipe.imageUrl,

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -157,95 +157,50 @@ For successful parsing, return:
   "success": true,
   "recipe": {
     "name": "Recipe Name",
-    "story": "Brief summary of the recipe's story/background (1-2 sentences, or null if none)",
+    "story": "Brief summary (1-2 sentences)",
     "servings": 4,
     "prepTime": "15 minutes",
     "cookTime": "30 minutes",
     "totalTime": "45 minutes",
-    "ingredientSections": [
-      {
-        "name": "For the cake",
-        "ingredients": [
-          {
-            "name": "all-purpose flour",
-            "notes": "sifted",
-            "alternates": [],
-            "amounts": [
-              {"value": 2.0, "unit": "cups", "type": "volume", "isDefault": true},
-              {"value": 250.0, "unit": "grams", "type": "weight", "isDefault": false}
-            ]
-          },
-          {
-            "name": "eggs",
-            "notes": "room temperature",
-            "alternates": [],
-            "amounts": [
-              {"value": 3.0, "unit": "large", "type": "count", "isDefault": true}
-            ]
-          },
-          {
-            "name": "kosher salt",
-            "notes": null,
-            "alternates": [
-              {
-                "name": "table salt",
-                "notes": null,
-                "alternates": [],
-                "amounts": [
-                  {"value": 0.5, "unit": "teaspoons", "type": "volume", "isDefault": true}
-                ],
-                "optional": false
-              }
-            ],
-            "amounts": [
-              {"value": 1.0, "unit": "teaspoons", "type": "volume", "isDefault": true},
-              {"value": 6.0, "unit": "grams", "type": "weight", "isDefault": false}
-            ],
-            "optional": false
-          }
-        ]
-      }
-    ],
     "instructionSections": [
       {
         "name": "Make the cake",
         "steps": [
           {
             "stepNumber": 1,
-            "instruction": "Preheat oven.",
-            "ingredientReferences": [],
-            "ingredients": [],
-            "optional": false
+            "instruction": "Preheat oven to 350°F."
           },
           {
             "stepNumber": 2,
-            "instruction": "Mix together.",
-            "ingredientReferences": [
-              {"ingredientName": "all-purpose flour", "quantity": 2.0, "unit": "cups"},
-              {"ingredientName": "sugar", "quantity": 1.0, "unit": "cup"}
-            ],
-            "optional": false,
+            "instruction": "Mix dry ingredients together.",
             "ingredients": [
+              { "name": "all-purpose flour", "amount": { "value": 2.0, "unit": "cup" }, "density": 0.51 },
+              { "name": "granulated sugar", "amount": { "value": 1.0, "unit": "cup" }, "density": 0.84 },
+              { "name": "baking powder", "amount": { "value": 1.0, "unit": "tsp" }, "density": 0.81 }
+            ]
+          },
+          {
+            "stepNumber": 3,
+            "instruction": "Add wet ingredients and mix until combined.",
+            "ingredients": [
+              { "name": "eggs", "amount": { "value": 3.0 }, "notes": "room temperature" },
+              { "name": "milk", "amount": { "value": 1.0, "unit": "cup" }, "density": 0.96 },
               {
-                "name": "all-purpose flour",
-                "notes": "sifted",
-                "alternates": [],
-                "amounts": [
-                  {"value": 2.0, "unit": "cups", "type": "volume", "isDefault": true},
-                  {"value": 250.0, "unit": "grams", "type": "weight", "isDefault": false}
-                ],
-                "optional": false
-              },
-              {
-                "name": "sugar",
-                "notes": null,
-                "alternates": [],
-                "amounts": [
-                  {"value": 1.0, "unit": "cup", "type": "volume", "isDefault": true},
-                  {"value": 200.0, "unit": "grams", "type": "weight", "isDefault": false}
-                ],
-                "optional": false
+                "name": "kosher salt",
+                "amount": { "value": 1.0, "unit": "tsp" },
+                "density": 0.54,
+                "alternates": [
+                  { "name": "table salt", "amount": { "value": 0.5, "unit": "tsp" }, "density": 1.22 }
+                ]
               }
+            ]
+          },
+          {
+            "stepNumber": 5,
+            "instruction": "Form into a ball, coat with olive oil, and place in a covered bowl.",
+            "yields": 2,
+            "ingredients": [
+              { "name": "olive oil", "amount": { "value": 1.0, "unit": "tsp" }, "density": 0.84 }
             ]
           }
         ]
@@ -267,42 +222,67 @@ Return an error response when:
 - The content is garbled, corrupted, or not in a readable format
 - You cannot confidently identify the recipe name, ingredients, or instructions
 
-Guidelines:
-- If the recipe has distinct sections (e.g., cake and frosting), create separate ingredientSections and instructionSections
-- If there's only one section, use null for the section name
-- IMPORTANT: For each ingredient, provide BOTH volume and weight measurements when possible:
-  * Use the "amounts" array to provide multiple measurement options
-  * Mark the original recipe measurement with "isDefault": true
-  * Provide approximate conversions to other measurement types (volume to weight or vice versa)
-  * Use your knowledge of common ingredient densities for conversions (e.g., flour ~125g/cup, sugar ~200g/cup, butter ~227g/cup)
-  * For items that are counted (eggs, onions, etc.), use "type": "count" and only include that measurement
-  * For ingredients marked "to taste", "as needed", or similar non-quantifiable amounts: leave the "amounts" array EMPTY and put the phrase in the "notes" field instead (e.g., notes: "to taste")
-- IMPORTANT: Always spell out units fully (use "cups" not "c", "tablespoons" not "tbsp", "teaspoons" not "tsp", "grams" not "g", "ounces" not "oz", etc.)
-- Extract quantities as decimal numbers (e.g., 0.5 for 1/2, 0.25 for 1/4)
-- Include notes for ingredient modifications like "room temperature", "divided", etc.
-- For ingredient alternates/substitutes (indicated by "or" in the ingredient list):
-  * Extract the first option as the main ingredient
-  * Parse subsequent options (separated by "or") as alternates in the alternates array
-  * Apply the same amounts structure to each alternate
-- For ingredientReferences, include the specific quantity used in that step if mentioned
-- IMPORTANT: For each instruction step, extract the ingredients used in that step:
-  * Populate the "ingredients" array with only the ingredients used in that step
-  * Include the same full ingredient data structure (name, amounts with volume/weight options, notes, alternates) as the top-level ingredients
-  * If an ingredient is used in multiple steps, include it in each step's ingredients array
-  * Rephrase the instruction text to remove quantity mentions since they'll be displayed separately from the ingredient list
-  * Example: "Add 2 cups flour" becomes "Add flour", with quantities shown in the ingredients array
-- IMPORTANT: Mark ingredients and steps as optional when appropriate:
-  * Set "optional": true for ingredients that are clearly marked as optional in the recipe (e.g., "optional garnish", "if desired", "for garnish")
-  * Set "optional": true for instruction steps that are purely decorative or enhancement steps (e.g., "Garnish with fresh herbs if desired")
-  * Set "optional": false for all ingredients and steps that are essential to the recipe
-- Generate relevant tags based on the recipe type, cuisine, dietary restrictions, etc.
-- Keep the story brief - just the essence of any background provided
-- Return null for fields that aren't present in the source
-- Always include the alternates array (empty array if no alternates)
-- Always include the amounts array (with at least one measurement, or empty if the ingredient is "to taste", "as needed", etc.)
-- Always include the ingredients array for each step (empty array if no ingredients used in that step)
-- Always include the optional field for ingredients (default to false if not specified)
-- Always include the optional field for steps (default to false if not specified)
+INGREDIENT FORMAT:
+- Each ingredient has a single "amount" object with "value" (decimal number) and "unit" (string).
+- For countable items (eggs, lemons, cloves), omit the "unit" field — just include "value".
+- Include a "density" field (g/mL) so the app can convert between volume and weight.
+- For countable items, omit "density".
+- If the recipe provides both weight and volume, prefer weight.
+- Estimate density for uncommon ingredients — cooking precision doesn't require exactness.
+
+SUPPORTED UNITS (use exactly these strings):
+- Weight: mg, g, kg, oz, lb
+- Volume: mL, L, tsp, tbsp, cup, fl_oz, pint, quart, gal
+- Count: omit unit field
+
+INGREDIENT DENSITIES (g/mL — use these when known):
+water 0.96, milk 0.96, buttermilk 0.96, heavy cream 0.96, yogurt 0.96, sour cream 0.96,
+vegetable oil 0.84, olive oil 0.84, coconut oil 0.96, butter 0.96,
+lard 0.96, vegetable shortening 0.78,
+honey 1.42, molasses 1.44, corn syrup 1.32, maple syrup 1.32,
+all-purpose flour 0.51, bread flour 0.51, cake flour 0.51, whole wheat flour 0.48,
+pastry flour 0.45, almond flour 0.41, coconut flour 0.54, rye flour 0.45,
+cornmeal 0.58, cornstarch 0.47, cocoa powder 0.35, tapioca starch 0.48,
+potato starch 0.64,
+granulated sugar 0.84, brown sugar (packed) 0.90, confectioners sugar 0.48,
+demerara sugar 0.93, turbinado sugar 0.76,
+table salt 1.22, kosher salt (Diamond Crystal) 0.54, kosher salt (Morton's) 1.08,
+baking powder 0.81, baking soda 1.22,
+peanut butter 1.14, cream cheese 0.96,
+oats (old-fashioned) 0.38, oats (rolled) 0.48,
+chocolate chips 0.72, walnuts (chopped) 0.48, pecans (chopped) 0.48,
+breadcrumbs (dried) 0.47, panko 0.21,
+vanilla extract 0.95, espresso powder 0.47
+
+OMIT NULL/EMPTY/DEFAULT FIELDS:
+- Do NOT include fields with null values, empty arrays, or default values.
+- "optional" defaults to false — omit when false.
+- "yields" defaults to 1 — omit when 1.
+- "alternates" defaults to empty — omit when empty.
+- "notes" defaults to null — omit when null.
+- Section "name" defaults to null — omit for single-section recipes.
+
+YIELDS FIELD:
+- If a step is performed multiple times (e.g., "form 2 dough balls"), set "yields" to the count (e.g., 2).
+- Ingredient amounts are per-iteration; the app multiplies by yields for totals.
+- Default is 1 — omit if the step is done once.
+
+INGREDIENTS LIVE ON STEPS ONLY:
+- There is NO global ingredient list. All ingredients belong to the step that uses them.
+- If an ingredient is split across steps (e.g., 1/2 cup water in step 1 and 1/2 cup water in step 3), list it on each step separately with its per-step amount. The app aggregates totals.
+- Include the same ingredient name consistently across steps for correct aggregation.
+
+ADDITIONAL GUIDELINES:
+- If the recipe has distinct sections (e.g., cake and frosting), create separate instructionSections.
+- Extract quantities as decimal numbers (e.g., 0.5 for 1/2, 0.25 for 1/4).
+- Include "notes" for ingredient modifications like "room temperature", "divided", etc.
+- For ingredient alternates/substitutes (indicated by "or" in the recipe): extract the first option as the main ingredient, subsequent options as "alternates" array items.
+- For ingredients marked "to taste", "as needed", or similar: omit "amount" entirely and put the phrase in "notes".
+- Rephrase instruction text to remove quantity mentions — quantities are shown separately from the ingredient list. Example: "Add 2 cups flour" → instruction: "Add flour", with amount on the ingredient.
+- Mark optional ingredients and steps with "optional": true (for garnish, decorative, "if desired" items).
+- Generate relevant tags based on recipe type, cuisine, dietary restrictions, etc.
+- Keep the story brief — just the essence of any background provided.
+- Return null for fields that aren't present in the source.
 """.trimIndent()
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/RecipeParseResult.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/RecipeParseResult.kt
@@ -1,6 +1,5 @@
 package com.lionotter.recipes.data.remote
 
-import com.lionotter.recipes.domain.model.IngredientSection
 import com.lionotter.recipes.domain.model.InstructionSection
 import kotlinx.serialization.Serializable
 
@@ -12,7 +11,6 @@ data class RecipeParseResult(
     val prepTime: String? = null,
     val cookTime: String? = null,
     val totalTime: String? = null,
-    val ingredientSections: List<IngredientSection>,
     val instructionSections: List<InstructionSection>,
     val tags: List<String>,
     val imageUrl: String? = null

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
@@ -3,7 +3,6 @@ package com.lionotter.recipes.data.repository
 import android.util.Log
 import com.lionotter.recipes.data.local.RecipeDao
 import com.lionotter.recipes.data.local.RecipeEntity
-import com.lionotter.recipes.domain.model.IngredientSection
 import com.lionotter.recipes.domain.model.InstructionSection
 import com.lionotter.recipes.domain.model.Recipe
 import kotlinx.coroutines.flow.Flow
@@ -65,7 +64,6 @@ class RecipeRepository @Inject constructor(
     suspend fun saveRecipe(recipe: Recipe, originalHtml: String? = null) {
         val entity = RecipeEntity.fromRecipe(
             recipe = recipe,
-            ingredientSectionsJson = json.encodeToString(recipe.ingredientSections),
             instructionSectionsJson = json.encodeToString(recipe.instructionSections),
             tagsJson = json.encodeToString(recipe.tags),
             originalHtml = originalHtml
@@ -105,9 +103,6 @@ class RecipeRepository @Inject constructor(
         val failedFields = mutableListOf<String>()
         fun onError(field: String): () -> Unit = { failedFields.add(field) }
 
-        val ingredientSections: List<IngredientSection> = safeDecodeJson(
-            entity.ingredientSectionsJson, entity.name, entity.id, "ingredients", emptyList(), onError("ingredients")
-        )
         val instructionSections: List<InstructionSection> = safeDecodeJson(
             entity.instructionSectionsJson, entity.name, entity.id, "instructions", emptyList(), onError("instructions")
         )
@@ -126,7 +121,6 @@ class RecipeRepository @Inject constructor(
         }
 
         return entity.toRecipe(
-            ingredientSections = ingredientSections,
             instructionSections = instructionSections,
             tags = tags
         )
@@ -137,9 +131,6 @@ class RecipeRepository @Inject constructor(
      * Logs errors but cannot emit to the error flow.
      */
     private fun entityToRecipe(entity: RecipeEntity): Recipe {
-        val ingredientSections: List<IngredientSection> = safeDecodeJson(
-            entity.ingredientSectionsJson, entity.name, entity.id, "ingredients", emptyList()
-        )
         val instructionSections: List<InstructionSection> = safeDecodeJson(
             entity.instructionSectionsJson, entity.name, entity.id, "instructions", emptyList()
         )
@@ -148,7 +139,6 @@ class RecipeRepository @Inject constructor(
         )
 
         return entity.toRecipe(
-            ingredientSections = ingredientSections,
             instructionSections = instructionSections,
             tags = tags
         )

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportPaprikaUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportPaprikaUseCase.kt
@@ -167,7 +167,6 @@ class ImportPaprikaUseCase @Inject constructor(
                 prepTime = parsed.prepTime,
                 cookTime = parsed.cookTime,
                 totalTime = parsed.totalTime,
-                ingredientSections = parsed.ingredientSections,
                 instructionSections = parsed.instructionSections,
                 tags = parsed.tags,
                 imageUrl = imageUrl,

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -123,7 +123,6 @@ class ParseHtmlUseCase @Inject constructor(
             prepTime = parsed.prepTime,
             cookTime = parsed.cookTime,
             totalTime = parsed.totalTime,
-            ingredientSections = parsed.ingredientSections,
             instructionSections = parsed.instructionSections,
             tags = parsed.tags,
             imageUrl = extractedImageUrl,

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -42,8 +42,7 @@ fun RecipeDetailScreen(
     val recipe by viewModel.recipe.collectAsStateWithLifecycle()
     val scale by viewModel.scale.collectAsStateWithLifecycle()
     val measurementPreference by viewModel.measurementPreference.collectAsStateWithLifecycle()
-    val hasMultipleMeasurementTypes by viewModel.hasMultipleMeasurementTypes.collectAsStateWithLifecycle()
-    val availableMeasurementTypes by viewModel.availableMeasurementTypes.collectAsStateWithLifecycle()
+    val supportsConversion by viewModel.supportsConversion.collectAsStateWithLifecycle()
     val usedInstructionIngredients by viewModel.usedInstructionIngredients.collectAsStateWithLifecycle()
     val globalIngredientUsage by viewModel.globalIngredientUsage.collectAsStateWithLifecycle()
     val highlightedInstructionStep by viewModel.highlightedInstructionStep.collectAsStateWithLifecycle()
@@ -139,8 +138,7 @@ fun RecipeDetailScreen(
                 onScaleDecrement = viewModel::decrementScale,
                 measurementPreference = measurementPreference,
                 onMeasurementPreferenceChange = viewModel::setMeasurementPreference,
-                showMeasurementToggle = hasMultipleMeasurementTypes,
-                availableMeasurementTypes = availableMeasurementTypes,
+                showMeasurementToggle = supportsConversion,
                 usedInstructionIngredients = usedInstructionIngredients,
                 globalIngredientUsage = globalIngredientUsage,
                 onToggleInstructionIngredient = viewModel::toggleInstructionIngredientUsed,

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/MeasurementToggle.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/MeasurementToggle.kt
@@ -18,28 +18,18 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.MeasurementPreference
-import com.lionotter.recipes.domain.model.MeasurementType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun MeasurementToggle(
     selectedPreference: MeasurementPreference,
-    onPreferenceChange: (MeasurementPreference) -> Unit,
-    availableMeasurementTypes: Set<MeasurementType>
+    onPreferenceChange: (MeasurementPreference) -> Unit
 ) {
-    // Determine which options to show based on available measurement types
-    val hasVolume = MeasurementType.VOLUME in availableMeasurementTypes
-    val hasWeight = MeasurementType.WEIGHT in availableMeasurementTypes
-
-    // Build the list of options to display
-    val options = buildList {
-        add(MeasurementPreference.ORIGINAL to stringResource(R.string.original))
-        if (hasVolume) add(MeasurementPreference.VOLUME to stringResource(R.string.volume))
-        if (hasWeight) add(MeasurementPreference.WEIGHT to stringResource(R.string.weight))
-    }
-
-    // Only show toggle if there are at least 2 options (Original plus at least one conversion)
-    if (options.size < 2) return
+    val options = listOf(
+        MeasurementPreference.DEFAULT to stringResource(R.string.original),
+        MeasurementPreference.VOLUME to stringResource(R.string.volume),
+        MeasurementPreference.WEIGHT to stringResource(R.string.weight)
+    )
 
     Card(
         colors = CardDefaults.cardColors(

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
@@ -35,7 +35,6 @@ import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.IngredientUsageStatus
 import com.lionotter.recipes.domain.model.InstructionIngredientKey
 import com.lionotter.recipes.domain.model.MeasurementPreference
-import com.lionotter.recipes.domain.model.MeasurementType
 import com.lionotter.recipes.domain.model.Recipe
 import com.lionotter.recipes.ui.screens.recipedetail.HighlightedInstructionStep
 
@@ -49,7 +48,6 @@ fun RecipeContent(
     measurementPreference: MeasurementPreference,
     onMeasurementPreferenceChange: (MeasurementPreference) -> Unit,
     showMeasurementToggle: Boolean,
-    availableMeasurementTypes: Set<MeasurementType>,
     usedInstructionIngredients: Set<InstructionIngredientKey>,
     globalIngredientUsage: Map<String, IngredientUsageStatus>,
     onToggleInstructionIngredient: (Int, Int, Int) -> Unit,
@@ -120,17 +118,16 @@ fun RecipeContent(
                 onDecrement = onScaleDecrement
             )
 
-            // Measurement toggle (only shown if recipe has multiple measurement types)
+            // Measurement toggle (only shown if recipe has ingredients with density for conversion)
             if (showMeasurementToggle) {
                 Spacer(modifier = Modifier.height(16.dp))
                 MeasurementToggle(
                     selectedPreference = measurementPreference,
-                    onPreferenceChange = onMeasurementPreferenceChange,
-                    availableMeasurementTypes = availableMeasurementTypes
+                    onPreferenceChange = onMeasurementPreferenceChange
                 )
             }
 
-            // Ingredients
+            // Ingredients (aggregated from steps)
             Spacer(modifier = Modifier.height(24.dp))
             Text(
                 text = stringResource(R.string.ingredients),
@@ -138,7 +135,8 @@ fun RecipeContent(
                 fontWeight = FontWeight.Bold
             )
             Spacer(modifier = Modifier.height(12.dp))
-            recipe.ingredientSections.forEach { section ->
+            val aggregatedSections = recipe.aggregateIngredients()
+            aggregatedSections.forEach { section ->
                 IngredientSectionContent(
                     section = section,
                     scale = scale,

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/model/IngredientTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/model/IngredientTest.kt
@@ -2,25 +2,19 @@ package com.lionotter.recipes.domain.model
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class IngredientTest {
 
-    private fun volumeMeasurement(value: Double, unit: String, isDefault: Boolean = true) =
-        Measurement(value = value, unit = unit, type = MeasurementType.VOLUME, isDefault = isDefault)
-
-    private fun weightMeasurement(value: Double, unit: String, isDefault: Boolean = false) =
-        Measurement(value = value, unit = unit, type = MeasurementType.WEIGHT, isDefault = isDefault)
-
-    private fun countMeasurement(value: Double, unit: String, isDefault: Boolean = true) =
-        Measurement(value = value, unit = unit, type = MeasurementType.COUNT, isDefault = isDefault)
-
     @Test
     fun `format with all fields`() {
         val ingredient = Ingredient(
             name = "flour",
-            amounts = listOf(volumeMeasurement(2.0, "cups")),
+            amount = Amount(value = 2.0, unit = "cup"),
+            density = 0.51,
             notes = "sifted"
         )
         assertEquals("2 cups flour, sifted", ingredient.format())
@@ -30,22 +24,23 @@ class IngredientTest {
     fun `format without notes`() {
         val ingredient = Ingredient(
             name = "sugar",
-            amounts = listOf(volumeMeasurement(1.0, "cup"))
+            amount = Amount(value = 1.0, unit = "cup"),
+            density = 0.84
         )
         assertEquals("1 cup sugar", ingredient.format())
     }
 
     @Test
-    fun `format with count measurement`() {
+    fun `format count ingredient without unit`() {
         val ingredient = Ingredient(
             name = "eggs",
-            amounts = listOf(countMeasurement(3.0, "large"))
+            amount = Amount(value = 3.0)
         )
-        assertEquals("3 larges eggs", ingredient.format())
+        assertEquals("3 eggs", ingredient.format())
     }
 
     @Test
-    fun `format without amounts`() {
+    fun `format without amount`() {
         val ingredient = Ingredient(
             name = "salt",
             notes = "to taste"
@@ -54,12 +49,10 @@ class IngredientTest {
     }
 
     @Test
-    fun `format with null value in measurement (to taste)`() {
+    fun `format with null value in amount`() {
         val ingredient = Ingredient(
             name = "salt",
-            amounts = listOf(
-                Measurement(value = null, unit = "to taste", type = MeasurementType.VOLUME, isDefault = true)
-            ),
+            amount = Amount(value = null, unit = "tsp"),
             notes = "to taste"
         )
         assertEquals("salt, to taste", ingredient.format())
@@ -69,7 +62,8 @@ class IngredientTest {
     fun `format with scaling`() {
         val ingredient = Ingredient(
             name = "butter",
-            amounts = listOf(volumeMeasurement(1.0, "cup"))
+            amount = Amount(value = 1.0, unit = "cup"),
+            density = 0.96
         )
         assertEquals("2 cups butter", ingredient.format(scale = 2.0))
     }
@@ -78,7 +72,8 @@ class IngredientTest {
     fun `format half quantity`() {
         val ingredient = Ingredient(
             name = "milk",
-            amounts = listOf(volumeMeasurement(0.5, "cup"))
+            amount = Amount(value = 0.5, unit = "cup"),
+            density = 0.96
         )
         assertEquals("1/2 cup milk", ingredient.format())
     }
@@ -87,16 +82,18 @@ class IngredientTest {
     fun `format quarter quantity`() {
         val ingredient = Ingredient(
             name = "vanilla",
-            amounts = listOf(volumeMeasurement(0.25, "teaspoon"))
+            amount = Amount(value = 0.25, unit = "tsp"),
+            density = 0.95
         )
-        assertEquals("1/4 teaspoon vanilla", ingredient.format())
+        assertEquals("1/4 tsp vanilla", ingredient.format())
     }
 
     @Test
     fun `format mixed number`() {
         val ingredient = Ingredient(
             name = "flour",
-            amounts = listOf(volumeMeasurement(2.5, "cups"))
+            amount = Amount(value = 2.5, unit = "cup"),
+            density = 0.51
         )
         assertEquals("2 1/2 cups flour", ingredient.format())
     }
@@ -105,7 +102,8 @@ class IngredientTest {
     fun `format third quantity`() {
         val ingredient = Ingredient(
             name = "oil",
-            amounts = listOf(volumeMeasurement(0.33, "cup"))
+            amount = Amount(value = 0.33, unit = "cup"),
+            density = 0.84
         )
         assertEquals("1/3 cup oil", ingredient.format())
     }
@@ -114,7 +112,8 @@ class IngredientTest {
     fun `format two thirds quantity`() {
         val ingredient = Ingredient(
             name = "water",
-            amounts = listOf(volumeMeasurement(0.66, "cup"))
+            amount = Amount(value = 0.66, unit = "cup"),
+            density = 0.96
         )
         assertEquals("2/3 cup water", ingredient.format())
     }
@@ -123,7 +122,8 @@ class IngredientTest {
     fun `format three quarters quantity`() {
         val ingredient = Ingredient(
             name = "cream",
-            amounts = listOf(volumeMeasurement(0.75, "cup"))
+            amount = Amount(value = 0.75, unit = "cup"),
+            density = 0.96
         )
         assertEquals("3/4 cup cream", ingredient.format())
     }
@@ -132,9 +132,9 @@ class IngredientTest {
     fun `format scaling with fractions`() {
         val ingredient = Ingredient(
             name = "sugar",
-            amounts = listOf(volumeMeasurement(1.0, "cup"))
+            amount = Amount(value = 1.0, unit = "cup"),
+            density = 0.84
         )
-        // 1 cup * 0.5 = 0.5 cup = 1/2 cup
         assertEquals("1/2 cup sugar", ingredient.format(scale = 0.5))
     }
 
@@ -142,23 +142,26 @@ class IngredientTest {
     fun `format with alternates`() {
         val alternate = Ingredient(
             name = "table salt",
-            amounts = listOf(volumeMeasurement(0.5, "teaspoon"))
+            amount = Amount(value = 0.5, unit = "tsp"),
+            density = 1.22
         )
         val ingredient = Ingredient(
             name = "kosher salt",
-            amounts = listOf(volumeMeasurement(1.0, "teaspoon")),
+            amount = Amount(value = 1.0, unit = "tsp"),
+            density = 0.54,
             alternates = listOf(alternate)
         )
-        assertEquals("1 teaspoon kosher salt", ingredient.format())
+        assertEquals("1 tsp kosher salt", ingredient.format())
     }
 
     @Test
     fun `alternate formats correctly with scaling`() {
         val alternate = Ingredient(
             name = "table salt",
-            amounts = listOf(volumeMeasurement(0.5, "teaspoon"))
+            amount = Amount(value = 0.5, unit = "tsp"),
+            density = 1.22
         )
-        assertEquals("1 teaspoon table salt", alternate.format(scale = 2.0))
+        assertEquals("1 tsp table salt", alternate.format(scale = 2.0))
     }
 
     @Test
@@ -166,91 +169,145 @@ class IngredientTest {
         val alternates = listOf(
             Ingredient(
                 name = "table salt",
-                amounts = listOf(volumeMeasurement(0.5, "teaspoon"))
+                amount = Amount(value = 0.5, unit = "tsp"),
+                density = 1.22
             ),
             Ingredient(
                 name = "sea salt",
-                amounts = listOf(volumeMeasurement(0.75, "teaspoon"))
+                amount = Amount(value = 0.75, unit = "tsp")
             )
         )
         val ingredient = Ingredient(
             name = "kosher salt",
-            amounts = listOf(volumeMeasurement(1.0, "teaspoon")),
+            amount = Amount(value = 1.0, unit = "tsp"),
+            density = 0.54,
             alternates = alternates
         )
-        assertEquals("1 teaspoon kosher salt", ingredient.format())
+        assertEquals("1 tsp kosher salt", ingredient.format())
         assertEquals(2, ingredient.alternates.size)
     }
 
     @Test
-    fun `format with volume preference when both available`() {
+    fun `format with volume preference converts weight to volume`() {
         val ingredient = Ingredient(
             name = "flour",
-            amounts = listOf(
-                volumeMeasurement(2.0, "cups", isDefault = true),
-                weightMeasurement(250.0, "grams", isDefault = false)
-            )
+            amount = Amount(value = 250.0, unit = "g"),
+            density = 0.51
         )
-        assertEquals("2 cups flour", ingredient.format(preference = MeasurementPreference.VOLUME))
-        assertEquals("250 grams flour", ingredient.format(preference = MeasurementPreference.WEIGHT))
-        assertEquals("2 cups flour", ingredient.format(preference = MeasurementPreference.ORIGINAL))
+        val formatted = ingredient.format(preference = MeasurementPreference.VOLUME)
+        assertTrue(formatted.contains("flour"))
+        assertTrue(formatted.contains("cup"))
     }
 
     @Test
-    fun `format with weight preference when both available`() {
+    fun `format with weight preference converts volume to weight`() {
         val ingredient = Ingredient(
-            name = "sugar",
-            amounts = listOf(
-                weightMeasurement(200.0, "grams", isDefault = true),
-                volumeMeasurement(1.0, "cup", isDefault = false)
-            )
+            name = "flour",
+            amount = Amount(value = 2.0, unit = "cup"),
+            density = 0.51
         )
-        assertEquals("1 cup sugar", ingredient.format(preference = MeasurementPreference.VOLUME))
-        assertEquals("200 grams sugar", ingredient.format(preference = MeasurementPreference.WEIGHT))
-        assertEquals("200 grams sugar", ingredient.format(preference = MeasurementPreference.ORIGINAL))
+        val formatted = ingredient.format(preference = MeasurementPreference.WEIGHT)
+        assertTrue(formatted.contains("flour"))
+        assertTrue(formatted.contains("g") || formatted.contains("oz"))
     }
 
     @Test
-    fun `format falls back to default when preferred type not available`() {
+    fun `format with default preference returns original amount`() {
+        val ingredient = Ingredient(
+            name = "flour",
+            amount = Amount(value = 2.0, unit = "cup"),
+            density = 0.51
+        )
+        assertEquals("2 cups flour", ingredient.format(preference = MeasurementPreference.DEFAULT))
+    }
+
+    @Test
+    fun `format falls back to original when no density`() {
         val ingredient = Ingredient(
             name = "eggs",
-            amounts = listOf(countMeasurement(3.0, "large"))
+            amount = Amount(value = 3.0)
         )
-        // Should fall back to default (count) when volume or weight requested
-        assertEquals("3 larges eggs", ingredient.format(preference = MeasurementPreference.VOLUME))
-        assertEquals("3 larges eggs", ingredient.format(preference = MeasurementPreference.WEIGHT))
+        assertEquals("3 eggs", ingredient.format(preference = MeasurementPreference.VOLUME))
+        assertEquals("3 eggs", ingredient.format(preference = MeasurementPreference.WEIGHT))
     }
 
     @Test
-    fun `hasMultipleMeasurementTypes returns true when multiple types`() {
+    fun `supportsConversion returns true when density and unit present`() {
         val ingredient = Ingredient(
             name = "flour",
-            amounts = listOf(
-                volumeMeasurement(2.0, "cups"),
-                weightMeasurement(250.0, "grams")
-            )
+            amount = Amount(value = 2.0, unit = "cup"),
+            density = 0.51
         )
-        assertTrue(ingredient.hasMultipleMeasurementTypes())
+        assertTrue(ingredient.supportsConversion())
     }
 
     @Test
-    fun `hasMultipleMeasurementTypes returns false when single type`() {
+    fun `supportsConversion returns false when no density`() {
         val ingredient = Ingredient(
             name = "flour",
-            amounts = listOf(volumeMeasurement(2.0, "cups"))
+            amount = Amount(value = 2.0, unit = "cup")
         )
-        assertFalse(ingredient.hasMultipleMeasurementTypes())
+        assertFalse(ingredient.supportsConversion())
     }
 
     @Test
-    fun `availableMeasurementTypes returns correct set`() {
+    fun `supportsConversion returns false when no unit (count item)`() {
+        val ingredient = Ingredient(
+            name = "eggs",
+            amount = Amount(value = 3.0),
+            density = 1.0
+        )
+        assertFalse(ingredient.supportsConversion())
+    }
+
+    @Test
+    fun `supportsConversion returns false when no amount`() {
+        val ingredient = Ingredient(
+            name = "salt",
+            density = 1.22
+        )
+        assertFalse(ingredient.supportsConversion())
+    }
+
+    @Test
+    fun `getDisplayAmount returns scaled amount for default preference`() {
         val ingredient = Ingredient(
             name = "flour",
-            amounts = listOf(
-                volumeMeasurement(2.0, "cups"),
-                weightMeasurement(250.0, "grams")
-            )
+            amount = Amount(value = 2.0, unit = "cup"),
+            density = 0.51
         )
-        assertEquals(setOf(MeasurementType.VOLUME, MeasurementType.WEIGHT), ingredient.availableMeasurementTypes())
+        val result = ingredient.getDisplayAmount(scale = 2.0, preference = MeasurementPreference.DEFAULT)
+        assertNotNull(result)
+        assertEquals(4.0, result!!.value!!, 0.01)
+        assertEquals("cup", result.unit)
+    }
+
+    @Test
+    fun `getDisplayAmount returns null when no amount`() {
+        val ingredient = Ingredient(name = "salt")
+        assertNull(ingredient.getDisplayAmount())
+    }
+
+    @Test
+    fun `weight units are recognized`() {
+        val weightUnits = listOf("mg", "g", "kg", "oz", "lb")
+        for (unit in weightUnits) {
+            assertEquals("Unit $unit should be WEIGHT", UnitCategory.WEIGHT, unitType(unit))
+        }
+    }
+
+    @Test
+    fun `volume units are recognized`() {
+        val volumeUnits = listOf("mL", "L", "tsp", "tbsp", "cup", "fl_oz", "pint", "quart", "gal")
+        for (unit in volumeUnits) {
+            assertEquals("Unit $unit should be VOLUME", UnitCategory.VOLUME, unitType(unit))
+        }
+    }
+
+    @Test
+    fun `unknown units return null type`() {
+        assertNull(unitType("large"))
+        assertNull(unitType("pinch"))
+        assertNull(unitType("bunch"))
     }
 }


### PR DESCRIPTION
## Summary
- Removes the global ingredient list from the AI output schema; ingredients now live exclusively on instruction steps, eliminating duplication and reducing output tokens
- Replaces multiple `Measurement` objects per ingredient with a single `Amount` (value + unit) plus `density` (g/mL) for app-side unit conversion between weight and volume
- Adds `yields` field to `InstructionStep` for repeated operations (e.g. "make 12 cookies" → `yields: 12`)
- Includes a ~40-entry common ingredient density reference table and supported units list in the AI prompt
- Instructs AI to omit null/empty/default fields to further reduce output tokens
- Adds app-side unit conversion logic (volume↔weight using density) with smart unit selection for cooking-friendly values
- Aggregates ingredients from steps for display via `Recipe.aggregateIngredients()`

## Changes
- **Domain model** (`Recipe.kt`): Removed `ingredientSections` from Recipe, removed `Measurement`/`MeasurementType`/`IngredientReference` types, added `Amount`, `UnitCategory`, unit conversion utilities, `aggregateIngredients()` method
- **AI prompt** (`AnthropicService.kt`): New JSON schema with ingredients on steps only, density table, supported units, `yields` documentation, omit-defaults instruction
- **Data layer** (`RecipeParseResult.kt`, `RecipeEntity.kt`, `RecipeRepository.kt`): Removed `ingredientSections` handling, `ingredientSectionsJson` column always `"[]"`
- **Use cases** (`CalculateIngredientUsageUseCase.kt`, `ParseHtmlUseCase.kt`, `ImportPaprikaUseCase.kt`): Updated to derive ingredient data from steps with `yields` multiplier
- **UI** (`RecipeDetailViewModel.kt`, `RecipeDetailScreen.kt`, `RecipeContent.kt`, `MeasurementToggle.kt`): `supportsConversion` replaces `hasMultipleMeasurementTypes`, `MeasurementPreference.DEFAULT` replaces `ORIGINAL`
- **Tests**: All 4 test files updated to match new data model

## Test plan
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes (all unit tests)
- [x] `./gradlew lintDebug` passes
- [ ] Manual test: import a recipe from URL and verify ingredient display, scaling, and unit conversion work correctly
- [ ] Manual test: verify measurement toggle (Default/Volume/Weight) works with density-based conversion
- [ ] Manual test: verify ingredient usage tracking still works with aggregated ingredients

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)