### PR TITLE
feat: sort grocery list by checked status then alphabetically

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModel.kt
@@ -118,7 +118,10 @@ class GroceryListViewModel @Inject constructor(
     ) { items, checkedItems, checkedSources, volumeSystem, weightSystem ->
         items.mapNotNull { item ->
             buildDisplayItem(item, checkedItems, checkedSources, volumeSystem, weightSystem)
-        }
+        }.sortedWith(
+            compareBy<DisplayGroceryItem> { it.isChecked }
+                .thenBy { it.displayText.lowercase() }
+        )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
@@ -292,7 +295,10 @@ class GroceryListViewModel @Inject constructor(
                 recipeName = source.recipeName,
                 isChecked = sourceKey in checkedSources
             )
-        }
+        }.sortedWith(
+            compareBy<DisplayGrocerySource> { it.isChecked }
+                .thenBy { it.recipeName.lowercase() }
+        )
 
         // Calculate total display amount for aggregate header
         val totalAmountText = if (displaySources.size > 1) {

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModelTest.kt
@@ -532,8 +532,10 @@ class GroceryListViewModelTest {
             viewModel.toggleSourceChecked(source1Key)
             val afterFirst = awaitItem()
             assertFalse("Top-level should NOT be checked yet", afterFirst[0].isChecked)
-            assertTrue("First source should be checked", afterFirst[0].sources[0].isChecked)
-            assertFalse("Second source should NOT be checked", afterFirst[0].sources[1].isChecked)
+            assertTrue("First source should be checked",
+                afterFirst[0].sources.first { it.key == source1Key }.isChecked)
+            assertFalse("Second source should NOT be checked",
+                afterFirst[0].sources.first { it.key == source2Key }.isChecked)
 
             // Check second source - should auto-check top-level
             viewModel.toggleSourceChecked(source2Key)
@@ -588,8 +590,10 @@ class GroceryListViewModelTest {
             viewModel.toggleSourceChecked(source1Key)
             val afterUncheck = awaitItem()
             assertFalse("Top-level should be unchecked", afterUncheck[0].isChecked)
-            assertFalse("First source should be unchecked", afterUncheck[0].sources[0].isChecked)
-            assertTrue("Second source should still be checked", afterUncheck[0].sources[1].isChecked)
+            assertFalse("First source should be unchecked",
+                afterUncheck[0].sources.first { it.key == source1Key }.isChecked)
+            assertTrue("Second source should still be checked",
+                afterUncheck[0].sources.first { it.key != source1Key }.isChecked)
 
             cancelAndIgnoreRemainingEvents()
         }


### PR DESCRIPTION
## Summary
- Sort grocery list items with unchecked items first, then alphabetically by name
- Sort sub-sources within multi-source items by checked status, then alphabetically by recipe name
- Updated tests to use key-based lookups instead of index-based assertions for robustness

Closes #183

## Test plan
- [x] All existing unit tests pass with updated assertions
- [x] Debug build succeeds
- [x] Lint checks pass
- [ ] Manual testing: verify unchecked items appear above checked items
- [ ] Manual testing: verify items within each group are sorted alphabetically
- [ ] Manual testing: verify sub-sources are sorted by checked status then recipe name

🤖 Generated with [Claude Code](https://claude.com/claude-code)