### PR TITLE
feat: separate unit settings for grocery list

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -42,6 +42,8 @@ class SettingsDataStore @Inject constructor(
         val IMPORT_DEBUGGING_ENABLED = booleanPreferencesKey("import_debugging_enabled")
         val VOLUME_UNIT_SYSTEM = stringPreferencesKey("volume_unit_system")
         val WEIGHT_UNIT_SYSTEM = stringPreferencesKey("weight_unit_system")
+        val GROCERY_VOLUME_UNIT_SYSTEM = stringPreferencesKey("grocery_volume_unit_system")
+        val GROCERY_WEIGHT_UNIT_SYSTEM = stringPreferencesKey("grocery_weight_unit_system")
         val START_OF_WEEK = stringPreferencesKey("start_of_week")
         const val ENCRYPTED_API_KEY = "anthropic_api_key"
     }
@@ -121,6 +123,46 @@ class SettingsDataStore @Inject constructor(
             try { UnitSystem.valueOf(value) } catch (_: IllegalArgumentException) { UnitSystem.localeDefault() }
         } else {
             UnitSystem.localeDefault()
+        }
+    }
+
+    /**
+     * Grocery list volume unit system. Falls back to the recipe volume unit system
+     * when no grocery-specific preference has been set.
+     */
+    val groceryVolumeUnitSystem: Flow<UnitSystem> = context.dataStore.data.map { preferences ->
+        val groceryValue = preferences[Keys.GROCERY_VOLUME_UNIT_SYSTEM]
+        if (groceryValue != null) {
+            try { UnitSystem.valueOf(groceryValue) } catch (_: IllegalArgumentException) { null }
+        } else {
+            null
+        } ?: run {
+            val recipeValue = preferences[Keys.VOLUME_UNIT_SYSTEM]
+            if (recipeValue != null) {
+                try { UnitSystem.valueOf(recipeValue) } catch (_: IllegalArgumentException) { UnitSystem.localeDefault() }
+            } else {
+                UnitSystem.localeDefault()
+            }
+        }
+    }
+
+    /**
+     * Grocery list weight unit system. Falls back to the recipe weight unit system
+     * when no grocery-specific preference has been set.
+     */
+    val groceryWeightUnitSystem: Flow<UnitSystem> = context.dataStore.data.map { preferences ->
+        val groceryValue = preferences[Keys.GROCERY_WEIGHT_UNIT_SYSTEM]
+        if (groceryValue != null) {
+            try { UnitSystem.valueOf(groceryValue) } catch (_: IllegalArgumentException) { null }
+        } else {
+            null
+        } ?: run {
+            val recipeValue = preferences[Keys.WEIGHT_UNIT_SYSTEM]
+            if (recipeValue != null) {
+                try { UnitSystem.valueOf(recipeValue) } catch (_: IllegalArgumentException) { UnitSystem.localeDefault() }
+            } else {
+                UnitSystem.localeDefault()
+            }
         }
     }
 
