### PR TITLE
refactor: deduplicate AI generation logic across use cases

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportRecipeUseCase.kt
@@ -1,16 +1,13 @@
 package com.lionotter.recipes.domain.usecase
 
-import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.remote.WebScraperService
 import com.lionotter.recipes.domain.model.Recipe
-import kotlinx.coroutines.flow.first
 import org.jsoup.Jsoup
 import javax.inject.Inject
 
 class ImportRecipeUseCase @Inject constructor(
     private val webScraperService: WebScraperService,
-    private val parseHtmlUseCase: ParseHtmlUseCase,
-    private val settingsDataStore: SettingsDataStore
+    private val parseHtmlUseCase: ParseHtmlUseCase
 ) {
     sealed class ImportResult {
         data class Success(val recipe: Recipe) : ImportResult()
@@ -31,12 +28,6 @@ class ImportRecipeUseCase @Inject constructor(
         url: String,
         onProgress: suspend (ImportProgress) -> Unit = {}
     ): ImportResult {
-        // Check for API key early
-        val apiKey = settingsDataStore.anthropicApiKey.first()
-        if (apiKey.isNullOrBlank()) {
-            return ImportResult.NoApiKey
-        }
-
         // Fetch page content
         onProgress(ImportProgress.FetchingPage)
         val pageResult = webScraperService.fetchPage(url)
@@ -52,7 +43,7 @@ class ImportRecipeUseCase @Inject constructor(
         ))
 
         // Use ParseHtmlUseCase to parse the HTML content
-        val parseResult = parseHtmlUseCase.execute(
+        val parseResult = parseHtmlUseCase.parseHtml(
             html = page.originalHtml,
             sourceUrl = url,
             imageUrl = page.imageUrl,

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/RegenerateRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/RegenerateRecipeUseCase.kt
@@ -49,7 +49,7 @@ class RegenerateRecipeUseCase @Inject constructor(
         }
 
         // Re-parse with AI (don't save yet, we need to adjust the recipe)
-        val parseResult = parseHtmlUseCase.execute(
+        val parseResult = parseHtmlUseCase.parseHtml(
             html = originalHtml,
             sourceUrl = existingRecipe.sourceUrl,
             imageUrl = existingRecipe.imageUrl,

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -251,11 +251,11 @@ app: {
       import: ImportRecipeUseCase
       parse_html: {
         label: ParseHtmlUseCase
-        tooltip: "Reusable helper for parsing HTML via AI. Used by URL import."
+        tooltip: "Central AI parsing use case. parseHtml() extracts content from HTML via Readability4J then delegates to parseText(). parseText() sends pre-extracted text to AI, builds Recipe, saves debug data. Used by URL import, Paprika import, and regeneration."
       }
       import_paprika: {
         label: ImportPaprikaUseCase
-        tooltip: "Imports recipes from Paprika export (.paprikarecipes). Parses export, sends recipe content (not source URL) through AI, resolves images from Paprika data or source page. Supports cooperative cancellation — checks coroutine state between recipes and preserves already-imported recipes on cancel."
+        tooltip: "Imports recipes from Paprika export (.paprikarecipes). Parses export, sends recipe content through ParseHtmlUseCase.parseText(), resolves images from Paprika data or source page. Supports cooperative cancellation — checks coroutine state between recipes and preserves already-imported recipes on cancel."
       }
       sync_drive: {
         label: SyncToGoogleDriveUseCase
@@ -271,7 +271,7 @@ app: {
       }
       regenerate: {
         label: RegenerateRecipeUseCase
-        tooltip: "Re-parses a recipe from its stored original HTML via ParseHtmlUseCase. Temporarily overrides model/thinking settings, preserves recipe ID, favorite status, and creation timestamp."
+        tooltip: "Re-parses a recipe from its stored original HTML via ParseHtmlUseCase.parseHtml(). Passes model/thinking overrides as parameters, preserves recipe ID, favorite status, and creation timestamp."
       }
       tags: GetTagsUseCase
       calc_usage: {
@@ -523,7 +523,7 @@ app: {
   background.worker.zip_import_worker -> domain.usecases.import_zip: execute
   domain.usecases -> data.repository: access data
   domain.usecases.import_paprika -> data.paprika.parser: parse export
-  domain.usecases.import_paprika -> data.remote.anthropic_svc: parse recipe content
+  domain.usecases.import_paprika -> domain.usecases.parse_html: parseText
   domain.usecases.import_paprika -> data.remote.scraper: fetch source image
   data.remote.scraper -> external.web: fetch HTML
   data.remote.anthropic_svc -> external.anthropic: parse recipe


### PR DESCRIPTION
## Summary
- Split `ParseHtmlUseCase.execute()` into two functions:
  - `parseText()`: core AI parsing for pre-extracted text (API key check, settings, AI call, Recipe construction, debug data)
  - `parseHtml()`: extracts content from HTML via Readability4J, then delegates to `parseText()`
- Routed `ImportPaprikaUseCase` through `parseText()` instead of calling `AnthropicService` directly, eliminating duplicate API key checking, settings reading, Recipe construction, and error handling
- Paprika imports now get debug data saving for free
- Removed redundant API key check and `SettingsDataStore` dependency from `ImportRecipeUseCase`
- Removed `SettingsDataStore` dependency from `RegenerateRecipeUseCase` (from prior commit)
- Updated architecture diagram

## Test plan
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes
- [ ] Manual: import a recipe from URL (uses `parseHtml` path)
- [ ] Manual: import from Paprika export (uses `parseText` path)
- [ ] Manual: regenerate a recipe with different model/thinking settings (uses `parseHtml` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)