### PR TITLE
fix: default meal plan add date to first day of viewed week

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanViewModel.kt
@@ -148,7 +148,7 @@ class MealPlanViewModel @Inject constructor(
     }
 
     fun openAddDialog() {
-        _selectedDate.value = today
+        _selectedDate.value = currentWeekStart.value
         _selectedMealType.value = MealType.DINNER
         _selectedServings.value = 1.0
         _recipeSearchQuery.value = ""


### PR DESCRIPTION
## Summary
- When viewing a different week and clicking the add button, the date now defaults to the first day of the currently viewed week instead of always defaulting to today
- This respects the user's start-of-week setting (e.g., Monday, Sunday, locale default)

Fixes #163

## Test plan
- [ ] Navigate to a future/past week in the meal planner
- [ ] Click the add (FAB) button
- [ ] Verify the date defaults to the first day of that week, not today
- [ ] Change start-of-week setting and repeat to verify it's respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)