### PR TITLE
feat: filter grocery list to show only selected week

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/MealPlanDao.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/MealPlanDao.kt
@@ -42,4 +42,7 @@ interface MealPlanDao {
 
     @Query("SELECT * FROM meal_plans WHERE deleted = 0")
     suspend fun getAllMealPlansOnce(): List<MealPlanEntity>
+
+    @Query("SELECT * FROM meal_plans WHERE date BETWEEN :startDate AND :endDate AND deleted = 0 ORDER BY date ASC, mealType ASC, recipeName ASC")
+    suspend fun getMealPlansForDateRangeOnce(startDate: String, endDate: String): List<MealPlanEntity>
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/MealPlanRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/MealPlanRepository.kt
@@ -61,6 +61,10 @@ class MealPlanRepository @Inject constructor(
         return mealPlanDao.getAllMealPlansOnce().map { it.toMealPlanEntry() }
     }
 
+    suspend fun getMealPlansForDateRangeOnce(startDate: LocalDate, endDate: LocalDate): List<MealPlanEntry> {
+        return mealPlanDao.getMealPlansForDateRangeOnce(startDate.toString(), endDate.toString()).map { it.toMealPlanEntry() }
+    }
+
     /**
      * Hard delete a meal plan (used during sync when remote deletion is detected).
      */

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
@@ -35,7 +35,9 @@ sealed class Screen(val route: String) {
     }
     object Settings : Screen("settings")
     object MealPlan : Screen("meal-plan")
-    object GroceryList : Screen("grocery-list")
+    object GroceryList : Screen("grocery-list/{weekStart}") {
+        fun createRoute(weekStart: String) = "grocery-list/$weekStart"
+    }
     object ImportDebugList : Screen("import-debug")
     object ImportDebugDetail : Screen("import-debug/{debugEntryId}") {
         fun createRoute(debugEntryId: String) = "import-debug/$debugEntryId"
@@ -165,13 +167,18 @@ fun NavGraph(
                     navController.navigate(Screen.RecipeDetail.createRoute(recipeId))
                 },
                 onBackClick = navigateBack,
-                onGroceryListClick = {
-                    navController.navigate(Screen.GroceryList.route)
+                onGroceryListClick = { weekStart ->
+                    navController.navigate(Screen.GroceryList.createRoute(weekStart))
                 }
             )
         }
 
-        composable(Screen.GroceryList.route) {
+        composable(
+            route = Screen.GroceryList.route,
+            arguments = listOf(
+                navArgument("weekStart") { type = NavType.StringType }
+            )
+        ) {
             GroceryListScreen(
                 onBackClick = navigateBack
             )

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
@@ -71,7 +71,7 @@ import java.util.Locale
 fun MealPlanScreen(
     onRecipeClick: (String) -> Unit,
     onBackClick: () -> Unit,
-    onGroceryListClick: () -> Unit,
+    onGroceryListClick: (String) -> Unit,
     viewModel: MealPlanViewModel = hiltViewModel()
 ) {
     val weekStart by viewModel.currentWeekStart.collectAsStateWithLifecycle()
@@ -107,7 +107,7 @@ fun MealPlanScreen(
                 title = stringResource(R.string.meal_planner),
                 onBackClick = onBackClick,
                 actions = {
-                    IconButton(onClick = onGroceryListClick) {
+                    IconButton(onClick = { onGroceryListClick(weekStart.toString()) }) {
                         Icon(
                             imageVector = Icons.Default.ShoppingCart,
                             contentDescription = stringResource(R.string.grocery_list)

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -738,11 +738,12 @@ legend: {
       bold: true
     }
   }
-  gl1: "Select recipes from meal plan entries (grouped by date and meal type)"
+  gl1: "Shows only meals for the currently selected week (passed from meal planner via nav arg)"
+  gl1a: "Select recipes from meal plan entries (grouped by date and meal type)"
   gl2: "Aggregate ingredients across recipes: deduplicate by normalized name, sum amounts in base units"
   gl3: "Display with check-off support: top-level hides all sub-items, sub-item reduces aggregate count"
   gl4: "Share as Markdown via Android share sheet"
   gl5: "Non-persistent: state resets between app sessions"
 
-  gl1 -> gl2 -> gl3 -> gl4 -> gl5
+  gl1 -> gl1a -> gl2 -> gl3 -> gl4 -> gl5
 }


### PR DESCRIPTION
## Summary
- The grocery list now only shows meals for the currently selected week instead of all meal plans
- The week start date is passed from the meal planner to the grocery list via a navigation argument
- Added `getMealPlansForDateRangeOnce()` to DAO and repository for efficient one-shot date-range queries

## Test plan
- [x] All existing unit tests pass (updated to use week-filtered query)
- [x] Debug build succeeds
- [x] Lint passes
- [ ] Manual test: navigate to meal planner, add meals across different weeks, open grocery list and verify only the current week's meals appear
- [ ] Manual test: switch weeks in meal planner, open grocery list and verify it shows the correct week's meals

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)