### PR TITLE
feat: add individual recipe sharing with .lorecipes export/import

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,50 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+
+            <!-- Handle .lorecipes files opened from file manager or shared from other apps -->
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" />
+                <data android:mimeType="application/octet-stream" />
+                <data android:pathPattern=".*\\.lorecipes" />
+            </intent-filter>
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" />
+                <data android:mimeType="*/*" />
+                <data android:pathPattern=".*\\.lorecipes" />
+            </intent-filter>
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" />
+                <data android:mimeType="application/zip" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/octet-stream" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/zip" />
+            </intent-filter>
         </activity>
+
+        <!-- FileProvider for sharing .lorecipes files -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
         <!-- WorkManager initialization provider override for Hilt -->
         <provider

--- a/app/src/main/kotlin/com/lionotter/recipes/SharedIntentViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/SharedIntentViewModel.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -11,9 +12,16 @@ class SharedIntentViewModel @Inject constructor() : ViewModel() {
     private val _sharedUrl = MutableSharedFlow<String?>(replay = 0)
     val sharedUrl: SharedFlow<String?> = _sharedUrl
 
+    private val _sharedFileUri = MutableSharedFlow<Uri>(replay = 0)
+    val sharedFileUri: SharedFlow<Uri> = _sharedFileUri
+
     suspend fun onSharedUrlReceived(url: String?) {
         if (url != null) {
             _sharedUrl.emit(url)
         }
+    }
+
+    suspend fun onSharedFileReceived(uri: Uri) {
+        _sharedFileUri.emit(uri)
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportSingleRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportSingleRecipeUseCase.kt
@@ -1,0 +1,67 @@
+package com.lionotter.recipes.domain.usecase
+
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.util.RecipeSerializer
+import java.io.OutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.inject.Inject
+
+/**
+ * Use case for exporting a single recipe to a .lorecipes file.
+ * The format is a ZIP file containing the same folder structure as the bulk export:
+ * - recipe-name/recipe.json
+ * - recipe-name/original.html (if available)
+ * - recipe-name/recipe.md
+ *
+ * The .lorecipes extension allows the app to register as a handler for these files,
+ * enabling recipe sharing between users.
+ */
+class ExportSingleRecipeUseCase @Inject constructor(
+    private val recipeRepository: RecipeRepository,
+    private val recipeSerializer: RecipeSerializer
+) {
+    sealed class ExportResult {
+        data class Success(val fileName: String) : ExportResult()
+        data class Error(val message: String) : ExportResult()
+    }
+
+    /**
+     * Export a single recipe to a .lorecipes file written to the given output stream.
+     */
+    suspend fun exportRecipe(
+        recipe: Recipe,
+        outputStream: OutputStream
+    ): ExportResult {
+        return try {
+            val originalHtml = recipeRepository.getOriginalHtml(recipe.id)
+            val files = recipeSerializer.serializeRecipe(recipe, originalHtml)
+            val prefix = files.folderName
+
+            ZipOutputStream(outputStream).use { zipOut ->
+                // Write recipe.json
+                zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_JSON_FILENAME}"))
+                zipOut.write(files.recipeJson.toByteArray(Charsets.UTF_8))
+                zipOut.closeEntry()
+
+                // Write original.html (if available)
+                if (files.originalHtml != null) {
+                    zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_HTML_FILENAME}"))
+                    zipOut.write(files.originalHtml.toByteArray(Charsets.UTF_8))
+                    zipOut.closeEntry()
+                }
+
+                // Write recipe.md
+                zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_MARKDOWN_FILENAME}"))
+                zipOut.write(files.recipeMarkdown.toByteArray(Charsets.UTF_8))
+                zipOut.closeEntry()
+            }
+
+            val fileName = "${recipeSerializer.sanitizeFolderName(recipe.name)}.lorecipes"
+            ExportResult.Success(fileName)
+        } catch (e: Exception) {
+            ExportResult.Error("Failed to export recipe: ${e.message}")
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/FileImportViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/FileImportViewModel.kt
@@ -1,0 +1,104 @@
+package com.lionotter.recipes.ui.navigation
+
+import android.content.Context
+import android.net.Uri
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.util.RecipeSerializer
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import java.util.zip.ZipInputStream
+import javax.inject.Inject
+import androidx.lifecycle.ViewModel
+
+/**
+ * ViewModel for handling .lorecipes file imports.
+ * Reads the ZIP file directly (single recipe, fast operation) rather than
+ * going through WorkManager, so we can navigate to the imported recipe immediately.
+ */
+@HiltViewModel
+class FileImportViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val recipeRepository: RecipeRepository,
+    private val recipeSerializer: RecipeSerializer
+) : ViewModel() {
+
+    sealed class ImportResult {
+        data class Success(val importedRecipeId: String?) : ImportResult()
+        data class AlreadyExists(val existingRecipeId: String?) : ImportResult()
+        data class Error(val message: String) : ImportResult()
+    }
+
+    /**
+     * Import recipes from a .lorecipes (ZIP) file URI.
+     * Returns the result of the import operation.
+     */
+    suspend fun importFromFile(uri: Uri): ImportResult = withContext(Dispatchers.IO) {
+        val inputStream = try {
+            context.contentResolver.openInputStream(uri)
+                ?: return@withContext ImportResult.Error("Could not open file")
+        } catch (e: Exception) {
+            return@withContext ImportResult.Error("Failed to open file: ${e.message}")
+        }
+
+        val folderContents = mutableMapOf<String, MutableMap<String, String>>()
+
+        try {
+            ZipInputStream(inputStream).use { zipIn ->
+                var entry = zipIn.nextEntry
+                while (entry != null) {
+                    if (!entry.isDirectory) {
+                        val pathParts = entry.name.split("/", limit = 2)
+                        if (pathParts.size == 2) {
+                            val folderName = pathParts[0]
+                            val fileName = pathParts[1]
+                            val content = zipIn.readBytes().toString(Charsets.UTF_8)
+                            folderContents.getOrPut(folderName) { mutableMapOf() }[fileName] = content
+                        }
+                    }
+                    zipIn.closeEntry()
+                    entry = zipIn.nextEntry
+                }
+            }
+        } catch (e: Exception) {
+            return@withContext ImportResult.Error("Failed to read file: ${e.message}")
+        }
+
+        if (folderContents.isEmpty()) {
+            return@withContext ImportResult.Error("No recipes found in file")
+        }
+
+        var importedId: String? = null
+        var existingId: String? = null
+
+        for ((_, files) in folderContents) {
+            val jsonContent = files[RecipeSerializer.RECIPE_JSON_FILENAME] ?: continue
+
+            try {
+                val recipe = recipeSerializer.deserializeRecipe(jsonContent)
+
+                // Check if recipe already exists
+                val existing = recipeRepository.getRecipeByIdOnce(recipe.id)
+                if (existing != null) {
+                    existingId = recipe.id
+                    continue
+                }
+
+                val importedRecipe = recipe.copy(updatedAt = Clock.System.now())
+                val originalHtml = files[RecipeSerializer.RECIPE_HTML_FILENAME]
+                recipeRepository.saveRecipe(importedRecipe, originalHtml)
+                importedId = recipe.id
+            } catch (e: Exception) {
+                return@withContext ImportResult.Error("Failed to import recipe: ${e.message}")
+            }
+        }
+
+        when {
+            importedId != null -> ImportResult.Success(importedId)
+            existingId != null -> ImportResult.AlreadyExists(existingId)
+            else -> ImportResult.Error("No valid recipes found in file")
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <!-- Recipe Detail Screen -->
     <string name="recipe">Recipe</string>
     <string name="share_recipe">Share recipe</string>
+    <string name="share_as_text">Share as text</string>
+    <string name="share_as_file">Share as file (.lorecipes)</string>
     <string name="delete_recipe_action">Delete recipe</string>
     <string name="ingredients">Ingredients</string>
     <string name="instructions">Instructions</string>
@@ -211,4 +213,8 @@
     <string name="not_available">N/A</string>
     <string name="unknown_import">Unknown Import</string>
     <string name="copy_json">Copy JSON</string>
+
+    <!-- File Import -->
+    <string name="file_import_success">Recipe imported successfully</string>
+    <string name="file_import_already_exists">Recipe already exists</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="shared_recipes"
+        path="shared_recipes/" />
+</paths>

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
@@ -14,6 +14,8 @@ import com.lionotter.recipes.domain.model.Recipe
 import com.lionotter.recipes.domain.model.UnitSystem
 import com.lionotter.recipes.domain.model.createInstructionIngredientKey
 import com.lionotter.recipes.domain.usecase.CalculateIngredientUsageUseCase
+import com.lionotter.recipes.domain.usecase.ExportSingleRecipeUseCase
+import com.lionotter.recipes.domain.util.RecipeSerializer
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -90,7 +92,10 @@ class RecipeDetailViewModelTest {
             recipeRepository = recipeRepository,
             settingsDataStore = settingsDataStore,
             calculateIngredientUsage = CalculateIngredientUsageUseCase(),
-            workManager = workManager
+            workManager = workManager,
+            exportSingleRecipeUseCase = mockk<ExportSingleRecipeUseCase>(),
+            recipeSerializer = mockk<RecipeSerializer>(),
+            applicationContext = mockk(relaxed = true)
         )
     }
 

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -68,7 +68,7 @@ app: {
       list: RecipeListScreen
       detail: {
         label: RecipeDetailScreen
-        tooltip: "Displays recipe details with share, regenerate, and delete buttons. Regenerate re-parses from original HTML with selectable model/thinking mode. Share exports as Markdown via Android share sheet. All text is selectable."
+        tooltip: "Displays recipe details with share menu (Markdown text or .lorecipes file), regenerate, and delete buttons. Regenerate re-parses from original HTML with selectable model/thinking mode. All text is selectable."
       }
       add: AddRecipeScreen
       settings: SettingsScreen
@@ -131,6 +131,10 @@ app: {
       import_debug_detail_vm: {
         label: ImportDebugDetailViewModel
         tooltip: "Loads a single import debug entry by ID from SavedStateHandle."
+      }
+      file_import_vm: {
+        label: FileImportViewModel
+        tooltip: "Handles .lorecipes file imports. Reads ZIP file directly (single recipe, fast) and navigates to imported recipe."
       }
     }
 
@@ -265,6 +269,10 @@ app: {
         label: ExportToZipUseCase
         tooltip: "Exports all recipes to a ZIP file using RecipeSerializer. Same folder structure as Google Drive export."
       }
+      export_single: {
+        label: ExportSingleRecipeUseCase
+        tooltip: "Exports a single recipe to a .lorecipes file (ZIP format) for sharing. Uses RecipeSerializer for consistent format."
+      }
       import_zip: {
         label: ImportFromZipUseCase
         tooltip: "Imports recipes from a ZIP file. Reads recipe.json from each folder, skips duplicates by ID, optionally restores original HTML."
@@ -342,6 +350,7 @@ app: {
     usecases.parse_html -> data.repository.import_debug_repo: save debug data
     usecases.sync_drive -> util.serializer: serialize
     usecases.export_zip -> util.serializer: serialize
+    usecases.export_single -> util.serializer: serialize
     usecases.import_zip -> util.serializer: deserialize
   }
 
@@ -501,9 +510,12 @@ app: {
   ui.viewmodels.list_vm -> domain.usecases.tags: top tags
   ui.viewmodels.detail_vm -> data.repository.repo: recipe, delete, favorite
   ui.viewmodels.detail_vm -> domain.usecases.calc_usage: ingredient usage
+  ui.viewmodels.detail_vm -> domain.usecases.export_single: export .lorecipes
   ui.viewmodels.detail_vm -> data.local.settings: keep screen on, unit prefs
   ui.viewmodels.detail_vm -> background.worker.regenerate_worker: regenerate
   ui.viewmodels.detail_vm -> background.worker.work_ext: observe regenerate
+  ui.viewmodels.file_import_vm -> data.repository.repo: import recipe
+  ui.viewmodels.file_import_vm -> domain.util.serializer: deserialize
   ui.viewmodels.add_vm -> background.worker: enqueue work
   ui.viewmodels.add_vm -> background.worker.work_ext: observe import
   ui.viewmodels.drive_vm -> background.worker.sync_worker: sync
@@ -594,6 +606,20 @@ legend: {
   pap5: "5. Repository saves each parsed recipe to Room"
 
   pap1 -> pap2 -> pap3 -> pap4 -> pap5
+
+  share_flow: {
+    label: "Recipe Sharing Flow"
+    style: {
+      font-size: 14
+      bold: true
+    }
+  }
+  share1: "Share as text: RecipeMarkdownFormatter creates Markdown, shared via ACTION_SEND text/plain"
+  share2: "Share as file: ExportSingleRecipeUseCase creates .lorecipes ZIP, shared via FileProvider + ACTION_SEND"
+  share3: "Import: .lorecipes file opened/shared to app triggers FileImportViewModel"
+  share4: "FileImportViewModel reads ZIP, deserializes recipe, saves to Room, navigates to recipe"
+
+  share1 -> share2 -> share3 -> share4
 
   note: {
     label: "Import runs in background via WorkManager. Import queue is database-backed (PendingImportEntity) and persists across app restarts. Supports multiple concurrent imports with individual cancellation from the recipe list via swipe-to-dismiss. Page metadata (title, image) is fetched cheaply before AI parsing begins. Google Drive sync, ZIP export/import, and Paprika import run in background with progress notifications. Sync runs on app startup and every 6 hours when enabled. Paprika import can be cancelled mid-way, keeping already-imported recipes. ZIP export uses the same folder format as sync via RecipeSerializer."


### PR DESCRIPTION
## Summary
- Adds a share dropdown menu on the recipe detail screen with two options: "Share as text" (Markdown) and "Share as file (.lorecipes)"
- The .lorecipes format is a ZIP file using the same folder structure as the existing bulk export, enabling easy recipe sharing between users
- Opening or sharing a .lorecipes file back to the app triggers an import, navigating directly to the imported recipe

## Changes
- **ExportSingleRecipeUseCase**: New use case that exports a single recipe to .lorecipes format (ZIP with recipe.json + original.html + recipe.md)
- **FileImportViewModel**: Handles .lorecipes file imports inline (fast for single recipes) and navigates to the imported recipe
- **FileProvider + file_paths.xml**: Configuration for sharing .lorecipes files via content URIs
- **AndroidManifest.xml**: Intent filters for VIEW and SEND of .lorecipes files (handles file manager opens and app-to-app sharing)
- **RecipeDetailScreen**: Share button replaced with dropdown menu offering text and file sharing options
- **RecipeDetailViewModel**: Added exportRecipeFile() that writes to cache dir and shares via FileProvider
- **MainActivity/SharedIntentViewModel**: Handle file URI intents for both cold start and while app is running
- **Architecture diagram**: Updated with new components and recipe sharing flow

## Test plan
- [ ] Verify "Share as text" still works correctly (Markdown sharing)
- [ ] Verify "Share as file" creates and shares a .lorecipes file
- [ ] Verify opening a .lorecipes file from a file manager triggers import
- [ ] Verify sharing a .lorecipes file from another app triggers import
- [ ] Verify importing a recipe that already exists shows "already exists" toast and navigates to it
- [ ] Verify the share dropdown menu dismisses properly
- [ ] Verify favorite and delete buttons still work on the recipe detail screen

Closes #125

Generated with [Claude Code](https://claude.com/claude-code)