### PR TITLE
feat: add unit system settings for volume and weight

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import com.lionotter.recipes.data.remote.AnthropicService
 import com.lionotter.recipes.domain.model.ThemeMode
+import com.lionotter.recipes.domain.model.UnitSystem
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -38,6 +39,8 @@ class SettingsDataStore @Inject constructor(
         val GOOGLE_DRIVE_SYNC_FOLDER_NAME = stringPreferencesKey("google_drive_sync_folder_name")
         val GOOGLE_DRIVE_LAST_SYNC_TIMESTAMP = stringPreferencesKey("google_drive_last_sync_timestamp")
         val IMPORT_DEBUGGING_ENABLED = booleanPreferencesKey("import_debugging_enabled")
+        val VOLUME_UNIT_SYSTEM = stringPreferencesKey("volume_unit_system")
+        val WEIGHT_UNIT_SYSTEM = stringPreferencesKey("weight_unit_system")
         const val ENCRYPTED_API_KEY = "anthropic_api_key"
     }
 
@@ -99,6 +102,24 @@ class SettingsDataStore @Inject constructor(
 
     val googleDriveLastSyncTimestamp: Flow<String?> = context.dataStore.data.map { preferences ->
         preferences[Keys.GOOGLE_DRIVE_LAST_SYNC_TIMESTAMP]
+    }
+
+    val volumeUnitSystem: Flow<UnitSystem> = context.dataStore.data.map { preferences ->
+        val value = preferences[Keys.VOLUME_UNIT_SYSTEM]
+        if (value != null) {
+            try { UnitSystem.valueOf(value) } catch (_: IllegalArgumentException) { UnitSystem.CUSTOMARY }
+        } else {
+            UnitSystem.CUSTOMARY
+        }
+    }
+
+    val weightUnitSystem: Flow<UnitSystem> = context.dataStore.data.map { preferences ->
+        val value = preferences[Keys.WEIGHT_UNIT_SYSTEM]
+        if (value != null) {
+            try { UnitSystem.valueOf(value) } catch (_: IllegalArgumentException) { UnitSystem.METRIC }
+        } else {
+            UnitSystem.METRIC
+        }
     }
 
     val importDebuggingEnabled: Flow<Boolean> = context.dataStore.data.map { preferences ->
@@ -168,6 +189,18 @@ class SettingsDataStore @Inject constructor(
     suspend fun setGoogleDriveLastSyncTimestamp(timestamp: String) {
         context.dataStore.edit { preferences ->
             preferences[Keys.GOOGLE_DRIVE_LAST_SYNC_TIMESTAMP] = timestamp
+        }
+    }
+
+    suspend fun setVolumeUnitSystem(system: UnitSystem) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.VOLUME_UNIT_SYSTEM] = system.name
+        }
+    }
+
+    suspend fun setWeightUnitSystem(system: UnitSystem) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.WEIGHT_UNIT_SYSTEM] = system.name
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/UnitSystem.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/UnitSystem.kt
@@ -1,0 +1,9 @@
+package com.lionotter.recipes.domain.model
+
+/**
+ * User preference for which unit system to use for a given measurement category.
+ */
+enum class UnitSystem {
+    METRIC,
+    CUSTOMARY
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -47,6 +47,8 @@ fun RecipeDetailScreen(
     val globalIngredientUsage by viewModel.globalIngredientUsage.collectAsStateWithLifecycle()
     val highlightedInstructionStep by viewModel.highlightedInstructionStep.collectAsStateWithLifecycle()
     val keepScreenOn by viewModel.keepScreenOn.collectAsStateWithLifecycle()
+    val volumeUnitSystem by viewModel.volumeUnitSystem.collectAsStateWithLifecycle()
+    val weightUnitSystem by viewModel.weightUnitSystem.collectAsStateWithLifecycle()
 
     // Keep screen on while viewing a recipe if the setting is enabled
     val view = LocalView.current
@@ -144,6 +146,8 @@ fun RecipeDetailScreen(
                 onToggleInstructionIngredient = viewModel::toggleInstructionIngredientUsed,
                 highlightedInstructionStep = highlightedInstructionStep,
                 onToggleHighlightedInstruction = viewModel::toggleHighlightedInstructionStep,
+                volumeUnitSystem = volumeUnitSystem,
+                weightUnitSystem = weightUnitSystem,
                 modifier = Modifier.padding(paddingValues)
             )
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
@@ -9,6 +9,7 @@ import com.lionotter.recipes.domain.model.IngredientUsageStatus
 import com.lionotter.recipes.domain.model.InstructionIngredientKey
 import com.lionotter.recipes.domain.model.MeasurementPreference
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.model.UnitSystem
 import com.lionotter.recipes.domain.model.createInstructionIngredientKey
 import com.lionotter.recipes.domain.usecase.CalculateIngredientUsageUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -63,6 +64,20 @@ class RecipeDetailViewModel @Inject constructor(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = true
+        )
+
+    val volumeUnitSystem: StateFlow<UnitSystem> = settingsDataStore.volumeUnitSystem
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = UnitSystem.CUSTOMARY
+        )
+
+    val weightUnitSystem: StateFlow<UnitSystem> = settingsDataStore.weightUnitSystem
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = UnitSystem.METRIC
         )
 
     private val _scale = MutableStateFlow(1.0)
