### PR TITLE
feat: add recipe regeneration from detail screen

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeRegenerateWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeRegenerateWorker.kt
@@ -1,0 +1,145 @@
+package com.lionotter.recipes.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.lionotter.recipes.domain.usecase.RegenerateRecipeUseCase
+import com.lionotter.recipes.notification.RecipeNotificationHelper
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class RecipeRegenerateWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val regenerateRecipeUseCase: RegenerateRecipeUseCase,
+    notificationHelper: RecipeNotificationHelper
+) : BaseRecipeWorker(context, workerParams, notificationHelper) {
+
+    override val notificationTitle = "Regenerating Recipe"
+
+    companion object {
+        const val TAG_RECIPE_REGENERATE = "recipe_regenerate"
+
+        const val KEY_RECIPE_ID = "recipe_id"
+        const val KEY_MODEL = "model"
+        const val KEY_EXTENDED_THINKING = "extended_thinking"
+        const val KEY_ERROR_MESSAGE = "error_message"
+        const val KEY_PROGRESS = "progress"
+        const val KEY_RESULT_TYPE = "result_type"
+        const val KEY_RECIPE_NAME = "recipe_name"
+
+        const val RESULT_SUCCESS = "success"
+        const val RESULT_ERROR = "error"
+        const val RESULT_NO_API_KEY = "no_api_key"
+        const val RESULT_NO_ORIGINAL_HTML = "no_original_html"
+
+        const val PROGRESS_PARSING = "parsing"
+        const val PROGRESS_SAVING = "saving"
+
+        fun createInputData(
+            recipeId: String,
+            model: String?,
+            extendedThinking: Boolean?
+        ): Data {
+            return workDataOf(
+                KEY_RECIPE_ID to recipeId,
+                KEY_MODEL to model,
+                KEY_EXTENDED_THINKING to extendedThinking
+            )
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        val recipeId = inputData.getString(KEY_RECIPE_ID)
+            ?: return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "No recipe ID provided"
+                )
+            )
+        val model = inputData.getString(KEY_MODEL)
+        val extendedThinking = if (inputData.keyValueMap.containsKey(KEY_EXTENDED_THINKING)) {
+            inputData.getBoolean(KEY_EXTENDED_THINKING, true)
+        } else {
+            null
+        }
+
+        setForegroundProgress("Starting regeneration...")
+
+        val result = regenerateRecipeUseCase.execute(
+            recipeId = recipeId,
+            model = model,
+            extendedThinking = extendedThinking,
+            onProgress = { progress ->
+                val progressMessage = when (progress) {
+                    is RegenerateRecipeUseCase.RegenerateProgress.ParsingRecipe -> {
+                        setProgress(workDataOf(
+                            KEY_RECIPE_ID to recipeId,
+                            KEY_PROGRESS to PROGRESS_PARSING
+                        ))
+                        "AI is re-analyzing the recipe..."
+                    }
+                    is RegenerateRecipeUseCase.RegenerateProgress.RecipeNameAvailable -> {
+                        setProgress(workDataOf(
+                            KEY_RECIPE_ID to recipeId,
+                            KEY_PROGRESS to PROGRESS_PARSING,
+                            KEY_RECIPE_NAME to progress.name
+                        ))
+                        "AI is re-analyzing the recipe..."
+                    }
+                    is RegenerateRecipeUseCase.RegenerateProgress.SavingRecipe -> {
+                        setProgress(workDataOf(
+                            KEY_RECIPE_ID to recipeId,
+                            KEY_PROGRESS to PROGRESS_SAVING
+                        ))
+                        "Saving recipe..."
+                    }
+                    is RegenerateRecipeUseCase.RegenerateProgress.Complete -> "Complete!"
+                }
+                setForegroundProgress(progressMessage)
+            }
+        )
+
+        return when (result) {
+            is RegenerateRecipeUseCase.RegenerateResult.Success -> {
+                notificationHelper.showSuccessNotification(
+                    recipeName = result.recipe.name,
+                    recipeId = result.recipe.id
+                )
+                Result.success(
+                    workDataOf(
+                        KEY_RECIPE_ID to recipeId,
+                        KEY_RESULT_TYPE to RESULT_SUCCESS,
+                        KEY_RECIPE_NAME to result.recipe.name
+                    )
+                )
+            }
+            is RegenerateRecipeUseCase.RegenerateResult.Error -> errorResult(
+                errorNotificationTitle = "Regeneration Failed",
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                errorType = RESULT_ERROR,
+                errorMessage = result.message,
+                KEY_RECIPE_ID to recipeId
+            )
+            RegenerateRecipeUseCase.RegenerateResult.NoApiKey -> notAvailableResult(
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                resultType = RESULT_NO_API_KEY,
+                errorMessage = "API key not configured",
+                KEY_RECIPE_ID to recipeId
+            )
+            RegenerateRecipeUseCase.RegenerateResult.NoOriginalHtml -> errorResult(
+                errorNotificationTitle = "Regeneration Failed",
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                errorType = RESULT_NO_ORIGINAL_HTML,
+                errorMessage = "Original HTML not available for this recipe",
+                KEY_RECIPE_ID to recipeId
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,14 @@
     <string name="remaining_amount_with_unit">%1$s %2$s left</string>
     <string name="remaining_amount">%1$s left</string>
 
+    <!-- Regenerate Recipe -->
+    <string name="regenerate_recipe">Regenerate Recipe</string>
+    <string name="regenerate_recipe_description">Re-parse this recipe from the original page content using AI. You can choose a different model or thinking mode. The current recipe will be replaced.</string>
+    <string name="regenerate">Regenerate</string>
+    <string name="regenerating_recipe">Regenerating recipe\u2026</string>
+    <string name="regenerate_success">Recipe regenerated successfully</string>
+    <string name="regenerate_no_original_html">Cannot regenerate: original page content is not available for this recipe.</string>
+
     <!-- Add Recipe Screen -->
     <string name="import_recipe">Import Recipe</string>
     <string name="import_recipe_title">Import a recipe from any website</string>

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.lionotter.recipes.ui.screens.recipedetail
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.work.WorkManager
 import app.cash.turbine.test
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.repository.RecipeRepository
@@ -41,6 +42,7 @@ class RecipeDetailViewModelTest {
     private lateinit var savedStateHandle: SavedStateHandle
     private lateinit var recipeRepository: RecipeRepository
     private lateinit var settingsDataStore: SettingsDataStore
+    private lateinit var workManager: WorkManager
     private lateinit var viewModel: RecipeDetailViewModel
     private val testDispatcher = StandardTestDispatcher()
 
@@ -64,12 +66,17 @@ class RecipeDetailViewModelTest {
         savedStateHandle = SavedStateHandle(mapOf("recipeId" to "recipe-1"))
         recipeRepository = mockk()
         settingsDataStore = mockk()
+        workManager = mockk()
 
         // Default mock setup
         every { recipeRepository.getRecipeById("recipe-1") } returns flowOf(createTestRecipe())
+        coEvery { recipeRepository.getOriginalHtml("recipe-1") } returns null
         every { settingsDataStore.keepScreenOn } returns flowOf(true)
         every { settingsDataStore.volumeUnitSystem } returns flowOf(UnitSystem.CUSTOMARY)
         every { settingsDataStore.weightUnitSystem } returns flowOf(UnitSystem.METRIC)
+        every { settingsDataStore.aiModel } returns flowOf("claude-sonnet-4-5")
+        every { settingsDataStore.extendedThinkingEnabled } returns flowOf(true)
+        every { workManager.getWorkInfosByTagFlow(any()) } returns flowOf(emptyList())
     }
 
     @After
@@ -82,7 +89,8 @@ class RecipeDetailViewModelTest {
             savedStateHandle = savedStateHandle,
             recipeRepository = recipeRepository,
             settingsDataStore = settingsDataStore,
-            calculateIngredientUsage = CalculateIngredientUsageUseCase()
+            calculateIngredientUsage = CalculateIngredientUsageUseCase(),
+            workManager = workManager
         )
     }
 

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -68,7 +68,7 @@ app: {
       list: RecipeListScreen
       detail: {
         label: RecipeDetailScreen
-        tooltip: "Displays recipe details with share button (exports as Markdown via Android share sheet). All text is selectable."
+        tooltip: "Displays recipe details with share, regenerate, and delete buttons. Regenerate re-parses from original HTML with selectable model/thinking mode. Share exports as Markdown via Android share sheet. All text is selectable."
       }
       add: AddRecipeScreen
       settings: SettingsScreen
@@ -180,6 +180,10 @@ app: {
         label: RecipeImportWorker
         tooltip: "CoroutineWorker that handles recipe import in background. Survives app closure and shows progress notifications. Supports queue of multiple imports."
       }
+      regenerate_worker: {
+        label: RecipeRegenerateWorker
+        tooltip: "CoroutineWorker that re-parses a recipe from its stored original HTML using the AI. Supports selecting a different model and thinking mode. Overwrites the existing recipe, preserving ID, favorite status, and creation timestamp."
+      }
       paprika_import_worker: {
         label: PaprikaImportWorker
         tooltip: "Imports recipes from a Paprika export file (.paprikarecipes). Parses ZIP of gzip-compressed JSON, sends content through AI pipeline."
@@ -197,13 +201,14 @@ app: {
         tooltip: "Imports recipes from a ZIP file. Reads recipe.json from each folder, skips duplicates, optionally restores original HTML."
       }
       import_worker -> base_worker: extends
+      regenerate_worker -> base_worker: extends
       paprika_import_worker -> base_worker: extends
       sync_worker -> base_worker: extends
       zip_export_worker -> base_worker: extends
       zip_import_worker -> base_worker: extends
       work_ext: {
         label: "observeWorkByTag()"
-        tooltip: "WorkManager extension function that encapsulates the common pattern of observing work by tag and filtering to a specific work ID. Used by AddRecipeViewModel, GoogleDriveViewModel (sync), and ZipExportImportViewModel."
+        tooltip: "WorkManager extension function that encapsulates the common pattern of observing work by tag and filtering to a specific work ID. Used by AddRecipeViewModel, RecipeDetailViewModel (regenerate), GoogleDriveViewModel (sync), and ZipExportImportViewModel."
       }
     }
 
@@ -220,6 +225,7 @@ app: {
     }
 
     worker.import_worker -> notification.helper: notify progress
+    worker.regenerate_worker -> notification.helper: notify progress
     worker.paprika_import_worker -> notification.helper: notify progress
     worker.sync_worker -> notification.helper: notify progress
     worker.zip_export_worker -> notification.helper: notify progress
@@ -260,6 +266,10 @@ app: {
       import_zip: {
         label: ImportFromZipUseCase
         tooltip: "Imports recipes from a ZIP file. Reads recipe.json from each folder, skips duplicates by ID, optionally restores original HTML."
+      }
+      regenerate: {
+        label: RegenerateRecipeUseCase
+        tooltip: "Re-parses a recipe from its stored original HTML via ParseHtmlUseCase. Temporarily overrides model/thinking settings, preserves recipe ID, favorite status, and creation timestamp."
       }
       tags: GetTagsUseCase
       calc_usage: {
@@ -326,6 +336,7 @@ app: {
     }
 
     usecases.import -> usecases.parse_html: uses
+    usecases.regenerate -> usecases.parse_html: uses
     usecases.parse_html -> data.repository.import_debug_repo: save debug data
     usecases.sync_drive -> util.serializer: serialize
     usecases.export_zip -> util.serializer: serialize
@@ -477,6 +488,8 @@ app: {
   ui.viewmodels.detail_vm -> data.repository.repo: recipe, delete, favorite
   ui.viewmodels.detail_vm -> domain.usecases.calc_usage: ingredient usage
   ui.viewmodels.detail_vm -> data.local.settings: keep screen on, unit prefs
+  ui.viewmodels.detail_vm -> background.worker.regenerate_worker: regenerate
+  ui.viewmodels.detail_vm -> background.worker.work_ext: observe regenerate
   ui.viewmodels.add_vm -> background.worker: enqueue work
   ui.viewmodels.add_vm -> background.worker.work_ext: observe import
   ui.viewmodels.drive_vm -> background.worker.sync_worker: sync
@@ -489,6 +502,7 @@ app: {
   ui.viewmodels.import_debug_list_vm -> data.repository.import_debug_repo: list entries
   ui.viewmodels.import_debug_detail_vm -> data.repository.import_debug_repo: get entry
   background.worker.import_worker -> domain.usecases.import: execute
+  background.worker.regenerate_worker -> domain.usecases.regenerate: execute
   background.worker.paprika_import_worker -> domain.usecases.import_paprika: execute
   background.worker.sync_worker -> domain.usecases.sync_drive: execute
   background.worker.zip_export_worker -> domain.usecases.export_zip: execute


### PR DESCRIPTION
## Summary
- Adds a regenerate button (refresh icon) to the recipe detail top bar that re-parses the recipe from its stored original HTML using AI
- Users can select a different model (Opus 4.6, Opus 4.5, Sonnet 4.5, Haiku 4.5) and toggle extended thinking mode before regenerating
- The regenerated recipe overwrites the existing one while preserving the recipe ID, favorite status, and creation timestamp
- The button is only shown when original HTML content is available for the recipe

## Implementation
- **RegenerateRecipeUseCase**: Orchestrates re-parsing via `ParseHtmlUseCase` with temporary model/thinking overrides (restores settings afterward)
- **RecipeRegenerateWorker**: Background WorkManager task with progress notifications
- **RecipeDetailViewModel**: Manages regeneration state, model/thinking selection, and WorkManager observation
- **RecipeDetailScreen**: Refresh icon button + dialog with `ModelSelectionSection` reuse, progress indicator, and error display
- Architecture diagram updated with new worker and use case

## Test plan
- [ ] Import a recipe from a URL, then tap the regenerate button on the recipe detail screen
- [ ] Verify the dialog shows model selection and thinking mode toggle
- [ ] Regenerate with a different model and verify the recipe content updates
- [ ] Verify favorite status and creation date are preserved after regeneration
- [ ] Verify the regenerate button does not appear for recipes without original HTML (e.g., from ZIP import without HTML)
- [ ] Verify progress and error states display correctly in the dialog

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)