### PR TITLE
feat: default measurement units based on device locale

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -109,18 +109,18 @@ class SettingsDataStore @Inject constructor(
     val volumeUnitSystem: Flow<UnitSystem> = context.dataStore.data.map { preferences ->
         val value = preferences[Keys.VOLUME_UNIT_SYSTEM]
         if (value != null) {
-            try { UnitSystem.valueOf(value) } catch (_: IllegalArgumentException) { UnitSystem.CUSTOMARY }
+            try { UnitSystem.valueOf(value) } catch (_: IllegalArgumentException) { UnitSystem.localeDefault() }
         } else {
-            UnitSystem.CUSTOMARY
+            UnitSystem.localeDefault()
         }
     }
 
     val weightUnitSystem: Flow<UnitSystem> = context.dataStore.data.map { preferences ->
         val value = preferences[Keys.WEIGHT_UNIT_SYSTEM]
         if (value != null) {
-            try { UnitSystem.valueOf(value) } catch (_: IllegalArgumentException) { UnitSystem.METRIC }
+            try { UnitSystem.valueOf(value) } catch (_: IllegalArgumentException) { UnitSystem.localeDefault() }
         } else {
-            UnitSystem.METRIC
+            UnitSystem.localeDefault()
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
@@ -148,8 +148,8 @@ data class Ingredient(
     fun format(
         scale: Double = 1.0,
         preference: MeasurementPreference = MeasurementPreference.DEFAULT,
-        volumeSystem: UnitSystem = UnitSystem.CUSTOMARY,
-        weightSystem: UnitSystem = UnitSystem.METRIC
+        volumeSystem: UnitSystem = UnitSystem.localeDefault(),
+        weightSystem: UnitSystem = UnitSystem.localeDefault()
     ): String {
         val displayAmount = getDisplayAmount(scale, preference, volumeSystem, weightSystem)
             ?: return name + (notes?.let { ", $it" } ?: "")
@@ -189,8 +189,8 @@ data class Ingredient(
     fun getDisplayAmount(
         scale: Double = 1.0,
         preference: MeasurementPreference = MeasurementPreference.DEFAULT,
-        volumeSystem: UnitSystem = UnitSystem.CUSTOMARY,
-        weightSystem: UnitSystem = UnitSystem.METRIC
+        volumeSystem: UnitSystem = UnitSystem.localeDefault(),
+        weightSystem: UnitSystem = UnitSystem.localeDefault()
     ): Amount? {
         val amt = amount ?: return null
         val scaledValue = amt.value?.let { it * scale }
@@ -372,8 +372,8 @@ private fun convertAmount(
     fromType: UnitCategory,
     toType: UnitCategory,
     density: Double,
-    volumeSystem: UnitSystem = UnitSystem.CUSTOMARY,
-    weightSystem: UnitSystem = UnitSystem.METRIC
+    volumeSystem: UnitSystem = UnitSystem.localeDefault(),
+    weightSystem: UnitSystem = UnitSystem.localeDefault()
 ): Amount {
     return when {
         fromType == UnitCategory.VOLUME && toType == UnitCategory.WEIGHT -> {
@@ -402,8 +402,8 @@ private fun convertAmount(
 internal fun convertToSystem(
     value: Double?,
     unit: String,
-    volumeSystem: UnitSystem = UnitSystem.CUSTOMARY,
-    weightSystem: UnitSystem = UnitSystem.METRIC
+    volumeSystem: UnitSystem = UnitSystem.localeDefault(),
+    weightSystem: UnitSystem = UnitSystem.localeDefault()
 ): Amount {
     if (value == null) return Amount(value, unit)
 

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/UnitSystem.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/UnitSystem.kt
@@ -1,9 +1,25 @@
 package com.lionotter.recipes.domain.model
 
+import java.util.Locale
+
 /**
  * User preference for which unit system to use for a given measurement category.
  */
 enum class UnitSystem {
     METRIC,
-    CUSTOMARY
+    CUSTOMARY;
+
+    companion object {
+        /**
+         * Returns the default unit system based on the device locale.
+         * The US, Liberia, and Myanmar are the only countries that use
+         * the US customary system; everyone else defaults to metric.
+         */
+        fun localeDefault(locale: Locale = Locale.getDefault()): UnitSystem {
+            return when (locale.country.uppercase()) {
+                "US", "LR", "MM" -> CUSTOMARY
+                else -> METRIC
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/CalculateIngredientUsageUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/CalculateIngredientUsageUseCase.kt
@@ -43,8 +43,8 @@ class CalculateIngredientUsageUseCase @Inject constructor() {
         usedInstructionIngredients: Set<InstructionIngredientKey>,
         scale: Double,
         measurementPreference: MeasurementPreference,
-        volumeSystem: UnitSystem = UnitSystem.CUSTOMARY,
-        weightSystem: UnitSystem = UnitSystem.METRIC
+        volumeSystem: UnitSystem = UnitSystem.localeDefault(),
+        weightSystem: UnitSystem = UnitSystem.localeDefault()
     ): Map<String, IngredientUsageStatus> {
         val globalTotals = buildGlobalTotals(recipe, scale, measurementPreference, volumeSystem, weightSystem)
         val usedAmounts = buildUsedAmounts(recipe, usedInstructionIngredients, scale, measurementPreference, volumeSystem, weightSystem)

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModel.kt
@@ -99,8 +99,8 @@ class GroceryListViewModel @Inject constructor(
     private val _checkedItems = MutableStateFlow<Set<String>>(emptySet())
     private val _checkedSources = MutableStateFlow<Set<String>>(emptySet())
 
-    private val _volumeSystem = MutableStateFlow(UnitSystem.CUSTOMARY)
-    private val _weightSystem = MutableStateFlow(UnitSystem.METRIC)
+    private val _volumeSystem = MutableStateFlow(UnitSystem.localeDefault())
+    private val _weightSystem = MutableStateFlow(UnitSystem.localeDefault())
 
     val displayGroceryItems: StateFlow<List<DisplayGroceryItem>> = combine(
         _groceryItems,

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
@@ -92,14 +92,14 @@ class RecipeDetailViewModel @Inject constructor(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
-            initialValue = UnitSystem.CUSTOMARY
+            initialValue = UnitSystem.localeDefault()
         )
 
     val weightUnitSystem: StateFlow<UnitSystem> = settingsDataStore.weightUnitSystem
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
-            initialValue = UnitSystem.METRIC
+            initialValue = UnitSystem.localeDefault()
         )
 
     private val _scale = MutableStateFlow(1.0)

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/IngredientSectionContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/IngredientSectionContent.kt
@@ -30,8 +30,8 @@ internal fun IngredientSectionContent(
     scale: Double,
     measurementPreference: MeasurementPreference,
     globalIngredientUsage: Map<String, IngredientUsageStatus>,
-    volumeUnitSystem: UnitSystem = UnitSystem.CUSTOMARY,
-    weightUnitSystem: UnitSystem = UnitSystem.METRIC
+    volumeUnitSystem: UnitSystem = UnitSystem.localeDefault(),
+    weightUnitSystem: UnitSystem = UnitSystem.localeDefault()
 ) {
     Column {
         section.name?.let { name ->

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/InstructionSectionContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/InstructionSectionContent.kt
@@ -38,8 +38,8 @@ internal fun InstructionSectionContent(
     onToggleIngredient: (Int, Int, Int) -> Unit,
     highlightedInstructionStep: HighlightedInstructionStep?,
     onToggleHighlightedInstruction: (Int, Int) -> Unit,
-    volumeUnitSystem: UnitSystem = UnitSystem.CUSTOMARY,
-    weightUnitSystem: UnitSystem = UnitSystem.METRIC
+    volumeUnitSystem: UnitSystem = UnitSystem.localeDefault(),
+    weightUnitSystem: UnitSystem = UnitSystem.localeDefault()
 ) {
     Column {
         section.name?.let { name ->

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
@@ -54,8 +54,8 @@ fun RecipeContent(
     onToggleInstructionIngredient: (Int, Int, Int) -> Unit,
     highlightedInstructionStep: HighlightedInstructionStep?,
     onToggleHighlightedInstruction: (Int, Int) -> Unit,
-    volumeUnitSystem: UnitSystem = UnitSystem.CUSTOMARY,
-    weightUnitSystem: UnitSystem = UnitSystem.METRIC,
+    volumeUnitSystem: UnitSystem = UnitSystem.localeDefault(),
+    weightUnitSystem: UnitSystem = UnitSystem.localeDefault(),
     modifier: Modifier = Modifier
 ) {
     Column(

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -62,14 +62,14 @@ class SettingsViewModel @Inject constructor(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
-            initialValue = UnitSystem.CUSTOMARY
+            initialValue = UnitSystem.localeDefault()
         )
 
     val weightUnitSystem: StateFlow<UnitSystem> = settingsDataStore.weightUnitSystem
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
-            initialValue = UnitSystem.METRIC
+            initialValue = UnitSystem.localeDefault()
         )
 
     val startOfWeek: StateFlow<StartOfWeek> = settingsDataStore.startOfWeek

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/model/IngredientTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/model/IngredientTest.kt
@@ -17,7 +17,7 @@ class IngredientTest {
             density = 0.51,
             notes = "sifted"
         )
-        assertEquals("2 cups flour, sifted", ingredient.format())
+        assertEquals("2 cups flour, sifted", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -27,7 +27,7 @@ class IngredientTest {
             amount = Amount(value = 1.0, unit = "cup"),
             density = 0.84
         )
-        assertEquals("1 cup sugar", ingredient.format())
+        assertEquals("1 cup sugar", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -89,7 +89,7 @@ class IngredientTest {
             amount = Amount(value = 500.0, unit = "g"),
             density = 0.51
         )
-        assertEquals("500 g flour", ingredient.format())
+        assertEquals("500 g flour", ingredient.format(weightSystem = UnitSystem.METRIC))
     }
 
     @Test
@@ -111,7 +111,7 @@ class IngredientTest {
             amount = Amount(value = 2.0, unit = "tsp"),
             density = 1.22
         )
-        assertEquals("2 tsp salt", ingredient.format())
+        assertEquals("2 tsp salt", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -121,7 +121,7 @@ class IngredientTest {
             amount = Amount(value = 3.0, unit = "tbsp"),
             density = 0.92
         )
-        assertEquals("3 tbsp olive oil", ingredient.format())
+        assertEquals("3 tbsp olive oil", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -131,7 +131,7 @@ class IngredientTest {
             amount = Amount(value = 1.0, unit = "cup"),
             density = 0.96
         )
-        assertEquals("2 cups butter", ingredient.format(scale = 2.0))
+        assertEquals("2 cups butter", ingredient.format(scale = 2.0, volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -141,7 +141,7 @@ class IngredientTest {
             amount = Amount(value = 0.5, unit = "cup"),
             density = 0.96
         )
-        assertEquals("1/2 cup milk", ingredient.format())
+        assertEquals("1/2 cup milk", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -151,7 +151,7 @@ class IngredientTest {
             amount = Amount(value = 0.25, unit = "tsp"),
             density = 0.95
         )
-        assertEquals("1/4 tsp vanilla", ingredient.format())
+        assertEquals("1/4 tsp vanilla", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -161,7 +161,7 @@ class IngredientTest {
             amount = Amount(value = 2.5, unit = "cup"),
             density = 0.51
         )
-        assertEquals("2 1/2 cups flour", ingredient.format())
+        assertEquals("2 1/2 cups flour", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -171,7 +171,7 @@ class IngredientTest {
             amount = Amount(value = 0.33, unit = "cup"),
             density = 0.84
         )
-        assertEquals("1/3 cup oil", ingredient.format())
+        assertEquals("1/3 cup oil", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -181,7 +181,7 @@ class IngredientTest {
             amount = Amount(value = 0.66, unit = "cup"),
             density = 0.96
         )
-        assertEquals("2/3 cup water", ingredient.format())
+        assertEquals("2/3 cup water", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -191,7 +191,7 @@ class IngredientTest {
             amount = Amount(value = 0.75, unit = "cup"),
             density = 0.96
         )
-        assertEquals("3/4 cup cream", ingredient.format())
+        assertEquals("3/4 cup cream", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -201,7 +201,7 @@ class IngredientTest {
             amount = Amount(value = 1.0, unit = "cup"),
             density = 0.84
         )
-        assertEquals("1/2 cup sugar", ingredient.format(scale = 0.5))
+        assertEquals("1/2 cup sugar", ingredient.format(scale = 0.5, volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -217,7 +217,7 @@ class IngredientTest {
             density = 0.54,
             alternates = listOf(alternate)
         )
-        assertEquals("1 tsp kosher salt", ingredient.format())
+        assertEquals("1 tsp kosher salt", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -227,7 +227,7 @@ class IngredientTest {
             amount = Amount(value = 0.5, unit = "tsp"),
             density = 1.22
         )
-        assertEquals("1 tsp table salt", alternate.format(scale = 2.0))
+        assertEquals("1 tsp table salt", alternate.format(scale = 2.0, volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -249,7 +249,7 @@ class IngredientTest {
             density = 0.54,
             alternates = alternates
         )
-        assertEquals("1 tsp kosher salt", ingredient.format())
+        assertEquals("1 tsp kosher salt", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
         assertEquals(2, ingredient.alternates.size)
     }
 
@@ -260,7 +260,7 @@ class IngredientTest {
             amount = Amount(value = 250.0, unit = "g"),
             density = 0.51
         )
-        val formatted = ingredient.format(preference = MeasurementPreference.VOLUME)
+        val formatted = ingredient.format(preference = MeasurementPreference.VOLUME, volumeSystem = UnitSystem.CUSTOMARY)
         assertTrue(formatted.contains("flour"))
         assertTrue(formatted.contains("cup"))
     }
@@ -284,7 +284,7 @@ class IngredientTest {
             amount = Amount(value = 2.0, unit = "cup"),
             density = 0.51
         )
-        assertEquals("2 cups flour", ingredient.format(preference = MeasurementPreference.DEFAULT))
+        assertEquals("2 cups flour", ingredient.format(preference = MeasurementPreference.DEFAULT, volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     @Test
@@ -342,7 +342,7 @@ class IngredientTest {
             amount = Amount(value = 2.0, unit = "cup"),
             density = 0.51
         )
-        val result = ingredient.getDisplayAmount(scale = 2.0, preference = MeasurementPreference.DEFAULT)
+        val result = ingredient.getDisplayAmount(scale = 2.0, preference = MeasurementPreference.DEFAULT, volumeSystem = UnitSystem.CUSTOMARY)
         assertNotNull(result)
         assertEquals(4.0, result!!.value!!, 0.01)
         assertEquals("cup", result.unit)
@@ -386,7 +386,7 @@ class IngredientTest {
             amount = Amount(value = 2.67, unit = "g")
         )
         // Should show "2.7 g" not "2 2/3 g"
-        assertEquals("2.7 g salt", ingredient.format())
+        assertEquals("2.7 g salt", ingredient.format(weightSystem = UnitSystem.METRIC))
     }
 
     @Test
@@ -395,7 +395,7 @@ class IngredientTest {
             name = "flour",
             amount = Amount(value = 10.25, unit = "kg")
         )
-        assertEquals("10 kg flour", ingredient.format())
+        assertEquals("10 kg flour", ingredient.format(weightSystem = UnitSystem.METRIC))
     }
 
     @Test
@@ -445,7 +445,7 @@ class IngredientTest {
             amount = Amount(value = 9.33, unit = "g")
         )
         // Should show "9 g" (rounded since >= 10 threshold is close), actually 9.33 < 10 so 9.3
-        assertEquals("9.3 g vanilla extract", ingredient.format())
+        assertEquals("9.3 g vanilla extract", ingredient.format(weightSystem = UnitSystem.METRIC))
     }
 
     @Test
@@ -455,7 +455,7 @@ class IngredientTest {
             name = "saffron",
             amount = Amount(value = 500.0, unit = "mg")
         )
-        assertEquals("500 mg saffron", ingredient.format())
+        assertEquals("500 mg saffron", ingredient.format(weightSystem = UnitSystem.METRIC))
     }
 
     @Test
@@ -556,7 +556,7 @@ class IngredientTest {
             name = "sugar",
             amount = Amount(value = 100.0, unit = "g")
         )
-        assertEquals("100 g sugar", ingredient.format())
+        assertEquals("100 g sugar", ingredient.format(weightSystem = UnitSystem.METRIC))
     }
 
     @Test
@@ -565,7 +565,7 @@ class IngredientTest {
             name = "salt",
             amount = Amount(value = 2.5, unit = "g")
         )
-        assertEquals("2.5 g salt", ingredient.format())
+        assertEquals("2.5 g salt", ingredient.format(weightSystem = UnitSystem.METRIC))
     }
 
     @Test
@@ -574,7 +574,7 @@ class IngredientTest {
             name = "sugar",
             amount = Amount(value = 15.7, unit = "g")
         )
-        assertEquals("16 g sugar", ingredient.format())
+        assertEquals("16 g sugar", ingredient.format(weightSystem = UnitSystem.METRIC))
     }
 
     @Test
@@ -584,7 +584,7 @@ class IngredientTest {
             name = "milk",
             amount = Amount(value = 0.25, unit = "cup")
         )
-        assertEquals("1/4 cup milk", ingredient.format())
+        assertEquals("1/4 cup milk", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
     }
 
     // --- Compound lb+oz display tests ---

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/model/UnitSystemTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/model/UnitSystemTest.kt
@@ -1,0 +1,48 @@
+package com.lionotter.recipes.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Locale
+
+class UnitSystemTest {
+
+    @Test
+    fun `localeDefault returns CUSTOMARY for US locale`() {
+        assertEquals(UnitSystem.CUSTOMARY, UnitSystem.localeDefault(Locale.US))
+    }
+
+    @Test
+    fun `localeDefault returns CUSTOMARY for Liberia locale`() {
+        assertEquals(UnitSystem.CUSTOMARY, UnitSystem.localeDefault(Locale("en", "LR")))
+    }
+
+    @Test
+    fun `localeDefault returns CUSTOMARY for Myanmar locale`() {
+        assertEquals(UnitSystem.CUSTOMARY, UnitSystem.localeDefault(Locale("my", "MM")))
+    }
+
+    @Test
+    fun `localeDefault returns METRIC for UK locale`() {
+        assertEquals(UnitSystem.METRIC, UnitSystem.localeDefault(Locale.UK))
+    }
+
+    @Test
+    fun `localeDefault returns METRIC for France locale`() {
+        assertEquals(UnitSystem.METRIC, UnitSystem.localeDefault(Locale.FRANCE))
+    }
+
+    @Test
+    fun `localeDefault returns METRIC for Germany locale`() {
+        assertEquals(UnitSystem.METRIC, UnitSystem.localeDefault(Locale.GERMANY))
+    }
+
+    @Test
+    fun `localeDefault returns METRIC for Japan locale`() {
+        assertEquals(UnitSystem.METRIC, UnitSystem.localeDefault(Locale.JAPAN))
+    }
+
+    @Test
+    fun `localeDefault returns METRIC for Canada locale`() {
+        assertEquals(UnitSystem.METRIC, UnitSystem.localeDefault(Locale.CANADA))
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/usecase/CalculateIngredientUsageUseCaseTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/usecase/CalculateIngredientUsageUseCaseTest.kt
@@ -74,7 +74,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = usedKeys,
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val flour = result["flour"]
@@ -98,7 +100,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = usedKeys,
             scale = 1.0,
-            measurementPreference = MeasurementPreference.WEIGHT
+            measurementPreference = MeasurementPreference.WEIGHT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val flour = result["flour"]
@@ -125,7 +129,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = usedKeys,
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val flour = result["flour"]
@@ -145,7 +151,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = emptySet(),
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val sugar = result["sugar"]
@@ -166,7 +174,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = usedKeys,
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val sugar = result["sugar"]
@@ -189,7 +199,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = usedKeys,
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val eggs = result["eggs"]
@@ -215,7 +227,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = usedKeys,
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val butter = result["butter"]
@@ -238,7 +252,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = emptySet(),
             scale = 2.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val salt = result["salt"]
@@ -260,7 +276,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = emptySet(),
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val flour = result["flour"]
@@ -285,7 +303,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = usedKeys,
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val flour = result["flour"]
@@ -311,7 +331,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = usedKeys,
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val flour = result["flour"]
@@ -336,7 +358,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = usedKeys,
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val salt = result["salt"]
@@ -378,7 +402,9 @@ class CalculateIngredientUsageUseCaseTest {
             recipe = recipe,
             usedInstructionIngredients = usedKeys,
             scale = 1.0,
-            measurementPreference = MeasurementPreference.DEFAULT
+            measurementPreference = MeasurementPreference.DEFAULT,
+            volumeSystem = UnitSystem.CUSTOMARY,
+            weightSystem = UnitSystem.METRIC
         )
 
         val kosherSalt = result["kosher salt"]


### PR DESCRIPTION
## Summary
- Adds `UnitSystem.localeDefault()` that returns CUSTOMARY for US/Liberia/Myanmar locales and METRIC for all others
- Replaces all hardcoded measurement unit defaults across SettingsDataStore, ViewModels, composables, and domain functions with locale-aware defaults
- Users can still override the defaults in settings; this only changes the initial default before any preference is saved

Closes #175

## Test plan
- [x] Added `UnitSystemTest` with tests for US, UK, France, Germany, Japan, Canada, Liberia, and Myanmar locales
- [x] Updated existing `IngredientTest` cases to be explicit about unit system rather than relying on defaults
- [x] All unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Debug build succeeds (`./gradlew assembleDebug`)
- [x] Lint passes (`./gradlew lintDebug`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)