### PR TITLE
fix: prevent unit abbreviations from incorrect pluralization

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/util/Pluralizer.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/util/Pluralizer.kt
@@ -313,6 +313,12 @@ object Pluralizer {
             "wealth", "welfare", "whiting", "wildebeest", "wildlife", "you"
         ).forEach { addUncountableRule(it) }
 
+        // Unit abbreviations should not be pluralized (e.g. "oz" not "ozs", "mL" not "mLs")
+        listOf(
+            "mg", "g", "kg", "oz", "lb",
+            "ml", "l", "tsp", "tbsp", "fl_oz", "gal"
+        ).forEach { addUncountableRule(it) }
+
         // Regex uncountables
         listOf(
             Regex("""pok[eé]mon$""", RegexOption.IGNORE_CASE),

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/model/IngredientTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/model/IngredientTest.kt
@@ -59,6 +59,72 @@ class IngredientTest {
     }
 
     @Test
+    fun `format oz unit does not pluralize`() {
+        val ingredient = Ingredient(
+            name = "granulated sugar",
+            amount = Amount(value = 5.0, unit = "oz"),
+            density = 0.84
+        )
+        assertEquals("5 oz granulated sugar", ingredient.format(
+            weightSystem = UnitSystem.CUSTOMARY
+        ))
+    }
+
+    @Test
+    fun `format mL unit does not pluralize`() {
+        val ingredient = Ingredient(
+            name = "water",
+            amount = Amount(value = 250.0, unit = "mL"),
+            density = 1.0
+        )
+        assertEquals("250 mL water", ingredient.format(
+            volumeSystem = UnitSystem.METRIC
+        ))
+    }
+
+    @Test
+    fun `format g unit does not pluralize`() {
+        val ingredient = Ingredient(
+            name = "flour",
+            amount = Amount(value = 500.0, unit = "g"),
+            density = 0.51
+        )
+        assertEquals("500 g flour", ingredient.format())
+    }
+
+    @Test
+    fun `format lb unit does not pluralize`() {
+        val ingredient = Ingredient(
+            name = "chicken",
+            amount = Amount(value = 3.0, unit = "lb"),
+            density = 1.0
+        )
+        assertEquals("3 lb chicken", ingredient.format(
+            weightSystem = UnitSystem.CUSTOMARY
+        ))
+    }
+
+    @Test
+    fun `format tsp unit does not pluralize`() {
+        val ingredient = Ingredient(
+            name = "salt",
+            amount = Amount(value = 2.0, unit = "tsp"),
+            density = 1.22
+        )
+        assertEquals("2 tsp salt", ingredient.format())
+    }
+
+    @Test
+    fun `format tbsp unit does not pluralize`() {
+        val ingredient = Ingredient(
+            name = "olive oil",
+            amount = Amount(value = 3.0, unit = "tbsp"),
+            density = 0.92
+        )
+        assertEquals("3 tbsp olive oil", ingredient.format())
+    }
+
+    @Test
     fun `format with scaling`() {
         val ingredient = Ingredient(
             name = "butter",

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/model/PluralizerTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/model/PluralizerTest.kt
@@ -39,6 +39,24 @@ class PluralizerTest {
     }
 
     @Test
+    fun `test unit abbreviations are not pluralized`() {
+        // Abbreviations should remain unchanged regardless of count
+        val abbreviations = listOf("mg", "g", "kg", "oz", "lb", "mL", "L", "tsp", "tbsp", "fl_oz", "gal")
+        for (abbr in abbreviations) {
+            assertEquals("$abbr should not change for count 1", abbr, abbr.singularize().pluralize(1))
+            assertEquals("$abbr should not change for count 2", abbr, abbr.singularize().pluralize(2))
+        }
+    }
+
+    @Test
+    fun `test words that should still pluralize`() {
+        // Full words like cup, pint, quart should still pluralize
+        assertEquals("cups", "cup".singularize().pluralize(2))
+        assertEquals("pints", "pint".singularize().pluralize(2))
+        assertEquals("quarts", "quart".singularize().pluralize(2))
+    }
+
+    @Test
     fun `test case preservation`() {
         assertEquals("Cups", "Cup".pluralize(2))
         assertEquals("CUPS", "CUP".pluralize(2))


### PR DESCRIPTION
## Summary
- Added unit abbreviations (mg, g, kg, oz, lb, mL, L, tsp, tbsp, fl_oz, gal) to the Pluralizer's uncountable words list so they are no longer incorrectly pluralized (e.g. "ozs", "mLs", "tsps")
- Full words like cup, pint, and quart continue to pluralize normally
- Added tests for all unit abbreviations in both PluralizerTest and IngredientTest

Fixes #133

## Test plan
- [x] Existing unit tests pass
- [x] New PluralizerTest verifies all abbreviations remain unchanged for both count 1 and 2
- [x] New PluralizerTest verifies cup/pint/quart still pluralize correctly
- [x] New IngredientTest verifies formatting with oz, mL, g, lb, tsp, tbsp units
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)