### PR TITLE
Fix recipe metadata section layout to display items vertically

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeMetadata.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeMetadata.kt
@@ -1,7 +1,6 @@
 package com.lionotter.recipes.ui.screens.recipedetail.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
@@ -36,11 +35,10 @@ internal fun RecipeMetadata(recipe: Recipe, scale: Double) {
                 containerColor = MaterialTheme.colorScheme.primaryContainer
             )
         ) {
-            Row(
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(12.dp),
-                horizontalArrangement = Arrangement.SpaceEvenly
             ) {
                 items.forEach { item ->
                     Text(


### PR DESCRIPTION
## Summary
- Fixes the Prep / Cook / Total / Servings section which was crammed into a single row, causing awkward text wrapping on narrower screens
- Changed the layout from a horizontal `Row` with `SpaceEvenly` arrangement to a vertical `Column`, so each metadata item displays on its own line

Fixes #176

## Test plan
- [ ] Open a recipe that has prep time, cook time, total time, and servings
- [ ] Verify each metadata item appears on its own line within the card
- [ ] Verify the layout looks correct on both narrow and wide screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)