### PR TITLE
fix: display every day in meal plan view even when empty

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
@@ -139,52 +139,30 @@ fun MealPlanScreen(
 
             // Week content
             val days = (0..6).map { weekStart.plus(it, DateTimeUnit.DAY) }
-            val hasAnyMeals = weekMealPlans.isNotEmpty()
 
-            if (!hasAnyMeals) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
-                            text = stringResource(R.string.no_meals_planned),
-                            style = MaterialTheme.typography.titleLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = stringResource(R.string.tap_plus_to_add_meal),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+            LazyColumn(
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                for (day in days) {
+                    val meals = weekMealPlans[day]
+                    item(key = "header_$day") {
+                        DayHeader(date = day)
                     }
-                }
-            } else {
-                LazyColumn(
-                    contentPadding = PaddingValues(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    for (day in days) {
-                        val meals = weekMealPlans[day]
-                        if (meals != null && meals.isNotEmpty()) {
-                            item(key = "header_$day") {
-                                DayHeader(date = day)
-                            }
-                            items(
-                                items = meals,
-                                key = { it.id }
-                            ) { entry ->
-                                SwipeableMealPlanCard(
-                                    entry = entry,
-                                    onClick = { onRecipeClick(entry.recipeId) },
-                                    onDeleteRequest = { entryToDelete = entry }
-                                )
-                            }
-                            item(key = "spacer_$day") {
-                                Spacer(modifier = Modifier.height(8.dp))
-                            }
+                    if (meals != null && meals.isNotEmpty()) {
+                        items(
+                            items = meals,
+                            key = { it.id }
+                        ) { entry ->
+                            SwipeableMealPlanCard(
+                                entry = entry,
+                                onClick = { onRecipeClick(entry.recipeId) },
+                                onDeleteRequest = { entryToDelete = entry }
+                            )
                         }
+                    }
+                    item(key = "spacer_$day") {
+                        Spacer(modifier = Modifier.height(8.dp))
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Always display all 7 days of the week in the meal plan view, including days with no meals assigned
- Removed the separate "no meals planned" empty state since every day is now always visible
- Days without meals show just the day header, making it clear where meals can be added

Fixes #160

## Test plan
- [ ] Open the meal plan view with no meals planned for the week — verify all 7 day headers are visible
- [ ] Add a meal to one day — verify all other days still show their headers
- [ ] Navigate between weeks — verify all days are always shown
- [ ] Swipe to delete the last meal on a day — verify the day header remains visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)