### PR TITLE
fix: properly propagate coroutine cancellation during recipe imports

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -95,6 +95,8 @@ class AnthropicService @Inject constructor(
                 outputTokens = outputTokens,
                 aiOutputJson = jsonContent
             ))
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/WebScraperService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/WebScraperService.kt
@@ -55,6 +55,8 @@ class WebScraperService @Inject constructor(
                 extractedContent = extractedContent,
                 imageUrl = imageUrl
             ))
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportFromZipUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportFromZipUseCase.kt
@@ -5,11 +5,13 @@ import com.lionotter.recipes.data.repository.MealPlanRepository
 import com.lionotter.recipes.data.repository.RecipeRepository
 import com.lionotter.recipes.domain.model.MealPlanEntry
 import com.lionotter.recipes.domain.util.RecipeSerializer
+import kotlinx.coroutines.ensureActive
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import java.io.InputStream
 import java.util.zip.ZipInputStream
 import javax.inject.Inject
+import kotlin.coroutines.coroutineContext
 
 /**
  * Use case for importing recipes from a ZIP file.
@@ -95,6 +97,8 @@ class ImportFromZipUseCase @Inject constructor(
 
         val folders = folderContents.entries.filter { it.key != MEAL_PLANS_FOLDER }.toList()
         folders.forEachIndexed { index, (folderName, files) ->
+            coroutineContext.ensureActive()
+
             onProgress(
                 ImportProgress.ImportingRecipe(
                     recipeName = folderName,

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -7,12 +7,14 @@ import com.lionotter.recipes.data.remote.RecipeParseException
 import com.lionotter.recipes.data.repository.ImportDebugRepository
 import com.lionotter.recipes.data.repository.RecipeRepository
 import com.lionotter.recipes.domain.model.Recipe
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Clock
 import net.dankito.readability4j.Readability4J
 import org.jsoup.Jsoup
 import java.util.UUID
 import javax.inject.Inject
+import kotlin.coroutines.coroutineContext
 
 /**
  * Use case for parsing content into a Recipe using AI.
@@ -151,6 +153,9 @@ class ParseHtmlUseCase @Inject constructor(
         val parsedWithUsage = parseResult.getOrThrow()
         val parsed = parsedWithUsage.result
 
+        // Check for cancellation before proceeding to save
+        coroutineContext.ensureActive()
+
         // Notify that recipe name is available
         onProgress(ParseProgress.RecipeNameAvailable(parsed.name))
 
@@ -174,6 +179,7 @@ class ParseHtmlUseCase @Inject constructor(
 
         // Save to database if requested
         if (saveRecipe) {
+            coroutineContext.ensureActive()
             onProgress(ParseProgress.SavingRecipe)
             recipeRepository.saveRecipe(recipe, originalHtml = originalHtml)
         }


### PR DESCRIPTION
## Summary
- Fix `CancellationException` being swallowed by catch-all `Exception` handlers in `AnthropicService` and `WebScraperService`, which caused imports to continue running after user cancellation
- Add `ensureActive()` cancellation checkpoints in `ParseHtmlUseCase` (before saving to DB) and `ImportFromZipUseCase` (in the import loop)

## Root Cause
When a user cancelled an import, `InProgressRecipeManager.cancelImport()` correctly called `workManager.cancelWorkById()` and deleted the pending import record (removing the UI item). However, the actual worker coroutine kept running because:

1. `AnthropicService.parseRecipe()` and `WebScraperService.fetchPage()` both had `catch (e: Exception)` blocks that caught `CancellationException` (a subclass of `Exception` in Kotlin) and wrapped it as `Result.failure()` instead of re-throwing it
2. This prevented cancellation from propagating up the call stack, so the import use cases continued processing and saving recipes to the database
3. `ImportFromZipUseCase` and `ParseHtmlUseCase` also lacked `ensureActive()` checkpoints between operations

## Test plan
- [ ] Start importing a recipe from URL, cancel during AI parsing — verify no recipe appears
- [ ] Start a Paprika bulk import, cancel mid-import — verify no additional recipes appear after cancellation
- [ ] Start a ZIP import, cancel mid-import — verify it stops promptly
- [ ] Complete a normal import without cancelling — verify it still works correctly

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)