### PR TITLE
fix: crash on long-press of recipes due to global SelectionContainer

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugDetailScreen.kt
@@ -3,6 +3,7 @@ package com.lionotter.recipes.ui.screens.importdebug
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -83,11 +84,13 @@ fun ImportDebugDetailScreen(
                 CircularProgressIndicator()
             }
         } else {
-            DebugDetailContent(
-                entry = currentEntry,
-                onNavigateToRecipe = onNavigateToRecipe,
-                modifier = Modifier.padding(paddingValues)
-            )
+            SelectionContainer {
+                DebugDetailContent(
+                    entry = currentEntry,
+                    onNavigateToRecipe = onNavigateToRecipe,
+                    modifier = Modifier.padding(paddingValues)
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
@@ -231,23 +232,25 @@ fun RecipeDetailScreen(
                 CircularProgressIndicator()
             }
         } else {
-            RecipeContent(
-                recipe = recipe!!,
-                scale = scale,
-                onScaleIncrement = viewModel::incrementScale,
-                onScaleDecrement = viewModel::decrementScale,
-                measurementPreference = measurementPreference,
-                onMeasurementPreferenceChange = viewModel::setMeasurementPreference,
-                showMeasurementToggle = supportsConversion,
-                usedInstructionIngredients = usedInstructionIngredients,
-                globalIngredientUsage = globalIngredientUsage,
-                onToggleInstructionIngredient = viewModel::toggleInstructionIngredientUsed,
-                highlightedInstructionStep = highlightedInstructionStep,
-                onToggleHighlightedInstruction = viewModel::toggleHighlightedInstructionStep,
-                volumeUnitSystem = volumeUnitSystem,
-                weightUnitSystem = weightUnitSystem,
-                modifier = Modifier.padding(paddingValues)
-            )
+            SelectionContainer {
+                RecipeContent(
+                    recipe = recipe!!,
+                    scale = scale,
+                    onScaleIncrement = viewModel::incrementScale,
+                    onScaleDecrement = viewModel::decrementScale,
+                    measurementPreference = measurementPreference,
+                    onMeasurementPreferenceChange = viewModel::setMeasurementPreference,
+                    showMeasurementToggle = supportsConversion,
+                    usedInstructionIngredients = usedInstructionIngredients,
+                    globalIngredientUsage = globalIngredientUsage,
+                    onToggleInstructionIngredient = viewModel::toggleInstructionIngredientUsed,
+                    highlightedInstructionStep = highlightedInstructionStep,
+                    onToggleHighlightedInstruction = viewModel::toggleHighlightedInstructionStep,
+                    volumeUnitSystem = volumeUnitSystem,
+                    weightUnitSystem = weightUnitSystem,
+                    modifier = Modifier.padding(paddingValues)
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/theme/Theme.kt
@@ -2,7 +2,6 @@ package com.lionotter.recipes.ui.theme
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -89,10 +88,7 @@ fun LionOtterTheme(
 
     MaterialTheme(
         colorScheme = colorScheme,
-        typography = Typography
-    ) {
-        SelectionContainer {
-            content()
-        }
-    }
+        typography = Typography,
+        content = content
+    )
 }


### PR DESCRIPTION
## Summary
- Fixes crash when long-pressing (click and hold) on recipes in the recipe list and meal planning screens
- Root cause: the app's theme wrapped the entire UI in a `SelectionContainer`, making all `Text` composables selectable. When long-pressing on text inside recipe cards (which use `combinedClickable` for context menus), the text selection gesture conflicted with the long-press handler, causing a crash
- Moved `SelectionContainer` from the global theme to only the recipe detail screen, where text selection is actually useful for copying ingredients/instructions

## Test plan
- [ ] Long-press on a recipe card in the recipe list — should show the delete context menu without crashing
- [ ] Long-press on a meal plan entry — should show the remove context menu without crashing  
- [ ] Long-press on text specifically (not just the card edge) — should work without crashing
- [ ] Verify text is still selectable on the recipe detail screen (ingredients, instructions)

Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)