@@ -212,6 +254,18 @@ class SettingsDataStore @Inject constructor(
     suspend fun setWeightUnitSystem(system: UnitSystem) {
         context.dataStore.edit { preferences ->
             preferences[Keys.WEIGHT_UNIT_SYSTEM] = system.name
+        }
+    }
+
+    suspend fun setGroceryVolumeUnitSystem(system: UnitSystem) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.GROCERY_VOLUME_UNIT_SYSTEM] = system.name
+        }
+    }
+
+    suspend fun setGroceryWeightUnitSystem(system: UnitSystem) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.GROCERY_WEIGHT_UNIT_SYSTEM] = system.name
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModel.kt
@@ -121,10 +121,10 @@ class GroceryListViewModel @Inject constructor(
     init {
         loadMealPlans()
         viewModelScope.launch {
-            settingsDataStore.volumeUnitSystem.collect { _volumeSystem.value = it }
+            settingsDataStore.groceryVolumeUnitSystem.collect { _volumeSystem.value = it }
         }
         viewModelScope.launch {
-            settingsDataStore.weightUnitSystem.collect { _weightSystem.value = it }
+            settingsDataStore.groceryWeightUnitSystem.collect { _weightSystem.value = it }
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -64,6 +64,8 @@ fun SettingsScreen(
     val zipOperationState by zipViewModel.operationState.collectAsStateWithLifecycle()
     val volumeUnitSystem by viewModel.volumeUnitSystem.collectAsStateWithLifecycle()
     val weightUnitSystem by viewModel.weightUnitSystem.collectAsStateWithLifecycle()
+    val groceryVolumeUnitSystem by viewModel.groceryVolumeUnitSystem.collectAsStateWithLifecycle()
+    val groceryWeightUnitSystem by viewModel.groceryWeightUnitSystem.collectAsStateWithLifecycle()
     val startOfWeek by viewModel.startOfWeek.collectAsStateWithLifecycle()
     val importDebuggingEnabled by viewModel.importDebuggingEnabled.collectAsStateWithLifecycle()
 
@@ -197,7 +199,11 @@ fun SettingsScreen(
                 volumeUnitSystem = volumeUnitSystem,
                 onVolumeUnitSystemChange = viewModel::setVolumeUnitSystem,
                 weightUnitSystem = weightUnitSystem,
-                onWeightUnitSystemChange = viewModel::setWeightUnitSystem
+                onWeightUnitSystemChange = viewModel::setWeightUnitSystem,
+                groceryVolumeUnitSystem = groceryVolumeUnitSystem,
+                onGroceryVolumeUnitSystemChange = viewModel::setGroceryVolumeUnitSystem,
+                groceryWeightUnitSystem = groceryWeightUnitSystem,
+                onGroceryWeightUnitSystemChange = viewModel::setGroceryWeightUnitSystem
             )
 
             HorizontalDivider()

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -72,6 +72,20 @@ class SettingsViewModel @Inject constructor(
             initialValue = UnitSystem.localeDefault()
         )
 
+    val groceryVolumeUnitSystem: StateFlow<UnitSystem> = settingsDataStore.groceryVolumeUnitSystem
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = UnitSystem.localeDefault()
+        )
+
+    val groceryWeightUnitSystem: StateFlow<UnitSystem> = settingsDataStore.groceryWeightUnitSystem
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = UnitSystem.localeDefault()
+        )
+
     val startOfWeek: StateFlow<StartOfWeek> = settingsDataStore.startOfWeek
         .stateIn(
             scope = viewModelScope,
@@ -156,6 +170,18 @@ class SettingsViewModel @Inject constructor(
     fun setWeightUnitSystem(system: UnitSystem) {
         viewModelScope.launch {
             settingsDataStore.setWeightUnitSystem(system)
+        }
+    }
+
+    fun setGroceryVolumeUnitSystem(system: UnitSystem) {
+        viewModelScope.launch {
+            settingsDataStore.setGroceryVolumeUnitSystem(system)
+        }
+    }
+
+    fun setGroceryWeightUnitSystem(system: UnitSystem) {
+        viewModelScope.launch {
+            settingsDataStore.setGroceryWeightUnitSystem(system)
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/UnitPreferencesSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/UnitPreferencesSection.kt
@@ -22,7 +22,11 @@ fun UnitPreferencesSection(
     volumeUnitSystem: UnitSystem,
     onVolumeUnitSystemChange: (UnitSystem) -> Unit,
     weightUnitSystem: UnitSystem,
-    onWeightUnitSystemChange: (UnitSystem) -> Unit
+    onWeightUnitSystemChange: (UnitSystem) -> Unit,
+    groceryVolumeUnitSystem: UnitSystem,
+    onGroceryVolumeUnitSystemChange: (UnitSystem) -> Unit,
+    groceryWeightUnitSystem: UnitSystem,
+    onGroceryWeightUnitSystemChange: (UnitSystem) -> Unit
 ) {
     val options = listOf(
         UnitSystem.CUSTOMARY to stringResource(R.string.unit_system_customary),
@@ -35,60 +39,96 @@ fun UnitPreferencesSection(
             style = MaterialTheme.typography.titleMedium
         )
 
+        // Recipe units subsection
+        Text(
+            text = stringResource(R.string.recipe_units),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
         // Volume unit system
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text(
-                text = stringResource(R.string.volume_units),
-                style = MaterialTheme.typography.bodyLarge
-            )
-            Text(
-                text = stringResource(R.string.volume_units_description),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            SingleChoiceSegmentedButtonRow(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                options.forEachIndexed { index, (system, label) ->
-                    SegmentedButton(
-                        selected = volumeUnitSystem == system,
-                        onClick = { onVolumeUnitSystemChange(system) },
-                        shape = SegmentedButtonDefaults.itemShape(
-                            index = index,
-                            count = options.size
-                        )
-                    ) {
-                        Text(label)
-                    }
-                }
-            }
-        }
+        UnitSystemSelector(
+            label = stringResource(R.string.volume_units),
+            description = stringResource(R.string.volume_units_description),
+            selectedSystem = volumeUnitSystem,
+            onSystemChange = onVolumeUnitSystemChange,
+            options = options
+        )
 
         // Weight unit system
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text(
-                text = stringResource(R.string.weight_units),
-                style = MaterialTheme.typography.bodyLarge
-            )
-            Text(
-                text = stringResource(R.string.weight_units_description),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            SingleChoiceSegmentedButtonRow(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                options.forEachIndexed { index, (system, label) ->
-                    SegmentedButton(
-                        selected = weightUnitSystem == system,
-                        onClick = { onWeightUnitSystemChange(system) },
-                        shape = SegmentedButtonDefaults.itemShape(
-                            index = index,
-                            count = options.size
-                        )
-                    ) {
-                        Text(label)
-                    }
+        UnitSystemSelector(
+            label = stringResource(R.string.weight_units),
+            description = stringResource(R.string.weight_units_description),
+            selectedSystem = weightUnitSystem,
+            onSystemChange = onWeightUnitSystemChange,
+            options = options
+        )
+
+        // Grocery list units subsection
+        Text(
+            text = stringResource(R.string.grocery_list_units),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Text(
+            text = stringResource(R.string.grocery_list_units_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        // Grocery volume unit system
+        UnitSystemSelector(
+            label = stringResource(R.string.volume_units),
+            description = stringResource(R.string.volume_units_description),
+            selectedSystem = groceryVolumeUnitSystem,
+            onSystemChange = onGroceryVolumeUnitSystemChange,
+            options = options
+        )
+
+        // Grocery weight unit system
+        UnitSystemSelector(
+            label = stringResource(R.string.weight_units),
+            description = stringResource(R.string.weight_units_description),
+            selectedSystem = groceryWeightUnitSystem,
+            onSystemChange = onGroceryWeightUnitSystemChange,
+            options = options
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun UnitSystemSelector(
+    label: String,
+    description: String,
+    selectedSystem: UnitSystem,
+    onSystemChange: (UnitSystem) -> Unit,
+    options: List<Pair<UnitSystem, String>>
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        SingleChoiceSegmentedButtonRow(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            options.forEachIndexed { index, (system, systemLabel) ->
+                SegmentedButton(
+                    selected = selectedSystem == system,
+                    onClick = { onSystemChange(system) },
+                    shape = SegmentedButtonDefaults.itemShape(
+                        index = index,
+                        count = options.size
+                    )
+                ) {
+                    Text(systemLabel)
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,12 +100,15 @@
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
     <string name="unit_preferences">Unit Preferences</string>
+    <string name="recipe_units">Recipe units</string>
     <string name="volume_units">Volume units</string>
     <string name="weight_units">Weight units</string>
     <string name="unit_system_customary">Customary</string>
     <string name="unit_system_metric">Metric</string>
     <string name="volume_units_description">Choose between customary (cups, tsp) and metric (mL, L) volume units.</string>
     <string name="weight_units_description">Choose between customary (oz, lb) and metric (g, kg) weight units.</string>
+    <string name="grocery_list_units">Grocery list units</string>
+    <string name="grocery_list_units_description">Units for the grocery list. Defaults to your recipe unit settings above.</string>
     <string name="display">Display</string>
     <string name="keep_screen_on">Keep screen on</string>
     <string name="keep_screen_on_description">Prevent the screen from turning off while viewing a recipe.</string>

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModelTest.kt
@@ -49,8 +49,8 @@ class GroceryListViewModelTest {
         recipeRepository = mockk()
         settingsDataStore = mockk()
 
-        every { settingsDataStore.volumeUnitSystem } returns flowOf(UnitSystem.CUSTOMARY)
-        every { settingsDataStore.weightUnitSystem } returns flowOf(UnitSystem.METRIC)
+        every { settingsDataStore.groceryVolumeUnitSystem } returns flowOf(UnitSystem.CUSTOMARY)
+        every { settingsDataStore.groceryWeightUnitSystem } returns flowOf(UnitSystem.METRIC)
         coEvery { mealPlanRepository.getAllMealPlansOnce() } returns emptyList()
     }
 

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -42,6 +42,8 @@ class SettingsViewModelTest {
     private val importDebuggingEnabledFlow = MutableStateFlow(false)
     private val volumeUnitSystemFlow = MutableStateFlow(UnitSystem.CUSTOMARY)
     private val weightUnitSystemFlow = MutableStateFlow(UnitSystem.METRIC)
+    private val groceryVolumeUnitSystemFlow = MutableStateFlow(UnitSystem.CUSTOMARY)
+    private val groceryWeightUnitSystemFlow = MutableStateFlow(UnitSystem.METRIC)
     private val startOfWeekFlow = MutableStateFlow(StartOfWeek.LOCALE_DEFAULT)
 
     @Before
@@ -57,6 +59,8 @@ class SettingsViewModelTest {
         every { settingsDataStore.importDebuggingEnabled } returns importDebuggingEnabledFlow
         every { settingsDataStore.volumeUnitSystem } returns volumeUnitSystemFlow
         every { settingsDataStore.weightUnitSystem } returns weightUnitSystemFlow
+        every { settingsDataStore.groceryVolumeUnitSystem } returns groceryVolumeUnitSystemFlow
+        every { settingsDataStore.groceryWeightUnitSystem } returns groceryWeightUnitSystemFlow
         every { settingsDataStore.startOfWeek } returns startOfWeekFlow
         viewModel = SettingsViewModel(settingsDataStore, importDebugRepository)
     }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -474,7 +474,7 @@ app: {
       }
       settings: {
         label: SettingsDataStore
-        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, extended thinking enabled, keep screen on, theme mode, volume/weight unit system preferences, start of week, import debugging enabled, Google Drive sync enabled/folder/last sync timestamp)"
+        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, extended thinking enabled, keep screen on, theme mode, volume/weight unit system preferences, grocery list volume/weight unit system preferences, start of week, import debugging enabled, Google Drive sync enabled/folder/last sync timestamp)"
       }
 
       dao -> room
@@ -593,7 +593,7 @@ app: {
   ui.viewmodels.grocery_list_vm -> data.repository.meal_plan_repo: meal plans
   ui.viewmodels.grocery_list_vm -> data.repository.repo: recipes
   ui.viewmodels.grocery_list_vm -> domain.usecases.aggregate_grocery: aggregate ingredients
-  ui.viewmodels.grocery_list_vm -> data.local.settings: unit prefs
+  ui.viewmodels.grocery_list_vm -> data.local.settings: grocery unit prefs
   domain.usecases.sync_drive -> domain.usecases.sync_meal_plans: sync meal plans
   domain.usecases.sync_meal_plans -> data.repository.meal_plan_repo: access data
   ui.viewmodels.settings_vm -> data.repository.import_debug_repo: delete debug data


### PR DESCRIPTION
## Summary
- Adds independent volume and weight unit system preferences for the grocery list
- Grocery list unit settings default to the recipe unit settings but can be overridden separately
- Allows users to use different measurement systems for cooking vs shopping (e.g. metric for recipes, customary at the store)

Closes #174

## Changes
- **SettingsDataStore**: Added `groceryVolumeUnitSystem` and `groceryWeightUnitSystem` preference keys, flows (with fallback to recipe settings), and setters
- **SettingsViewModel**: Exposed grocery unit system state flows and setter methods
- **UnitPreferencesSection**: Restructured UI into "Recipe units" and "Grocery list units" subsections, extracted reusable `UnitSystemSelector` composable
- **SettingsScreen**: Wired new grocery unit settings to the UI
- **GroceryListViewModel**: Now reads from grocery-specific unit preferences instead of recipe preferences
- **String resources**: Added `recipe_units`, `grocery_list_units`, and `grocery_list_units_description`
- **Architecture doc**: Updated SettingsDataStore tooltip and grocery list VM connection label
- **Tests**: Updated mocks in `SettingsViewModelTest` and `GroceryListViewModelTest`

## Test plan
- [ ] Verify grocery list unit settings appear in Settings under "Unit Preferences"
- [ ] Verify grocery list unit settings default to matching recipe unit settings
- [ ] Change grocery list units independently from recipe units and verify the grocery list uses the grocery-specific settings
- [ ] Change recipe unit settings and verify grocery list follows when no grocery-specific override is set
- [ ] Verify all existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)