@@ -151,10 +166,19 @@ class RecipeDetailViewModel @Inject constructor(
         recipe,
         _usedInstructionIngredients,
         _scale,
-        _measurementPreference
-    ) { recipe, usedKeys, scale, preference ->
+        _measurementPreference,
+        volumeUnitSystem,
+        weightUnitSystem
+    ) { args ->
+        @Suppress("UNCHECKED_CAST")
+        val recipe = args[0] as Recipe?
+        val usedKeys = args[1] as Set<InstructionIngredientKey>
+        val scale = args[2] as Double
+        val preference = args[3] as MeasurementPreference
+        val volSystem = args[4] as UnitSystem
+        val wtSystem = args[5] as UnitSystem
         if (recipe == null) return@combine emptyMap()
-        calculateIngredientUsage.execute(recipe, usedKeys, scale, preference)
+        calculateIngredientUsage.execute(recipe, usedKeys, scale, preference, volSystem, wtSystem)
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/IngredientSectionContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/IngredientSectionContent.kt
@@ -18,6 +18,7 @@ import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.IngredientSection
 import com.lionotter.recipes.domain.model.IngredientUsageStatus
 import com.lionotter.recipes.domain.model.MeasurementPreference
+import com.lionotter.recipes.domain.model.UnitSystem
 import com.lionotter.recipes.util.pluralize
 import com.lionotter.recipes.util.singularize
 
@@ -26,7 +27,9 @@ internal fun IngredientSectionContent(
     section: IngredientSection,
     scale: Double,
     measurementPreference: MeasurementPreference,
-    globalIngredientUsage: Map<String, IngredientUsageStatus>
+    globalIngredientUsage: Map<String, IngredientUsageStatus>,
+    volumeUnitSystem: UnitSystem = UnitSystem.CUSTOMARY,
+    weightUnitSystem: UnitSystem = UnitSystem.METRIC
 ) {
     Column {
         section.name?.let { name ->
@@ -57,7 +60,7 @@ internal fun IngredientSectionContent(
                 )
                 Column {
                     Text(
-                        text = ingredient.format(scale, measurementPreference),
+                        text = ingredient.format(scale, measurementPreference, volumeUnitSystem, weightUnitSystem),
                         style = MaterialTheme.typography.bodyLarge,
                         textDecoration = if (isFullyUsed) TextDecoration.LineThrough else TextDecoration.None,
                         color = if (isFullyUsed) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.onSurface
@@ -92,7 +95,7 @@ internal fun IngredientSectionContent(
                     )
                     Column {
                         Text(
-                            text = alternate.format(scale, measurementPreference),
+                            text = alternate.format(scale, measurementPreference, volumeUnitSystem, weightUnitSystem),
                             style = MaterialTheme.typography.bodyMedium,
                             textDecoration = if (altIsFullyUsed) TextDecoration.LineThrough else TextDecoration.None,
                             color = if (altIsFullyUsed) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/InstructionSectionContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/InstructionSectionContent.kt
@@ -24,6 +24,7 @@ import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.InstructionIngredientKey
 import com.lionotter.recipes.domain.model.InstructionSection
 import com.lionotter.recipes.domain.model.MeasurementPreference
+import com.lionotter.recipes.domain.model.UnitSystem
 import com.lionotter.recipes.domain.model.createInstructionIngredientKey
 import com.lionotter.recipes.ui.screens.recipedetail.HighlightedInstructionStep
 
@@ -36,7 +37,9 @@ internal fun InstructionSectionContent(
     usedInstructionIngredients: Set<InstructionIngredientKey>,
     onToggleIngredient: (Int, Int, Int) -> Unit,
     highlightedInstructionStep: HighlightedInstructionStep?,
-    onToggleHighlightedInstruction: (Int, Int) -> Unit
+    onToggleHighlightedInstruction: (Int, Int) -> Unit,
+    volumeUnitSystem: UnitSystem = UnitSystem.CUSTOMARY,
+    weightUnitSystem: UnitSystem = UnitSystem.METRIC
 ) {
     Column {
         section.name?.let { name ->
@@ -128,7 +131,7 @@ internal fun InstructionSectionContent(
                                     modifier = Modifier.padding(end = 8.dp)
                                 )
                                 Text(
-                                    text = ingredient.format(scale, measurementPreference),
+                                    text = ingredient.format(scale, measurementPreference, volumeUnitSystem, weightUnitSystem),
                                     style = MaterialTheme.typography.bodyMedium,
                                     textDecoration = if (isUsed) TextDecoration.LineThrough else TextDecoration.None,
                                     color = if (isUsed) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.onSurface
@@ -151,7 +154,7 @@ internal fun InstructionSectionContent(
                                         modifier = Modifier.padding(end = 8.dp)
                                     )
                                     Text(
-                                        text = alternate.format(scale, measurementPreference),
+                                        text = alternate.format(scale, measurementPreference, volumeUnitSystem, weightUnitSystem),
                                         style = MaterialTheme.typography.bodySmall,
                                         textDecoration = if (isUsed) TextDecoration.LineThrough else TextDecoration.None,
                                         color = if (isUsed) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
@@ -36,6 +36,7 @@ import com.lionotter.recipes.domain.model.IngredientUsageStatus
 import com.lionotter.recipes.domain.model.InstructionIngredientKey
 import com.lionotter.recipes.domain.model.MeasurementPreference
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.model.UnitSystem
 import com.lionotter.recipes.ui.screens.recipedetail.HighlightedInstructionStep
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -53,6 +54,8 @@ fun RecipeContent(
     onToggleInstructionIngredient: (Int, Int, Int) -> Unit,
     highlightedInstructionStep: HighlightedInstructionStep?,
     onToggleHighlightedInstruction: (Int, Int) -> Unit,
+    volumeUnitSystem: UnitSystem = UnitSystem.CUSTOMARY,
+    weightUnitSystem: UnitSystem = UnitSystem.METRIC,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -141,7 +144,9 @@ fun RecipeContent(
                     section = section,
                     scale = scale,
                     measurementPreference = measurementPreference,
-                    globalIngredientUsage = globalIngredientUsage
+                    globalIngredientUsage = globalIngredientUsage,
+                    volumeUnitSystem = volumeUnitSystem,
+                    weightUnitSystem = weightUnitSystem
                 )
             }
 
@@ -162,7 +167,9 @@ fun RecipeContent(
                     usedInstructionIngredients = usedInstructionIngredients,
                     onToggleIngredient = onToggleInstructionIngredient,
                     highlightedInstructionStep = highlightedInstructionStep,
-                    onToggleHighlightedInstruction = onToggleHighlightedInstruction
+                    onToggleHighlightedInstruction = onToggleHighlightedInstruction,
+                    volumeUnitSystem = volumeUnitSystem,
+                    weightUnitSystem = weightUnitSystem
                 )
             }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -36,6 +36,7 @@ import com.lionotter.recipes.ui.screens.settings.components.GoogleDriveSection
 import com.lionotter.recipes.ui.screens.settings.components.ImportDebuggingSection
 import com.lionotter.recipes.ui.screens.settings.components.ModelSelectionSection
 import com.lionotter.recipes.ui.screens.settings.components.ThemeSection
+import com.lionotter.recipes.ui.screens.settings.components.UnitPreferencesSection
 
 @Composable
 fun SettingsScreen(
@@ -60,6 +61,8 @@ fun SettingsScreen(
     val showFolderPicker by googleDriveViewModel.showFolderPicker.collectAsStateWithLifecycle()
     val folderPickerState by googleDriveViewModel.folderPickerState.collectAsStateWithLifecycle()
     val zipOperationState by zipViewModel.operationState.collectAsStateWithLifecycle()
+    val volumeUnitSystem by viewModel.volumeUnitSystem.collectAsStateWithLifecycle()
+    val weightUnitSystem by viewModel.weightUnitSystem.collectAsStateWithLifecycle()
     val importDebuggingEnabled by viewModel.importDebuggingEnabled.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
@@ -187,6 +190,16 @@ fun SettingsScreen(
             DisplaySection(
                 keepScreenOn = keepScreenOn,
                 onKeepScreenOnChange = viewModel::setKeepScreenOn
+            )
+
+            HorizontalDivider()
+
+            // Unit Preferences Section
+            UnitPreferencesSection(
+                volumeUnitSystem = volumeUnitSystem,
+                onVolumeUnitSystemChange = viewModel::setVolumeUnitSystem,
+                weightUnitSystem = weightUnitSystem,
+                onWeightUnitSystemChange = viewModel::setWeightUnitSystem
             )
 
             HorizontalDivider()

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.remote.AnthropicService
 import com.lionotter.recipes.data.repository.ImportDebugRepository
 import com.lionotter.recipes.domain.model.ThemeMode
+import com.lionotter.recipes.domain.model.UnitSystem
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -54,6 +55,20 @@ class SettingsViewModel @Inject constructor(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = ThemeMode.AUTO
+        )
+
+    val volumeUnitSystem: StateFlow<UnitSystem> = settingsDataStore.volumeUnitSystem
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = UnitSystem.CUSTOMARY
+        )
+
+    val weightUnitSystem: StateFlow<UnitSystem> = settingsDataStore.weightUnitSystem
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = UnitSystem.METRIC
         )
 
     val importDebuggingEnabled: StateFlow<Boolean> = settingsDataStore.importDebuggingEnabled
@@ -121,6 +136,18 @@ class SettingsViewModel @Inject constructor(
     fun setThemeMode(mode: ThemeMode) {
         viewModelScope.launch {
             settingsDataStore.setThemeMode(mode)
+        }
+    }
+
+    fun setVolumeUnitSystem(system: UnitSystem) {
+        viewModelScope.launch {
+            settingsDataStore.setVolumeUnitSystem(system)
+        }
+    }
+
+    fun setWeightUnitSystem(system: UnitSystem) {
+        viewModelScope.launch {
+            settingsDataStore.setWeightUnitSystem(system)
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/UnitPreferencesSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/UnitPreferencesSection.kt
@@ -1,0 +1,96 @@
+package com.lionotter.recipes.ui.screens.settings.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.lionotter.recipes.R
+import com.lionotter.recipes.domain.model.UnitSystem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UnitPreferencesSection(
+    volumeUnitSystem: UnitSystem,
+    onVolumeUnitSystemChange: (UnitSystem) -> Unit,
+    weightUnitSystem: UnitSystem,
+    onWeightUnitSystemChange: (UnitSystem) -> Unit
+) {
+    val options = listOf(
+        UnitSystem.CUSTOMARY to stringResource(R.string.unit_system_customary),
+        UnitSystem.METRIC to stringResource(R.string.unit_system_metric)
+    )
+
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            text = stringResource(R.string.unit_preferences),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        // Volume unit system
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = stringResource(R.string.volume_units),
+                style = MaterialTheme.typography.bodyLarge
+            )
+            Text(
+                text = stringResource(R.string.volume_units_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                options.forEachIndexed { index, (system, label) ->
+                    SegmentedButton(
+                        selected = volumeUnitSystem == system,
+                        onClick = { onVolumeUnitSystemChange(system) },
+                        shape = SegmentedButtonDefaults.itemShape(
+                            index = index,
+                            count = options.size
+                        )
+                    ) {
+                        Text(label)
+                    }
+                }
+            }
+        }
+
+        // Weight unit system
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = stringResource(R.string.weight_units),
+                style = MaterialTheme.typography.bodyLarge
+            )
+            Text(
+                text = stringResource(R.string.weight_units_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                options.forEachIndexed { index, (system, label) ->
+                    SegmentedButton(
+                        selected = weightUnitSystem == system,
+                        onClick = { onWeightUnitSystemChange(system) },
+                        shape = SegmentedButtonDefaults.itemShape(
+                            index = index,
+                            count = options.size
+                        )
+                    ) {
+                        Text(label)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,13 @@
     <string name="theme_auto">Auto (System)</string>
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
+    <string name="unit_preferences">Unit Preferences</string>
+    <string name="volume_units">Volume units</string>
+    <string name="weight_units">Weight units</string>
+    <string name="unit_system_customary">Customary</string>
+    <string name="unit_system_metric">Metric</string>
+    <string name="volume_units_description">Choose between customary (cups, tsp) and metric (mL, L) volume units.</string>
+    <string name="weight_units_description">Choose between customary (oz, lb) and metric (g, kg) weight units.</string>
     <string name="display">Display</string>
     <string name="keep_screen_on">Keep screen on</string>
     <string name="keep_screen_on_description">Prevent the screen from turning off while viewing a recipe.</string>

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
@@ -10,6 +10,7 @@ import com.lionotter.recipes.domain.model.InstructionSection
 import com.lionotter.recipes.domain.model.InstructionStep
 import com.lionotter.recipes.domain.model.MeasurementPreference
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.model.UnitSystem
 import com.lionotter.recipes.domain.model.createInstructionIngredientKey
 import com.lionotter.recipes.domain.usecase.CalculateIngredientUsageUseCase
 import io.mockk.coEvery
@@ -67,6 +68,8 @@ class RecipeDetailViewModelTest {
         // Default mock setup
         every { recipeRepository.getRecipeById("recipe-1") } returns flowOf(createTestRecipe())
         every { settingsDataStore.keepScreenOn } returns flowOf(true)
+        every { settingsDataStore.volumeUnitSystem } returns flowOf(UnitSystem.CUSTOMARY)
+        every { settingsDataStore.weightUnitSystem } returns flowOf(UnitSystem.METRIC)
     }
 
     @After

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -5,6 +5,7 @@ import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.remote.AnthropicService
 import com.lionotter.recipes.data.repository.ImportDebugRepository
 import com.lionotter.recipes.domain.model.ThemeMode
+import com.lionotter.recipes.domain.model.UnitSystem
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -38,6 +39,8 @@ class SettingsViewModelTest {
     private val keepScreenOnFlow = MutableStateFlow(true)
     private val themeModeFlow = MutableStateFlow(ThemeMode.AUTO)
     private val importDebuggingEnabledFlow = MutableStateFlow(false)
+    private val volumeUnitSystemFlow = MutableStateFlow(UnitSystem.CUSTOMARY)
+    private val weightUnitSystemFlow = MutableStateFlow(UnitSystem.METRIC)
 
     @Before
     fun setup() {
@@ -50,6 +53,8 @@ class SettingsViewModelTest {
         every { settingsDataStore.keepScreenOn } returns keepScreenOnFlow
         every { settingsDataStore.themeMode } returns themeModeFlow
         every { settingsDataStore.importDebuggingEnabled } returns importDebuggingEnabledFlow
+        every { settingsDataStore.volumeUnitSystem } returns volumeUnitSystemFlow
+        every { settingsDataStore.weightUnitSystem } returns weightUnitSystemFlow
         viewModel = SettingsViewModel(settingsDataStore, importDebugRepository)
     }
 

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -307,6 +307,10 @@ app: {
       measurement: Measurement
       measurement_type: MeasurementType
       measurement_pref: MeasurementPreference
+      unit_system: {
+        label: UnitSystem
+        tooltip: "Enum: METRIC, CUSTOMARY. Used for volume and weight unit preferences separately."
+      }
       usage_status: {
         label: IngredientUsageStatus
         tooltip: "@Immutable. Fields: totalAmount, usedAmount, unit, isFullyUsed, remainingAmount"
@@ -380,7 +384,7 @@ app: {
       }
       settings: {
         label: SettingsDataStore
-        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, extended thinking enabled, keep screen on, theme mode, import debugging enabled, Google Drive sync enabled/folder/last sync timestamp)"
+        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, extended thinking enabled, keep screen on, theme mode, volume/weight unit system preferences, import debugging enabled, Google Drive sync enabled/folder/last sync timestamp)"
       }
 
       dao -> room
@@ -472,7 +476,7 @@ app: {
   ui.viewmodels.list_vm -> domain.usecases.tags: top tags
   ui.viewmodels.detail_vm -> data.repository.repo: recipe, delete, favorite
   ui.viewmodels.detail_vm -> domain.usecases.calc_usage: ingredient usage
-  ui.viewmodels.detail_vm -> data.local.settings: keep screen on
+  ui.viewmodels.detail_vm -> data.local.settings: keep screen on, unit prefs
   ui.viewmodels.add_vm -> background.worker: enqueue work
   ui.viewmodels.add_vm -> background.worker.work_ext: observe import
   ui.viewmodels.drive_vm -> background.worker.sync_worker: sync


### PR DESCRIPTION
## Summary
- Adds two new settings in the Settings screen: **Volume units** (Customary/Metric) and **Weight units** (Customary/Metric)
- Default is customary volume (cups, tsp, tbsp) and metric weight (g, kg) as requested
- All displayed units are automatically converted to the preferred system - e.g. if metric volume is chosen, cups are displayed as mL/L; if customary weight is chosen, grams are displayed as oz/lb
- Unit conversion uses the existing `bestUnit` scoring system to pick the most readable unit within the target system

## Changes
- **New files**: `UnitSystem.kt` enum, `UnitPreferencesSection.kt` settings UI component
- **SettingsDataStore**: Added `volumeUnitSystem` and `weightUnitSystem` preferences with persistence
- **Recipe.kt**: Added within-category unit conversion (`convertToSystem`), updated `bestUnit` to filter by target system, updated `format()` and `getDisplayAmount()` signatures
- **CalculateIngredientUsageUseCase**: Passes unit system preferences through to display amount calculations
- **UI pipeline**: Unit system preferences flow from SettingsDataStore → RecipeDetailViewModel → RecipeDetailScreen → RecipeContent → IngredientSectionContent/InstructionSectionContent
- **Tests**: Updated mock setup in SettingsViewModelTest and RecipeDetailViewModelTest for new flows
- **Architecture doc**: Updated to reflect new UnitSystem model and settings

## Test plan
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes (all 160 tests)
- [x] `./gradlew lintDebug` passes
- [ ] Manual: Open Settings, verify Unit Preferences section with two segmented button rows
- [ ] Manual: Set volume to Metric, verify cups display as mL/L in recipes
- [ ] Manual: Set weight to Customary, verify grams display as oz/lb in recipes
- [ ] Manual: Verify defaults are Customary volume, Metric weight

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)