### PR TITLE
feat: add edit functionality for meal plan entries

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/MealPlanRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/MealPlanRepository.kt
@@ -40,6 +40,10 @@ class MealPlanRepository @Inject constructor(
         mealPlanDao.insertMealPlan(MealPlanEntity.fromMealPlanEntry(entry))
     }
 
+    suspend fun updateMealPlan(entry: MealPlanEntry) {
+        mealPlanDao.updateMealPlan(MealPlanEntity.fromMealPlanEntry(entry))
+    }
+
     suspend fun deleteMealPlan(id: String) {
         val now = Clock.System.now().toEpochMilliseconds()
         mealPlanDao.softDeleteMealPlan(id, now)

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/AddMealPlanDialog.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/AddMealPlanDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DatePicker
@@ -77,6 +78,8 @@ fun AddMealPlanDialog(
     val selectedDate by viewModel.selectedDate.collectAsStateWithLifecycle()
     val selectedMealType by viewModel.selectedMealType.collectAsStateWithLifecycle()
     val selectedServings by viewModel.selectedServings.collectAsStateWithLifecycle()
+    val editingEntry by viewModel.editingEntry.collectAsStateWithLifecycle()
+    val isEditMode = editingEntry != null
 
     var showDatePicker by remember { mutableStateOf(false) }
 
@@ -125,7 +128,9 @@ fun AddMealPlanDialog(
                 .padding(bottom = 32.dp)
         ) {
             Text(
-                text = stringResource(R.string.add_to_meal_plan),
+                text = stringResource(
+                    if (isEditMode) R.string.edit_meal_plan else R.string.add_to_meal_plan
+                ),
                 style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
@@ -213,6 +218,18 @@ fun AddMealPlanDialog(
             }
 
             Spacer(modifier = Modifier.height(16.dp))
+
+            // Save button in edit mode (save without changing recipe)
+            if (isEditMode) {
+                Button(
+                    onClick = { viewModel.saveEditedMealPlan() },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.save))
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
 
             // Recipe search
             Text(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -244,5 +244,8 @@
     <string name="next_week">Next week</string>
     <string name="servings_format">%1$sx</string>
     <string name="remove">Remove</string>
+    <string name="edit">Edit</string>
+    <string name="edit_meal_plan">Edit Meal Plan</string>
+    <string name="save">Save</string>
     <string name="recipes">Recipes</string>
 </resources>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -83,7 +83,7 @@ app: {
 
       meal_plan: {
         label: MealPlanScreen
-        tooltip: "Weekly meal planner view. Shows meals grouped by day with swipe-to-delete and long-press menu. Recipe selector bottom sheet with search, tag filter, date picker, meal type selector, and servings."
+        tooltip: "Weekly meal planner view. Shows meals grouped by day with swipe-to-delete, swipe-to-edit, and long-press menu (edit/delete). Recipe selector bottom sheet with search, tag filter, date picker, meal type selector, and servings. Supports edit mode to modify date, meal type, servings, and recipe of existing entries."
       }
 
       list -> detail: tap recipe
@@ -145,7 +145,7 @@ app: {
       }
       meal_plan_vm: {
         label: MealPlanViewModel
-        tooltip: "Manages weekly meal plan view state, recipe selection dialog, and CRUD operations for meal plan entries. Respects user's start-of-week setting from preferences. Triggers incremental Google Drive sync on changes."
+        tooltip: "Manages weekly meal plan view state, add/edit dialog, and CRUD operations for meal plan entries. Supports editing existing entries (date, meal type, servings, recipe). Respects user's start-of-week setting from preferences. Triggers incremental Google Drive sync on changes."
       }
     }
 


### PR DESCRIPTION
## Summary
- Long-press context menu now shows **Edit** and **Remove** options (previously only Remove)
- Swipe left-to-right opens the edit dialog; swipe right-to-left still triggers delete confirmation
- The add meal plan bottom sheet dialog is reused in edit mode, pre-populated with the entry's date, meal type, and servings
- In edit mode, a **Save** button allows saving changes without changing the recipe, and selecting a recipe from the list updates it

## Changes
- **MealPlanRepository**: Added `updateMealPlan()` method using Room's `@Update`
- **MealPlanViewModel**: Added `editingEntry` state, `openEditDialog()`, `saveEditedMealPlan()`, and updated `addRecipeToMealPlan()` to handle edit mode
- **AddMealPlanDialog**: Shows "Edit Meal Plan" title in edit mode, includes a Save button for editing without recipe change
- **MealPlanScreen**: Added Edit to long-press dropdown menu, enabled swipe-from-start-to-end with edit icon
- **strings.xml**: Added `edit`, `edit_meal_plan`, and `save` string resources
- **architecture.d2**: Updated tooltips for MealPlanScreen and MealPlanViewModel

Closes #162

## Test plan
- [ ] Long-press a meal plan entry and verify both Edit and Remove options appear
- [ ] Tap Edit from the long-press menu and verify the dialog opens with pre-populated values
- [ ] Change the date, meal type, or servings and tap Save — verify the entry updates
- [ ] Select a different recipe in edit mode — verify the recipe changes
- [ ] Swipe a meal plan entry left-to-right and verify the edit dialog opens
- [ ] Swipe right-to-left and verify the delete confirmation still works
- [ ] Add a new meal plan entry and verify the add flow still works as before
- [ ] Verify changes sync to Google Drive

🤖 Generated with [Claude Code](https://claude.com/claude-code)