### PR TITLE
feat: sort recipes alphabetically

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListViewModel.kt
@@ -97,14 +97,14 @@ class RecipeListViewModel @Inject constructor(
         val idsChanged = currentIds != prevState.sortedIds.toSet()
 
         if (filtersChanged || idsChanged) {
-            // Re-sort: in-progress first, then favorites, preserving DAO order within groups
+            // Re-sort: in-progress first, then favorites, then alphabetically by name
             val sorted = filteredItems.sortedWith(
-                compareByDescending {
+                compareByDescending<RecipeListItem> {
                     when (it) {
                         is RecipeListItem.InProgress -> true
                         is RecipeListItem.Saved -> it.recipe.isFavorite
                     }
-                }
+                }.thenBy { it.name.lowercase() }
             )
             val newState = SortState(
                 sortedIds = sorted.map { it.id },


### PR DESCRIPTION
## Summary
- Sort recipes alphabetically by name (case-insensitive) as a secondary sort within the existing grouping (in-progress first, then favorites, then the rest)
- Follows the same pattern used in the grocery list sorting

Closes #191

## Test plan
- [ ] Verify recipes appear in alphabetical order within each group (in-progress, favorites, non-favorites)
- [ ] Verify sorting is case-insensitive
- [ ] Verify search/tag filtering still works correctly with the new sort order

🤖 Generated with [Claude Code](https://claude.com/claude-code)