### PR TITLE
feat: add grocery list export from meal plan

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/AggregateGroceryListUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/AggregateGroceryListUseCase.kt
@@ -1,0 +1,123 @@
+package com.lionotter.recipes.domain.usecase
+
+import com.lionotter.recipes.domain.model.Ingredient
+import com.lionotter.recipes.domain.model.MealPlanEntry
+import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.util.singularize
+import javax.inject.Inject
+
+/**
+ * A single ingredient contribution from one recipe (possibly appearing multiple times in the meal plan).
+ */
+data class GroceryIngredientSource(
+    val recipeName: String,
+    val ingredient: Ingredient,
+    val scale: Double
+)
+
+/**
+ * An aggregated grocery item that combines the same ingredient across multiple recipes.
+ */
+data class GroceryItem(
+    val normalizedName: String,
+    val sources: List<GroceryIngredientSource>
+)
+
+/**
+ * Aggregates ingredients from selected meal plan recipes into a deduplicated grocery list.
+ *
+ * Deduplication strategy:
+ * - Normalize ingredient names by removing size prefixes (small, medium, large),
+ *   lowercasing, and singularizing
+ * - Group same ingredients across recipes
+ * - Within the same recipe, merge duplicate sources (e.g., same recipe on two different days)
+ *   by summing their scale factors
+ */
+class AggregateGroceryListUseCase @Inject constructor() {
+
+    companion object {
+        private val SIZE_PREFIXES = setOf("small", "medium", "large")
+    }
+
+    /**
+     * Aggregate ingredients from the given recipes scaled by their meal plan servings.
+     *
+     * @param entries The selected meal plan entries with their corresponding recipes
+     * @return A list of aggregated grocery items
+     */
+    fun execute(entries: List<Pair<MealPlanEntry, Recipe>>): List<GroceryItem> {
+        // Map of normalized ingredient key -> map of (recipeName, ingredientName) -> merged source
+        val aggregation = linkedMapOf<String, LinkedHashMap<String, MutableGrocerySource>>()
+        // Track the first display name seen for each key
+        val displayNames = linkedMapOf<String, String>()
+
+        for ((entry, recipe) in entries) {
+            // entry.servings is a scale multiplier (1.0 = full recipe)
+            val scale = entry.servings
+            val sections = recipe.aggregateIngredients()
+            for (section in sections) {
+                for (ingredient in section.ingredients) {
+                    val key = normalizeKey(ingredient.name)
+                    if (key !in displayNames) {
+                        displayNames[key] = normalizeName(ingredient.name)
+                    }
+
+                    val sourceMap = aggregation.getOrPut(key) { linkedMapOf() }
+                    // Use recipe name + original ingredient name as source key
+                    // so same recipe appearing multiple times merges into one source
+                    val sourceKey = "${recipe.name}\u0000${ingredient.name}"
+                    val existing = sourceMap[sourceKey]
+                    if (existing != null) {
+                        existing.scale += scale
+                    } else {
+                        sourceMap[sourceKey] = MutableGrocerySource(
+                            recipeName = recipe.name,
+                            ingredient = ingredient,
+                            scale = scale
+                        )
+                    }
+                }
+            }
+        }
+
+        return aggregation.map { (key, sourceMap) ->
+            GroceryItem(
+                normalizedName = displayNames[key] ?: key,
+                sources = sourceMap.values.map { it.toSource() }
+            )
+        }
+    }
+
+    /**
+     * Normalize an ingredient name for deduplication:
+     * - Lowercase
+     * - Remove size prefixes (small, medium, large)
+     * - Singularize
+     */
+    private fun normalizeKey(name: String): String {
+        val words = name.lowercase().trim().split("\\s+".toRegex())
+        val filtered = words.filter { it !in SIZE_PREFIXES }
+        val joined = if (filtered.isNotEmpty()) filtered.joinToString(" ") else words.joinToString(" ")
+        return joined.singularize()
+    }
+
+    /**
+     * Normalize the display name: remove size prefixes but keep original casing.
+     */
+    private fun normalizeName(name: String): String {
+        val words = name.trim().split("\\s+".toRegex())
+        return words.filter { it.lowercase() !in SIZE_PREFIXES }.joinToString(" ").ifEmpty { name }
+    }
+
+    private class MutableGrocerySource(
+        val recipeName: String,
+        val ingredient: Ingredient,
+        var scale: Double
+    ) {
+        fun toSource() = GroceryIngredientSource(
+            recipeName = recipeName,
+            ingredient = ingredient,
+            scale = scale
+        )
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
@@ -16,6 +16,7 @@ import com.lionotter.recipes.SharedIntentViewModel
 import com.lionotter.recipes.ui.screens.addrecipe.AddRecipeScreen
 import com.lionotter.recipes.ui.screens.importdebug.ImportDebugDetailScreen
 import com.lionotter.recipes.ui.screens.importdebug.ImportDebugListScreen
+import com.lionotter.recipes.ui.screens.grocerylist.GroceryListScreen
 import com.lionotter.recipes.ui.screens.mealplan.MealPlanScreen
 import com.lionotter.recipes.ui.screens.recipedetail.RecipeDetailScreen
 import com.lionotter.recipes.ui.screens.recipelist.RecipeListScreen
@@ -34,6 +35,7 @@ sealed class Screen(val route: String) {
     }
     object Settings : Screen("settings")
     object MealPlan : Screen("meal-plan")
+    object GroceryList : Screen("grocery-list")
     object ImportDebugList : Screen("import-debug")
     object ImportDebugDetail : Screen("import-debug/{debugEntryId}") {
         fun createRoute(debugEntryId: String) = "import-debug/$debugEntryId"
@@ -162,6 +164,15 @@ fun NavGraph(
                 onRecipeClick = { recipeId ->
                     navController.navigate(Screen.RecipeDetail.createRoute(recipeId))
                 },
+                onBackClick = navigateBack,
+                onGroceryListClick = {
+                    navController.navigate(Screen.GroceryList.route)
+                }
+            )
+        }
+
+        composable(Screen.GroceryList.route) {
+            GroceryListScreen(
                 onBackClick = navigateBack
             )
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListScreen.kt
@@ -1,0 +1,445 @@
+package com.lionotter.recipes.ui.screens.grocerylist
+
+import android.content.Intent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lionotter.recipes.R
+import com.lionotter.recipes.domain.model.MealType
+import com.lionotter.recipes.ui.components.RecipeTopAppBar
+import kotlinx.datetime.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GroceryListScreen(
+    onBackClick: () -> Unit,
+    viewModel: GroceryListViewModel = hiltViewModel()
+) {
+    val step by viewModel.step.collectAsStateWithLifecycle()
+
+    when (step) {
+        GroceryListStep.SELECT_RECIPES -> RecipeSelectionScreen(
+            viewModel = viewModel,
+            onBackClick = onBackClick
+        )
+        GroceryListStep.VIEW_LIST -> GroceryListDisplayScreen(
+            viewModel = viewModel,
+            onBackClick = { viewModel.backToSelection() }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RecipeSelectionScreen(
+    viewModel: GroceryListViewModel,
+    onBackClick: () -> Unit
+) {
+    val selectableEntries by viewModel.selectableEntries.collectAsStateWithLifecycle()
+    val hasSelection = selectableEntries.values.any { entries ->
+        entries.any { it.isSelected }
+    }
+
+    Scaffold(
+        topBar = {
+            RecipeTopAppBar(
+                title = stringResource(R.string.grocery_list),
+                onBackClick = onBackClick
+            )
+        },
+        bottomBar = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Button(
+                    onClick = { viewModel.generateGroceryList() },
+                    enabled = hasSelection,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.generate_grocery_list))
+                }
+            }
+        }
+    ) { paddingValues ->
+        if (selectableEntries.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.no_meals_planned),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.grocery_list_empty_hint),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            LazyColumn(
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = 8.dp,
+                    bottom = paddingValues.calculateBottomPadding() + 8.dp
+                ),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = paddingValues.calculateTopPadding()),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                // Select all / Deselect all row
+                item(key = "select_actions") {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(onClick = { viewModel.selectAll() }) {
+                            Text(stringResource(R.string.select_all))
+                        }
+                        TextButton(onClick = { viewModel.deselectAll() }) {
+                            Text(stringResource(R.string.deselect_all))
+                        }
+                    }
+                }
+
+                for ((date, entries) in selectableEntries) {
+                    item(key = "date_header_$date") {
+                        DateHeader(date = date)
+                    }
+                    items(
+                        items = entries,
+                        key = { it.entry.id }
+                    ) { selectable ->
+                        MealPlanCheckboxRow(
+                            entry = selectable,
+                            onToggle = { viewModel.toggleEntrySelection(selectable.entry.id) }
+                        )
+                    }
+                    item(key = "date_spacer_$date") {
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DateHeader(date: LocalDate) {
+    val dayName = java.time.DayOfWeek.of(date.dayOfWeek.value)
+        .getDisplayName(TextStyle.FULL, Locale.getDefault())
+    val monthName = java.time.Month.of(date.monthNumber)
+        .getDisplayName(TextStyle.SHORT, Locale.getDefault())
+
+    Text(
+        text = "$dayName, $monthName ${date.dayOfMonth}",
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(vertical = 4.dp)
+    )
+}
+
+@Composable
+private fun MealPlanCheckboxRow(
+    entry: SelectableMealPlanEntry,
+    onToggle: () -> Unit
+) {
+    val mealTypeLabel = when (entry.entry.mealType) {
+        MealType.BREAKFAST -> stringResource(R.string.breakfast)
+        MealType.LUNCH -> stringResource(R.string.lunch)
+        MealType.DINNER -> stringResource(R.string.dinner)
+        MealType.SNACK -> stringResource(R.string.snack)
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = entry.isSelected,
+            onCheckedChange = { onToggle() }
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = entry.entry.recipeName,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = mealTypeLabel + if (entry.entry.servings != 1.0) {
+                    " \u2022 ${formatServings(entry.entry.servings)}x"
+                } else "",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GroceryListDisplayScreen(
+    viewModel: GroceryListViewModel,
+    onBackClick: () -> Unit
+) {
+    val items by viewModel.displayGroceryItems.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            RecipeTopAppBar(
+                title = stringResource(R.string.grocery_list),
+                onBackClick = onBackClick,
+                actions = {
+                    IconButton(onClick = {
+                        val shareText = viewModel.getShareText()
+                        val intent = Intent(Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(Intent.EXTRA_TEXT, shareText)
+                        }
+                        context.startActivity(Intent.createChooser(intent, null))
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.Share,
+                            contentDescription = stringResource(R.string.share_grocery_list)
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        if (items.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.no_ingredients),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            LazyColumn(
+                contentPadding = PaddingValues(16.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                items(
+                    items = items,
+                    key = { it.key }
+                ) { item ->
+                    GroceryItemRow(
+                        item = item,
+                        onItemToggle = { viewModel.toggleItemChecked(item.key) },
+                        onSourceToggle = { sourceKey -> viewModel.toggleSourceChecked(sourceKey) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroceryItemRow(
+    item: DisplayGroceryItem,
+    onItemToggle: () -> Unit,
+    onSourceToggle: (String) -> Unit
+) {
+    val uncheckedSources = item.sources.filter { !it.isChecked }
+
+    // If only one source total, show it directly
+    if (item.sources.size <= 1) {
+        val source = item.sources.firstOrNull() ?: return
+        SingleIngredientRow(
+            source = source,
+            recipeName = source.recipeName,
+            isChecked = item.isChecked || source.isChecked,
+            onToggle = onItemToggle
+        )
+    } else if (uncheckedSources.size == 1 && !item.isChecked) {
+        // Multiple sources but only one remaining unchecked - collapse to single item
+        val source = uncheckedSources.first()
+        SingleIngredientRow(
+            source = source,
+            recipeName = source.recipeName,
+            isChecked = false,
+            onToggle = { onSourceToggle(source.key) }
+        )
+    } else {
+        // Multiple unchecked sources - show aggregate header with sub-items
+        AnimatedVisibility(visible = !item.isChecked) {
+            Column {
+                AggregateIngredientHeader(
+                    item = item,
+                    onToggle = onItemToggle
+                )
+                // Sub-items
+                for (source in item.sources) {
+                    AnimatedVisibility(visible = !source.isChecked) {
+                        SubIngredientRow(
+                            source = source,
+                            onToggle = { onSourceToggle(source.key) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SingleIngredientRow(
+    source: DisplayGrocerySource,
+    recipeName: String,
+    isChecked: Boolean,
+    onToggle: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = isChecked,
+            onCheckedChange = { onToggle() }
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = "${source.displayText} ($recipeName)",
+            style = MaterialTheme.typography.bodyMedium,
+            textDecoration = if (isChecked) TextDecoration.LineThrough else TextDecoration.None,
+            color = if (isChecked) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun AggregateIngredientHeader(
+    item: DisplayGroceryItem,
+    onToggle: () -> Unit
+) {
+    val headerText = if (item.totalAmount != null) {
+        "${item.totalAmount} ${item.displayText}"
+    } else {
+        item.displayText
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = item.isChecked,
+            onCheckedChange = { onToggle() }
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = headerText,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun SubIngredientRow(
+    source: DisplayGrocerySource,
+    onToggle: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(start = 40.dp, top = 2.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = source.isChecked,
+            onCheckedChange = { onToggle() }
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = "${source.displayText} (${source.recipeName})",
+            style = MaterialTheme.typography.bodySmall,
+            textDecoration = if (source.isChecked) TextDecoration.LineThrough else TextDecoration.None,
+            color = if (source.isChecked) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+private fun formatServings(servings: Double): String {
+    return if (servings == servings.toLong().toDouble()) {
+        servings.toLong().toString()
+    } else {
+        servings.toString()
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModel.kt
@@ -1,0 +1,362 @@
+package com.lionotter.recipes.ui.screens.grocerylist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lionotter.recipes.data.local.SettingsDataStore
+import com.lionotter.recipes.data.repository.MealPlanRepository
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.model.Amount
+import com.lionotter.recipes.domain.model.MealPlanEntry
+import com.lionotter.recipes.domain.model.UnitCategory
+import com.lionotter.recipes.domain.model.UnitSystem
+import com.lionotter.recipes.domain.model.fromBaseUnit
+import com.lionotter.recipes.domain.model.toBaseUnitValue
+import com.lionotter.recipes.domain.model.unitType
+import com.lionotter.recipes.domain.usecase.AggregateGroceryListUseCase
+import com.lionotter.recipes.domain.usecase.GroceryIngredientSource
+import com.lionotter.recipes.domain.usecase.GroceryItem
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDate
+import javax.inject.Inject
+
+/**
+ * A meal plan entry grouped by date and meal type for the recipe selector.
+ */
+data class SelectableMealPlanEntry(
+    val entry: MealPlanEntry,
+    val isSelected: Boolean
+)
+
+/**
+ * A displayable grocery item with check-off state.
+ */
+data class DisplayGroceryItem(
+    val key: String,
+    val displayText: String,
+    val totalAmount: String?,
+    val isChecked: Boolean,
+    val sources: List<DisplayGrocerySource>
+)
+
+data class DisplayGrocerySource(
+    val key: String,
+    val displayText: String,
+    val recipeName: String,
+    val isChecked: Boolean
+)
+
+enum class GroceryListStep {
+    SELECT_RECIPES,
+    VIEW_LIST
+}
+
+@HiltViewModel
+class GroceryListViewModel @Inject constructor(
+    private val mealPlanRepository: MealPlanRepository,
+    private val recipeRepository: RecipeRepository,
+    private val aggregateGroceryListUseCase: AggregateGroceryListUseCase,
+    private val settingsDataStore: SettingsDataStore
+) : ViewModel() {
+
+    private val _step = MutableStateFlow(GroceryListStep.SELECT_RECIPES)
+    val step: StateFlow<GroceryListStep> = _step.asStateFlow()
+
+    private val _mealPlanEntries = MutableStateFlow<List<MealPlanEntry>>(emptyList())
+
+    private val _selectedEntryIds = MutableStateFlow<Set<String>>(emptySet())
+
+    val selectableEntries: StateFlow<Map<LocalDate, List<SelectableMealPlanEntry>>> = combine(
+        _mealPlanEntries,
+        _selectedEntryIds
+    ) { entries, selectedIds ->
+        entries.map { entry ->
+            SelectableMealPlanEntry(
+                entry = entry,
+                isSelected = entry.id in selectedIds
+            )
+        }.groupBy { it.entry.date }
+            .mapValues { (_, entries) ->
+                entries.sortedWith(
+                    compareBy<SelectableMealPlanEntry> { it.entry.mealType.displayOrder }
+                        .thenBy { it.entry.recipeName }
+                )
+            }.toSortedMap()
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = emptyMap()
+    )
+
+    // Grocery list state
+    private val _groceryItems = MutableStateFlow<List<GroceryItem>>(emptyList())
+    private val _checkedItems = MutableStateFlow<Set<String>>(emptySet())
+    private val _checkedSources = MutableStateFlow<Set<String>>(emptySet())
+
+    private val _volumeSystem = MutableStateFlow(UnitSystem.CUSTOMARY)
+    private val _weightSystem = MutableStateFlow(UnitSystem.METRIC)
+
+    val displayGroceryItems: StateFlow<List<DisplayGroceryItem>> = combine(
+        _groceryItems,
+        _checkedItems,
+        _checkedSources,
+        _volumeSystem,
+        _weightSystem
+    ) { items, checkedItems, checkedSources, volumeSystem, weightSystem ->
+        items.mapNotNull { item ->
+            buildDisplayItem(item, checkedItems, checkedSources, volumeSystem, weightSystem)
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = emptyList()
+    )
+
+    init {
+        loadMealPlans()
+        viewModelScope.launch {
+            settingsDataStore.volumeUnitSystem.collect { _volumeSystem.value = it }
+        }
+        viewModelScope.launch {
+            settingsDataStore.weightUnitSystem.collect { _weightSystem.value = it }
+        }
+    }
+
+    private fun loadMealPlans() {
+        viewModelScope.launch {
+            val entries = mealPlanRepository.getAllMealPlansOnce()
+            _mealPlanEntries.value = entries.sortedWith(
+                compareBy<MealPlanEntry> { it.date }
+                    .thenBy { it.mealType.displayOrder }
+                    .thenBy { it.recipeName }
+            )
+            // Select all by default
+            _selectedEntryIds.value = entries.map { it.id }.toSet()
+        }
+    }
+
+    fun toggleEntrySelection(entryId: String) {
+        val current = _selectedEntryIds.value
+        _selectedEntryIds.value = if (entryId in current) {
+            current - entryId
+        } else {
+            current + entryId
+        }
+    }
+
+    fun selectAll() {
+        _selectedEntryIds.value = _mealPlanEntries.value.map { it.id }.toSet()
+    }
+
+    fun deselectAll() {
+        _selectedEntryIds.value = emptySet()
+    }
+
+    fun generateGroceryList() {
+        viewModelScope.launch {
+            val selectedIds = _selectedEntryIds.value
+            val selectedEntries = _mealPlanEntries.value.filter { it.id in selectedIds }
+
+            // Load recipes for selected entries
+            val entriesWithRecipes = selectedEntries.mapNotNull { entry ->
+                val recipe = recipeRepository.getRecipeByIdOnce(entry.recipeId)
+                if (recipe != null) entry to recipe else null
+            }
+
+            val items = aggregateGroceryListUseCase.execute(entriesWithRecipes)
+            _groceryItems.value = items
+            _checkedItems.value = emptySet()
+            _checkedSources.value = emptySet()
+            _step.value = GroceryListStep.VIEW_LIST
+        }
+    }
+
+    fun backToSelection() {
+        _step.value = GroceryListStep.SELECT_RECIPES
+    }
+
+    fun toggleItemChecked(key: String) {
+        val current = _checkedItems.value
+        _checkedItems.value = if (key in current) {
+            current - key
+        } else {
+            current + key
+        }
+    }
+
+    fun toggleSourceChecked(key: String) {
+        val current = _checkedSources.value
+        _checkedSources.value = if (key in current) {
+            current - key
+        } else {
+            current + key
+        }
+    }
+
+    /**
+     * Build a shareable Markdown string of the grocery list.
+     */
+    fun getShareText(): String {
+        val items = displayGroceryItems.value
+        return buildString {
+            appendLine("# Grocery List")
+            appendLine()
+            for (item in items) {
+                if (item.isChecked) continue
+                val uncheckedSources = item.sources.filter { !it.isChecked }
+                if (uncheckedSources.isEmpty()) continue
+
+                if (uncheckedSources.size == 1) {
+                    // Single source - show the detailed line
+                    val source = uncheckedSources.first()
+                    appendLine("- [ ] ${source.displayText} (${source.recipeName})")
+                } else {
+                    // Multiple sources - show aggregate header and sub-items
+                    val headerText = if (item.totalAmount != null) {
+                        "${item.totalAmount} ${item.displayText}"
+                    } else {
+                        item.displayText
+                    }
+                    appendLine("- [ ] $headerText")
+                    for (source in uncheckedSources) {
+                        appendLine("  - [ ] ${source.displayText} (${source.recipeName})")
+                    }
+                }
+            }
+        }.trimEnd()
+    }
+
+    private fun buildDisplayItem(
+        item: GroceryItem,
+        checkedItems: Set<String>,
+        checkedSources: Set<String>,
+        volumeSystem: UnitSystem,
+        weightSystem: UnitSystem
+    ): DisplayGroceryItem {
+        val itemKey = item.normalizedName.lowercase()
+        val isItemChecked = itemKey in checkedItems
+
+        val displaySources = item.sources.map { source ->
+            val sourceKey = sourceKey(itemKey, source)
+            // Use the existing Ingredient.format() which correctly handles
+            // scaling, unit conversion, fractions, and pluralization
+            val ingredientText = source.ingredient.format(
+                scale = source.scale,
+                volumeSystem = volumeSystem,
+                weightSystem = weightSystem
+            )
+            DisplayGrocerySource(
+                key = sourceKey,
+                displayText = ingredientText,
+                recipeName = source.recipeName,
+                isChecked = sourceKey in checkedSources
+            )
+        }
+
+        // Calculate total display amount for aggregate header
+        val totalAmountText = if (displaySources.size > 1) {
+            calculateTotalDisplay(item.sources, itemKey, checkedSources, volumeSystem, weightSystem)
+        } else {
+            null
+        }
+
+        return DisplayGroceryItem(
+            key = itemKey,
+            displayText = item.normalizedName,
+            totalAmount = totalAmountText,
+            isChecked = isItemChecked,
+            sources = displaySources
+        )
+    }
+
+    /**
+     * Calculate the aggregate display amount by summing all unchecked sources.
+     * Uses Ingredient.getDisplayAmount() to get each source's scaled amount,
+     * then converts to base units to sum, then back to a display unit.
+     */
+    private fun calculateTotalDisplay(
+        sources: List<GroceryIngredientSource>,
+        itemKey: String,
+        checkedSources: Set<String>,
+        volumeSystem: UnitSystem,
+        weightSystem: UnitSystem
+    ): String? {
+        var totalBase = 0.0
+        var unitCategory: UnitCategory? = null
+        var countTotal = 0.0
+        var hasUnit = false
+        var hasCountOnly = false
+        var anyUnchecked = false
+
+        for (source in sources) {
+            val key = sourceKey(itemKey, source)
+            if (key in checkedSources) continue
+            anyUnchecked = true
+
+            // Use the same getDisplayAmount that format() uses internally
+            val displayAmount = source.ingredient.getDisplayAmount(
+                scale = source.scale,
+                volumeSystem = volumeSystem,
+                weightSystem = weightSystem
+            ) ?: continue
+            val value = displayAmount.value ?: continue
+
+            if (displayAmount.unit != null) {
+                hasUnit = true
+                val cat = unitType(displayAmount.unit)
+                if (cat != null) {
+                    if (unitCategory == null) unitCategory = cat
+                    if (cat == unitCategory) {
+                        val base = toBaseUnitValue(value, displayAmount.unit)
+                        if (base != null) totalBase += base
+                    }
+                }
+            } else {
+                // Count item (no unit, like "3 eggs")
+                hasCountOnly = true
+                countTotal += value
+            }
+        }
+
+        if (!anyUnchecked) return null
+
+        return when {
+            hasUnit && unitCategory != null && totalBase > 0 -> {
+                val displayAmount = fromBaseUnit(totalBase, unitCategory, volumeSystem, weightSystem)
+                formatAmountForDisplay(displayAmount)
+            }
+            !hasUnit && hasCountOnly && countTotal > 0 -> {
+                formatCountForDisplay(countTotal)
+            }
+            else -> null
+        }
+    }
+
+    private fun sourceKey(itemKey: String, source: GroceryIngredientSource): String {
+        return "${itemKey}_${source.recipeName}_${source.ingredient.name}".lowercase()
+    }
+
+    private fun formatAmountForDisplay(amount: Amount): String? {
+        val value = amount.value ?: return null
+        val formatted = if (value == value.toLong().toDouble()) {
+            value.toLong().toString()
+        } else {
+            "%.1f".format(value).trimEnd('0').trimEnd('.')
+        }
+        return if (amount.unit != null) "$formatted ${amount.unit}" else formatted
+    }
+
+    private fun formatCountForDisplay(count: Double): String {
+        return if (count == count.toLong().toDouble()) {
+            count.toLong().toString()
+        } else {
+            "%.1f".format(count).trimEnd('0').trimEnd('.')
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material.icons.filled.Today
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -70,6 +71,7 @@ import java.util.Locale
 fun MealPlanScreen(
     onRecipeClick: (String) -> Unit,
     onBackClick: () -> Unit,
+    onGroceryListClick: () -> Unit,
     viewModel: MealPlanViewModel = hiltViewModel()
 ) {
     val weekStart by viewModel.currentWeekStart.collectAsStateWithLifecycle()
@@ -105,6 +107,12 @@ fun MealPlanScreen(
                 title = stringResource(R.string.meal_planner),
                 onBackClick = onBackClick,
                 actions = {
+                    IconButton(onClick = onGroceryListClick) {
+                        Icon(
+                            imageVector = Icons.Default.ShoppingCart,
+                            contentDescription = stringResource(R.string.grocery_list)
+                        )
+                    }
                     IconButton(onClick = { viewModel.goToToday() }) {
                         Icon(
                             imageVector = Icons.Default.Today,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,4 +248,13 @@
     <string name="edit_meal_plan">Edit Meal Plan</string>
     <string name="save">Save</string>
     <string name="recipes">Recipes</string>
+
+    <!-- Grocery List -->
+    <string name="grocery_list">Grocery List</string>
+    <string name="generate_grocery_list">Generate Grocery List</string>
+    <string name="share_grocery_list">Share grocery list</string>
+    <string name="grocery_list_empty_hint">Add meals to your meal plan first</string>
+    <string name="no_ingredients">No ingredients found</string>
+    <string name="select_all">Select All</string>
+    <string name="deselect_all">Deselect All</string>
 </resources>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -86,11 +86,17 @@ app: {
         tooltip: "Weekly meal planner view. Shows meals grouped by day with swipe-to-delete, swipe-to-edit, and long-press menu (edit/delete). Recipe selector bottom sheet with search, tag filter, date picker, meal type selector, and servings. Supports edit mode to modify date, meal type, servings, and recipe of existing entries."
       }
 
+      grocery_list: {
+        label: GroceryListScreen
+        tooltip: "Two-step grocery list generator. Step 1: Select recipes from meal plan entries (grouped by date/meal type, with select all/deselect all). Step 2: View aggregated ingredient list with deduplication across recipes, check-off support (top-level hides all, sub-item reduces count), and share as Markdown."
+      }
+
       list -> detail: tap recipe
       list -> add: tap +
       list -> settings: tap gear
       list -> meal_plan: tap calendar
       meal_plan -> detail: tap recipe
+      meal_plan -> grocery_list: tap cart icon
       add -> settings: no API key
       settings -> import_debug_list: view debug data
       import_debug_list -> import_debug_detail: tap entry
@@ -147,6 +153,10 @@ app: {
         label: MealPlanViewModel
         tooltip: "Manages weekly meal plan view state, add/edit dialog, and CRUD operations for meal plan entries. Supports editing existing entries (date, meal type, servings, recipe). Respects user's start-of-week setting from preferences. Triggers incremental Google Drive sync on changes."
       }
+      grocery_list_vm: {
+        label: GroceryListViewModel
+        tooltip: "Manages grocery list generation from meal plan. Two-step flow: recipe selection (from all meal plan entries) then aggregated ingredient display with check-off and share-as-Markdown support. Non-persistent state."
+      }
     }
 
     state: {
@@ -168,6 +178,7 @@ app: {
     screens.settings -> viewmodels.drive_vm: sign in/out
     screens.settings -> viewmodels.zip_vm: backup/restore
     screens.meal_plan -> viewmodels.meal_plan_vm
+    screens.grocery_list -> viewmodels.grocery_list_vm
     screens.import_debug_list -> viewmodels.import_debug_list_vm
     screens.import_debug_detail -> viewmodels.import_debug_detail_vm
     viewmodels.list_vm -> state.in_progress_mgr: observes, cancel
@@ -296,6 +307,10 @@ app: {
       sync_meal_plans: {
         label: SyncMealPlansToGoogleDriveUseCase
         tooltip: "Bidirectional sync of meal plans with Google Drive. Stores one JSON file per day in a meal-plans subfolder. Handles soft-delete tracking, conflict resolution by timestamp, and purges deleted entries after sync."
+      }
+      aggregate_grocery: {
+        label: AggregateGroceryListUseCase
+        tooltip: "Aggregates ingredients from selected meal plan recipes into a deduplicated grocery list. Normalizes ingredient names by removing size prefixes (small/medium/large), sums amounts in base units across recipes."
       }
       tags: GetTagsUseCase
       calc_usage: {
@@ -575,6 +590,10 @@ app: {
   ui.viewmodels.meal_plan_vm -> data.repository.repo: recipe list
   ui.viewmodels.meal_plan_vm -> data.local.settings: start of week
   ui.viewmodels.meal_plan_vm -> domain.usecases.tags: top tags
+  ui.viewmodels.grocery_list_vm -> data.repository.meal_plan_repo: meal plans
+  ui.viewmodels.grocery_list_vm -> data.repository.repo: recipes
+  ui.viewmodels.grocery_list_vm -> domain.usecases.aggregate_grocery: aggregate ingredients
+  ui.viewmodels.grocery_list_vm -> data.local.settings: unit prefs
   domain.usecases.sync_drive -> domain.usecases.sync_meal_plans: sync meal plans
   domain.usecases.sync_meal_plans -> data.repository.meal_plan_repo: access data
   ui.viewmodels.settings_vm -> data.repository.import_debug_repo: delete debug data
@@ -711,4 +730,19 @@ legend: {
   mp7: "Incremental sync triggered on add/update/delete"
 
   mp1 -> mp2 -> mp3 -> mp4 -> mp5 -> mp6 -> mp7
+
+  grocery_flow: {
+    label: "Grocery List Feature"
+    style: {
+      font-size: 14
+      bold: true
+    }
+  }
+  gl1: "Select recipes from meal plan entries (grouped by date and meal type)"
+  gl2: "Aggregate ingredients across recipes: deduplicate by normalized name, sum amounts in base units"
+  gl3: "Display with check-off support: top-level hides all sub-items, sub-item reduces aggregate count"
+  gl4: "Share as Markdown via Android share sheet"
+  gl5: "Non-persistent: state resets between app sessions"
+
+  gl1 -> gl2 -> gl3 -> gl4 -> gl5
 }


### PR DESCRIPTION
## Summary

- Adds a grocery list feature accessible from the meal plan screen via a shopping cart icon in the top bar
- Two-step flow: select meal plan recipes to include, then view aggregated ingredient list
- Ingredients deduplicated across recipes by normalizing names (removing size prefixes like small/medium/large, singularizing), with amounts summed in base units (grams/mL)
- Check-off support: top-level hides whole ingredient, sub-item hides just that source and reduces aggregate count
- Single-source ingredients shown directly without grouping
- Share button exports the list as Markdown via Android share sheet
- Non-persistent state (resets between app sessions as specified in the issue)

Closes #154

## Test plan

- [ ] Open meal plan screen and tap the shopping cart icon in the top bar
- [ ] Verify recipe selection screen shows all meal plan entries grouped by date and meal type
- [ ] Test Select All / Deselect All buttons
- [ ] Generate grocery list and verify ingredients are deduplicated across recipes
- [ ] Verify single-source ingredients display as a single line with recipe name
- [ ] Verify multi-source ingredients show aggregate header with expandable sub-items
- [ ] Test checking off a top-level ingredient hides it completely
- [ ] Test checking off a sub-ingredient hides it and recalculates the aggregate amount
- [ ] Test the share button generates correct Markdown output
- [ ] Verify amounts respect user's unit system preferences (customary/metric)
- [ ] Verify back navigation works correctly between grocery list steps and meal plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)