### PR TITLE
feat: add import selection screen for all import types

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDao.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDao.kt
@@ -24,6 +24,9 @@ interface RecipeDao {
     @Query("SELECT * FROM recipes WHERE name LIKE '%' || :query || '%' AND deleted = 0 ORDER BY updatedAt DESC")
     fun searchRecipes(query: String): Flow<List<RecipeEntity>>
 
+    @Query("SELECT id, name FROM recipes WHERE deleted = 0")
+    suspend fun getAllRecipeIdsAndNames(): List<RecipeIdAndName>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertRecipe(recipe: RecipeEntity)
 

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeIdAndName.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeIdAndName.kt
@@ -1,0 +1,8 @@
+package com.lionotter.recipes.data.local
+
+import androidx.room.ColumnInfo
+
+data class RecipeIdAndName(
+    @ColumnInfo(name = "id") val id: String,
+    @ColumnInfo(name = "name") val name: String
+)

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
@@ -3,6 +3,7 @@ package com.lionotter.recipes.data.repository
 import android.util.Log
 import com.lionotter.recipes.data.local.RecipeDao
 import com.lionotter.recipes.data.local.RecipeEntity
+import com.lionotter.recipes.data.local.RecipeIdAndName
 import com.lionotter.recipes.domain.model.InstructionSection
 import com.lionotter.recipes.domain.model.Recipe
 import kotlinx.coroutines.flow.Flow
@@ -91,6 +92,10 @@ class RecipeRepository @Inject constructor(
 
     suspend fun setFavorite(id: String, isFavorite: Boolean) {
         recipeDao.setFavorite(id, isFavorite)
+    }
+
+    suspend fun getAllRecipeIdsAndNames(): List<RecipeIdAndName> {
+        return recipeDao.getAllRecipeIdsAndNames()
     }
 
     private inline fun <reified T> safeDecodeJson(

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeViewModel.kt
@@ -225,14 +225,14 @@ class AddRecipeViewModel @Inject constructor(
         _uiState.value = AddRecipeUiState.Loading(ImportProgress.Queued)
     }
 
-    fun importPaprikaFile(fileUri: Uri) {
+    fun importPaprikaFile(fileUri: Uri, selectedRecipeNames: Set<String>? = null) {
         currentImportId = UUID.randomUUID().toString()
         lastPaprikaImportedCount = 0
         lastPaprikaFailedCount = 0
         inProgressRecipeManager.addInProgressRecipe(currentImportId!!, "Importing from Paprika...")
 
         val workRequest = OneTimeWorkRequestBuilder<PaprikaImportWorker>()
-            .setInputData(PaprikaImportWorker.createInputData(fileUri))
+            .setInputData(PaprikaImportWorker.createInputData(fileUri, selectedRecipeNames))
             .addTag(PaprikaImportWorker.TAG_PAPRIKA_IMPORT)
             .build()
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importselection/ImportSelectionScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importselection/ImportSelectionScreen.kt
@@ -1,0 +1,234 @@
+package com.lionotter.recipes.ui.screens.importselection
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.lionotter.recipes.R
+import com.lionotter.recipes.ui.components.ErrorCard
+import com.lionotter.recipes.ui.components.RecipeTopAppBar
+
+/**
+ * Shared import selection screen that displays a checklist of recipes
+ * found in an import file. Used by Paprika import, .lorecipes file import,
+ * and ZIP backup import.
+ *
+ * @param title The title to display in the top bar
+ * @param state The current UI state
+ * @param onToggleItem Called when a recipe checkbox is toggled
+ * @param onSelectAll Called when "Select All" is tapped
+ * @param onDeselectAll Called when "Deselect All" is tapped
+ * @param onImportClick Called when the Import button is tapped
+ * @param onCancelClick Called when Cancel is tapped
+ */
+@Composable
+fun ImportSelectionScreen(
+    title: String,
+    state: ImportSelectionUiState,
+    onToggleItem: (String) -> Unit,
+    onSelectAll: () -> Unit,
+    onDeselectAll: () -> Unit,
+    onImportClick: () -> Unit,
+    onCancelClick: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            RecipeTopAppBar(
+                title = title,
+                onBackClick = onCancelClick
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            when (state) {
+                is ImportSelectionUiState.Loading -> {
+                    LoadingContent()
+                }
+                is ImportSelectionUiState.Ready -> {
+                    SelectionContent(
+                        items = state.items,
+                        onToggleItem = onToggleItem,
+                        onSelectAll = onSelectAll,
+                        onDeselectAll = onDeselectAll,
+                        onImportClick = onImportClick,
+                        onCancelClick = onCancelClick
+                    )
+                }
+                is ImportSelectionUiState.Error -> {
+                    ErrorContent(
+                        message = state.message,
+                        onCancelClick = onCancelClick
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator()
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.reading_recipes),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun SelectionContent(
+    items: List<ImportSelectionItem>,
+    onToggleItem: (String) -> Unit,
+    onSelectAll: () -> Unit,
+    onDeselectAll: () -> Unit,
+    onImportClick: () -> Unit,
+    onCancelClick: () -> Unit
+) {
+    val selectedCount = items.count { it.isSelected }
+    val hasSelection = selectedCount > 0
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Select All / Deselect All row
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.import_selection_count, selectedCount, items.size),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(onClick = onSelectAll) {
+                    Text(stringResource(R.string.select_all))
+                }
+                OutlinedButton(onClick = onDeselectAll) {
+                    Text(stringResource(R.string.deselect_all))
+                }
+            }
+        }
+
+        // Recipe checklist
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+        ) {
+            items(items, key = { it.id }) { item ->
+                RecipeChecklistItem(
+                    item = item,
+                    onToggle = { onToggleItem(item.id) }
+                )
+            }
+        }
+
+        // Bottom buttons
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedButton(
+                onClick = onCancelClick,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(stringResource(R.string.cancel))
+            }
+            Button(
+                onClick = onImportClick,
+                modifier = Modifier.weight(1f),
+                enabled = hasSelection
+            ) {
+                Text(stringResource(R.string.import_selected, selectedCount))
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecipeChecklistItem(
+    item: ImportSelectionItem,
+    onToggle: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = item.isSelected,
+            onCheckedChange = { onToggle() }
+        )
+        Column(modifier = Modifier.padding(start = 8.dp)) {
+            Text(
+                text = item.name,
+                style = MaterialTheme.typography.bodyLarge
+            )
+            if (item.alreadyExists) {
+                Text(
+                    text = stringResource(R.string.recipe_already_exists),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    message: String,
+    onCancelClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        ErrorCard(message = message)
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = onCancelClick) {
+            Text(stringResource(R.string.back))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importselection/ImportSelectionState.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importselection/ImportSelectionState.kt
@@ -1,0 +1,30 @@
+package com.lionotter.recipes.ui.screens.importselection
+
+/**
+ * Represents a recipe candidate for the import selection screen.
+ *
+ * @param id A unique identifier for this item (recipe ID for .lorecipes, index for Paprika)
+ * @param name The recipe name to display
+ * @param isSelected Whether the user has selected this recipe for import
+ * @param alreadyExists Whether this recipe already exists in the app (by ID or name)
+ */
+data class ImportSelectionItem(
+    val id: String,
+    val name: String,
+    val isSelected: Boolean,
+    val alreadyExists: Boolean
+)
+
+/**
+ * Shared state for the import selection screen, used across all import types.
+ */
+sealed class ImportSelectionUiState {
+    /** Parsing the file to extract recipe names */
+    object Loading : ImportSelectionUiState()
+
+    /** Recipes parsed and ready for user selection */
+    data class Ready(val items: List<ImportSelectionItem>) : ImportSelectionUiState()
+
+    /** Error parsing the file */
+    data class Error(val message: String) : ImportSelectionUiState()
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importselection/ImportSelectionViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importselection/ImportSelectionViewModel.kt
@@ -1,0 +1,326 @@
+package com.lionotter.recipes.ui.screens.importselection
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lionotter.recipes.data.paprika.PaprikaParser
+import com.lionotter.recipes.data.paprika.PaprikaRecipe
+import com.lionotter.recipes.data.repository.MealPlanRepository
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.model.MealPlanEntry
+import com.lionotter.recipes.domain.util.RecipeSerializer
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.Json
+import java.util.zip.ZipInputStream
+import javax.inject.Inject
+
+/**
+ * ViewModel for the import selection screen. Handles parsing of import files
+ * (Paprika, .lorecipes, and ZIP backup) to extract recipe names, checking
+ * for duplicates, and performing the actual import of selected recipes.
+ */
+@HiltViewModel
+class ImportSelectionViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val recipeRepository: RecipeRepository,
+    private val recipeSerializer: RecipeSerializer,
+    private val paprikaParser: PaprikaParser,
+    private val mealPlanRepository: MealPlanRepository,
+    private val json: Json
+) : ViewModel() {
+
+    companion object {
+        private const val TAG = "ImportSelection"
+        private const val MEAL_PLANS_FOLDER = "meal-plans"
+    }
+
+    private val _uiState = MutableStateFlow<ImportSelectionUiState>(ImportSelectionUiState.Loading)
+    val uiState: StateFlow<ImportSelectionUiState> = _uiState.asStateFlow()
+
+    // Parsed data held in memory for import
+    private var parsedPaprikaRecipes: List<PaprikaRecipe>? = null
+    private var parsedLorecipesFolders: Map<String, Map<String, String>>? = null
+    private var currentImportType: ImportType? = null
+    private var currentFileUri: Uri? = null
+    private var alreadyParsed = false
+
+    enum class ImportType {
+        PAPRIKA,
+        LORECIPES,
+        ZIP_BACKUP
+    }
+
+    sealed class ImportResult {
+        /** Paprika import: recipes were parsed and selected, ready for WorkManager */
+        data class PaprikaSelected(
+            val fileUri: Uri,
+            val selectedRecipeNames: Set<String>
+        ) : ImportResult()
+
+        /** .lorecipes or ZIP import completed synchronously */
+        data class DirectImportComplete(
+            val importedCount: Int,
+            val skippedCount: Int,
+            val failedCount: Int,
+            val importedRecipeId: String? = null
+        ) : ImportResult()
+
+        data class Error(val message: String) : ImportResult()
+    }
+
+    /**
+     * Parse a file to extract recipe names for selection.
+     */
+    fun parseFile(uri: Uri, importType: ImportType) {
+        if (alreadyParsed) return
+        alreadyParsed = true
+        currentFileUri = uri
+        currentImportType = importType
+        _uiState.value = ImportSelectionUiState.Loading
+
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                when (importType) {
+                    ImportType.PAPRIKA -> parsePaprikaFile(uri)
+                    ImportType.LORECIPES, ImportType.ZIP_BACKUP -> parseZipContents(uri)
+                }
+            }
+        }
+    }
+
+    private suspend fun parsePaprikaFile(uri: Uri) {
+        try {
+            val inputStream = context.contentResolver.openInputStream(uri)
+                ?: run {
+                    _uiState.value = ImportSelectionUiState.Error("Could not open file")
+                    return
+                }
+
+            val recipes = inputStream.use { paprikaParser.parseExport(it) }
+
+            if (recipes.isEmpty()) {
+                _uiState.value = ImportSelectionUiState.Error("No recipes found in Paprika export")
+                return
+            }
+
+            parsedPaprikaRecipes = recipes
+
+            val existingRecipes = recipeRepository.getAllRecipeIdsAndNames()
+            val existingNames = existingRecipes.map { it.name.lowercase() }.toSet()
+
+            val items = recipes.map { recipe ->
+                val alreadyExists = recipe.name.lowercase() in existingNames
+                ImportSelectionItem(
+                    id = recipe.uid,
+                    name = recipe.name,
+                    isSelected = !alreadyExists,
+                    alreadyExists = alreadyExists
+                )
+            }.sortedBy { it.name.lowercase() }
+
+            _uiState.value = ImportSelectionUiState.Ready(items)
+        } catch (e: Exception) {
+            _uiState.value = ImportSelectionUiState.Error("Failed to read Paprika export: ${e.message}")
+        }
+    }
+
+    private suspend fun parseZipContents(uri: Uri) {
+        try {
+            val inputStream = context.contentResolver.openInputStream(uri)
+                ?: run {
+                    _uiState.value = ImportSelectionUiState.Error("Could not open file")
+                    return
+                }
+
+            val folderContents = mutableMapOf<String, MutableMap<String, String>>()
+
+            ZipInputStream(inputStream).use { zipIn ->
+                var entry = zipIn.nextEntry
+                while (entry != null) {
+                    if (!entry.isDirectory) {
+                        val pathParts = entry.name.split("/", limit = 2)
+                        if (pathParts.size == 2) {
+                            val folderName = pathParts[0]
+                            val fileName = pathParts[1]
+                            val content = zipIn.readBytes().toString(Charsets.UTF_8)
+                            folderContents.getOrPut(folderName) { mutableMapOf() }[fileName] = content
+                        }
+                    }
+                    zipIn.closeEntry()
+                    entry = zipIn.nextEntry
+                }
+            }
+
+            if (folderContents.isEmpty()) {
+                _uiState.value = ImportSelectionUiState.Error("No recipes found in file")
+                return
+            }
+
+            parsedLorecipesFolders = folderContents
+
+            val existingRecipes = recipeRepository.getAllRecipeIdsAndNames()
+            val existingIds = existingRecipes.map { it.id }.toSet()
+            val existingNames = existingRecipes.map { it.name.lowercase() }.toSet()
+
+            // Filter out meal-plans folder - only show recipe folders
+            val items = folderContents
+                .filter { (folderName, _) -> folderName != MEAL_PLANS_FOLDER }
+                .mapNotNull { (_, files) ->
+                    val jsonContent = files[RecipeSerializer.RECIPE_JSON_FILENAME] ?: return@mapNotNull null
+                    try {
+                        val recipe = recipeSerializer.deserializeRecipe(jsonContent)
+                        val alreadyExists = recipe.id in existingIds || recipe.name.lowercase() in existingNames
+                        ImportSelectionItem(
+                            id = recipe.id,
+                            name = recipe.name,
+                            isSelected = !alreadyExists,
+                            alreadyExists = alreadyExists
+                        )
+                    } catch (e: Exception) {
+                        null
+                    }
+                }.sortedBy { it.name.lowercase() }
+
+            if (items.isEmpty()) {
+                _uiState.value = ImportSelectionUiState.Error("No valid recipes found in file")
+                return
+            }
+
+            _uiState.value = ImportSelectionUiState.Ready(items)
+        } catch (e: Exception) {
+            _uiState.value = ImportSelectionUiState.Error("Failed to read file: ${e.message}")
+        }
+    }
+
+    fun toggleItem(itemId: String) {
+        val current = _uiState.value
+        if (current is ImportSelectionUiState.Ready) {
+            val updatedItems = current.items.map { item ->
+                if (item.id == itemId) item.copy(isSelected = !item.isSelected) else item
+            }
+            _uiState.value = ImportSelectionUiState.Ready(updatedItems)
+        }
+    }
+
+    fun selectAll() {
+        val current = _uiState.value
+        if (current is ImportSelectionUiState.Ready) {
+            val updatedItems = current.items.map { it.copy(isSelected = true) }
+            _uiState.value = ImportSelectionUiState.Ready(updatedItems)
+        }
+    }
+
+    fun deselectAll() {
+        val current = _uiState.value
+        if (current is ImportSelectionUiState.Ready) {
+            val updatedItems = current.items.map { it.copy(isSelected = false) }
+            _uiState.value = ImportSelectionUiState.Ready(updatedItems)
+        }
+    }
+
+    /**
+     * Import the selected recipes. Returns the result via the callback.
+     * For Paprika, returns a PaprikaSelected result that the caller should
+     * use to start the WorkManager import.
+     * For .lorecipes and ZIP, performs the import directly.
+     */
+    fun importSelected(onResult: (ImportResult) -> Unit) {
+        val current = _uiState.value
+        if (current !is ImportSelectionUiState.Ready) return
+
+        val selectedIds = current.items.filter { it.isSelected }.map { it.id }.toSet()
+        if (selectedIds.isEmpty()) return
+
+        when (currentImportType) {
+            ImportType.PAPRIKA -> {
+                val selectedNames = current.items
+                    .filter { it.isSelected }
+                    .map { it.name }
+                    .toSet()
+                onResult(ImportResult.PaprikaSelected(currentFileUri!!, selectedNames))
+            }
+            ImportType.LORECIPES, ImportType.ZIP_BACKUP -> {
+                viewModelScope.launch {
+                    val result = withContext(Dispatchers.IO) {
+                        importZipSelected(selectedIds)
+                    }
+                    onResult(result)
+                }
+            }
+            null -> onResult(ImportResult.Error("Unknown import type"))
+        }
+    }
+
+    private suspend fun importZipSelected(selectedIds: Set<String>): ImportResult {
+        val folderContents = parsedLorecipesFolders
+            ?: return ImportResult.Error("No parsed data available")
+
+        var importedCount = 0
+        var skippedCount = 0
+        var failedCount = 0
+        var lastImportedId: String? = null
+
+        for ((folderName, files) in folderContents) {
+            // Import meal plans automatically (not part of recipe selection)
+            if (folderName == MEAL_PLANS_FOLDER) {
+                for ((fileName, content) in files) {
+                    if (!fileName.endsWith(".json")) continue
+                    try {
+                        val entries = json.decodeFromString<List<MealPlanEntry>>(content)
+                        for (entry in entries) {
+                            val existing = mealPlanRepository.getMealPlanByIdOnce(entry.id)
+                            if (existing == null) {
+                                mealPlanRepository.saveMealPlan(entry)
+                            }
+                        }
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to import meal plan file $fileName", e)
+                    }
+                }
+                continue
+            }
+
+            val jsonContent = files[RecipeSerializer.RECIPE_JSON_FILENAME] ?: continue
+
+            try {
+                val recipe = recipeSerializer.deserializeRecipe(jsonContent)
+
+                if (recipe.id !in selectedIds) {
+                    continue
+                }
+
+                // Check if recipe already exists by ID
+                val existing = recipeRepository.getRecipeByIdOnce(recipe.id)
+                if (existing != null) {
+                    skippedCount++
+                    continue
+                }
+
+                val importedRecipe = recipe.copy(updatedAt = Clock.System.now())
+                val originalHtml = files[RecipeSerializer.RECIPE_HTML_FILENAME]
+                recipeRepository.saveRecipe(importedRecipe, originalHtml)
+                importedCount++
+                lastImportedId = recipe.id
+            } catch (e: Exception) {
+                failedCount++
+            }
+        }
+
+        return ImportResult.DirectImportComplete(
+            importedCount = importedCount,
+            skippedCount = skippedCount,
+            failedCount = failedCount,
+            importedRecipeId = lastImportedId
+        )
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.ui.screens.settings
 
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -42,6 +43,7 @@ import com.lionotter.recipes.ui.screens.settings.components.UnitPreferencesSecti
 fun SettingsScreen(
     onBackClick: () -> Unit,
     onNavigateToImportDebug: () -> Unit = {},
+    onNavigateToImportSelection: (importType: String, uri: Uri) -> Unit = { _, _ -> },
     viewModel: SettingsViewModel = hiltViewModel(),
     googleDriveViewModel: GoogleDriveViewModel = hiltViewModel(),
     zipViewModel: ZipExportImportViewModel = hiltViewModel()
@@ -96,11 +98,11 @@ fun SettingsScreen(
         uri?.let { zipViewModel.exportToZip(it) }
     }
 
-    // ZIP import file picker (open document)
+    // ZIP import file picker - navigate to selection screen
     val zipImportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
-        uri?.let { zipViewModel.importFromZip(it) }
+        uri?.let { onNavigateToImportSelection("zip", it) }
     }
 
     // Show snackbar for zip operation results

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/PaprikaImportWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/PaprikaImportWorker.kt
@@ -26,6 +26,7 @@ class PaprikaImportWorker @AssistedInject constructor(
         const val TAG_PAPRIKA_IMPORT = "paprika_import"
 
         const val KEY_FILE_URI = "file_uri"
+        const val KEY_SELECTED_RECIPE_NAMES = "selected_recipe_names"
         const val KEY_RESULT_TYPE = "result_type"
         const val KEY_IMPORTED_COUNT = "imported_count"
         const val KEY_FAILED_COUNT = "failed_count"
@@ -44,8 +45,11 @@ class PaprikaImportWorker @AssistedInject constructor(
         const val PROGRESS_PARSING = "parsing"
         const val PROGRESS_IMPORTING = "importing"
 
-        fun createInputData(fileUri: Uri): Data {
-            return workDataOf(KEY_FILE_URI to fileUri.toString())
+        fun createInputData(fileUri: Uri, selectedRecipeNames: Set<String>? = null): Data {
+            return workDataOf(
+                KEY_FILE_URI to fileUri.toString(),
+                KEY_SELECTED_RECIPE_NAMES to selectedRecipeNames?.toTypedArray()
+            )
         }
     }
 
@@ -59,6 +63,7 @@ class PaprikaImportWorker @AssistedInject constructor(
             )
 
         val fileUri = fileUriString.toUri()
+        val selectedRecipeNames = inputData.getStringArray(KEY_SELECTED_RECIPE_NAMES)?.toSet()
         setForegroundProgress("Starting Paprika import...")
 
         val inputStream = try {
@@ -81,6 +86,7 @@ class PaprikaImportWorker @AssistedInject constructor(
         val result = inputStream.use { stream ->
             importPaprikaUseCase.execute(
                 inputStream = stream,
+                selectedRecipeNames = selectedRecipeNames,
                 onProgress = { progress ->
                     val progressMessage = when (progress) {
                         is ImportPaprikaUseCase.ImportProgress.Parsing -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,15 @@
     <string name="file_import_success">Recipe imported successfully</string>
     <string name="file_import_already_exists">Recipe already exists</string>
 
+    <!-- Import Selection -->
+    <string name="select_recipes_to_import">Select Recipes to Import</string>
+    <string name="reading_recipes">Reading recipes\u2026</string>
+    <string name="import_selection_count">%1$d of %2$d selected</string>
+    <string name="import_selected">Import (%1$d)</string>
+    <string name="recipe_already_exists">Already in your recipes</string>
+    <string name="no_recipes_in_file">No recipes found in file</string>
+    <string name="file_import_success_count">Successfully imported %1$d recipes</string>
+
     <!-- Meal Planner -->
     <string name="meal_planner">Meal Planner</string>
     <string name="meal_planner_settings">Meal Planner</string>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -91,12 +91,20 @@ app: {
         tooltip: "Two-step grocery list generator. Step 1: Select recipes from meal plan entries (grouped by date/meal type, with select all/deselect all). Step 2: View aggregated ingredient list with deduplication across recipes, check-off support (top-level hides all, sub-item reduces count), and share as Markdown."
       }
 
+      import_selection: {
+        label: ImportSelectionScreen
+        tooltip: "Shared recipe selection screen for all import types (Paprika, .lorecipes, ZIP backup). Shows checklist of recipes found in file, sorted alphabetically. Recipes checked by default unless already in app (by ID or name). Import button disabled when nothing selected. Select All / Deselect All buttons."
+      }
+
       list -> detail: tap recipe
       list -> add: tap +
       list -> settings: tap gear
       list -> meal_plan: tap calendar
       meal_plan -> detail: tap recipe
       meal_plan -> grocery_list: tap cart icon
+      add -> import_selection: pick Paprika file
+      settings -> import_selection: pick ZIP file
+      import_selection -> add: Paprika import selected
       add -> settings: no API key
       settings -> import_debug_list: view debug data
       import_debug_list -> import_debug_detail: tap entry
@@ -157,6 +165,10 @@ app: {
         label: GroceryListViewModel
         tooltip: "Manages grocery list generation from meal plan. Two-step flow: recipe selection (from all meal plan entries) then aggregated ingredient display with check-off and share-as-Markdown support. Non-persistent state."
       }
+      import_selection_vm: {
+        label: ImportSelectionViewModel
+        tooltip: "Shared ViewModel for import recipe selection. Parses import files (Paprika, .lorecipes, ZIP backup) to extract recipe names, checks for duplicates against existing recipes, and manages selection state. For Paprika: returns selected names for WorkManager import. For .lorecipes/ZIP: performs direct import of selected recipes."
+      }
     }
 
     state: {
@@ -181,6 +193,7 @@ app: {
     screens.grocery_list -> viewmodels.grocery_list_vm
     screens.import_debug_list -> viewmodels.import_debug_list_vm
     screens.import_debug_detail -> viewmodels.import_debug_detail_vm
+    screens.import_selection -> viewmodels.import_selection_vm
     viewmodels.list_vm -> state.in_progress_mgr: observes, cancel
     viewmodels.add_vm -> state.in_progress_mgr: adds entries
     state.in_progress_mgr -> background.worker: observes status
@@ -578,6 +591,9 @@ app: {
   ui.viewmodels.detail_vm -> background.worker.work_ext: observe regenerate
   ui.viewmodels.file_import_vm -> data.repository.repo: import recipe
   ui.viewmodels.file_import_vm -> domain.util.serializer: deserialize
+  ui.viewmodels.import_selection_vm -> data.repository.repo: check duplicates, import
+  ui.viewmodels.import_selection_vm -> domain.util.serializer: deserialize
+  ui.viewmodels.import_selection_vm -> data.paprika.parser: parse export
   ui.viewmodels.add_vm -> background.worker: enqueue work
   ui.viewmodels.add_vm -> background.worker.work_ext: observe import
   ui.viewmodels.drive_vm -> background.worker.sync_worker: sync
@@ -658,7 +674,7 @@ legend: {
     }
   }
   zip1: "Export: User picks save location, ZipExportWorker writes ZIP with same folder structure as Drive"
-  zip2: "Import: User picks .zip file, ZipImportWorker reads recipe.json from each folder"
+  zip2: "Import: User picks .zip file, selects recipes via ImportSelectionScreen, imports selected"
   zip3: "Uses RecipeSerializer shared with Google Drive for consistent format"
   zip4: "Skips recipes that already exist locally (by ID)"
 
@@ -671,8 +687,8 @@ legend: {
       bold: true
     }
   }
-  pap1: "1. User picks .paprikarecipes file"
-  pap2: "2. PaprikaImportWorker parses ZIP of gzip-compressed JSON"
+  pap1: "1. User picks .paprikarecipes file, selects recipes to import"
+  pap2: "2. PaprikaImportWorker parses ZIP of gzip-compressed JSON (filtered to selected)"
   pap3: "3. Each recipe's content (not source URL) sent to AI"
   pap4: "4. Image resolved from Paprika data or source page"
   pap5: "5. Repository saves each parsed recipe to Room"
@@ -688,8 +704,8 @@ legend: {
   }
   share1: "Share as text: RecipeMarkdownFormatter creates Markdown, shared via ACTION_SEND text/plain"
   share2: "Share as file: ExportSingleRecipeUseCase creates .lorecipes ZIP, shared via FileProvider + ACTION_SEND"
-  share3: "Import: .lorecipes file opened/shared to app triggers FileImportViewModel"
-  share4: "FileImportViewModel reads ZIP, deserializes recipe, saves to Room, navigates to recipe"
+  share3: "Import: .lorecipes file opened/shared to app opens ImportSelectionScreen"
+  share4: "User selects recipes to import, ImportSelectionViewModel imports selected and navigates to recipe"
 
   share1 -> share2 -> share3 -> share4
 


### PR DESCRIPTION
## Summary
- Adds a shared `ImportSelectionScreen` that displays a checklist of recipes found in import files (Paprika, .lorecipes, ZIP backup), sorted alphabetically
- Recipes are checked by default unless they already exist in the app (matched by name for Paprika, by ID or name for .lorecipes/ZIP)
- Import button is disabled when no recipes are selected; Select All / Deselect All buttons provided
- Shared `ImportSelectionViewModel` handles parsing and duplicate detection for all three import types

## Changes
- **New files**: `ImportSelectionScreen.kt`, `ImportSelectionState.kt`, `ImportSelectionViewModel.kt`, `RecipeIdAndName.kt`
- **Modified**: `NavGraph.kt` (new route + .lorecipes files now go through selection), `AddRecipeScreen.kt` (Paprika files navigate to selection first), `SettingsScreen.kt` (ZIP import navigates to selection), `ImportPaprikaUseCase.kt` (filter by selected names), `PaprikaImportWorker.kt` (pass selected names), `RecipeDao.kt`/`RecipeRepository.kt` (new query for IDs+names), `strings.xml`, `architecture.d2`

## Test plan
- [ ] Import a Paprika .paprikarecipes file and verify the selection screen shows all recipes sorted alphabetically
- [ ] Verify recipes with matching names in the app are unchecked by default and show "Already in your recipes"
- [ ] Import a .lorecipes file via share intent and verify selection screen appears
- [ ] Import a ZIP backup from Settings and verify selection screen appears
- [ ] Verify Import button is disabled when nothing is selected
- [ ] Test Select All / Deselect All buttons
- [ ] Test canceling from the selection screen
- [ ] Verify meal plans in ZIP backups are still imported automatically

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)