### PR TITLE
feat: add equipment section to recipes

### DIFF
--- a/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/8.json
+++ b/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/8.json
@@ -1,0 +1,388 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "c891076f624aea1f6b4867b82a88b408",
+    "entities": [
+      {
+        "tableName": "recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sourceUrl` TEXT, `story` TEXT, `servings` INTEGER, `prepTime` TEXT, `cookTime` TEXT, `totalTime` TEXT, `ingredientSectionsJson` TEXT NOT NULL, `instructionSectionsJson` TEXT NOT NULL, `equipmentJson` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `imageUrl` TEXT, `originalHtml` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "story",
+            "columnName": "story",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "prepTime",
+            "columnName": "prepTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cookTime",
+            "columnName": "cookTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalTime",
+            "columnName": "totalTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ingredientSectionsJson",
+            "columnName": "ingredientSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructionSectionsJson",
+            "columnName": "instructionSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipmentJson",
+            "columnName": "equipmentJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "import_debug",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceUrl` TEXT, `originalHtml` TEXT, `cleanedContent` TEXT, `aiOutputJson` TEXT, `originalLength` INTEGER NOT NULL, `cleanedLength` INTEGER NOT NULL, `inputTokens` INTEGER, `outputTokens` INTEGER, `aiModel` TEXT, `thinkingEnabled` INTEGER NOT NULL, `recipeId` TEXT, `recipeName` TEXT, `errorMessage` TEXT, `isError` INTEGER NOT NULL, `durationMs` INTEGER, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cleanedContent",
+            "columnName": "cleanedContent",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "aiOutputJson",
+            "columnName": "aiOutputJson",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalLength",
+            "columnName": "originalLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanedLength",
+            "columnName": "cleanedLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "aiModel",
+            "columnName": "aiModel",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thinkingEnabled",
+            "columnName": "thinkingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recipeName",
+            "columnName": "recipeName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isError",
+            "columnName": "isError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pending_imports",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `name` TEXT, `imageUrl` TEXT, `status` TEXT NOT NULL, `workManagerId` TEXT, `errorMessage` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workManagerId",
+            "columnName": "workManagerId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "meal_plans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `recipeId` TEXT NOT NULL, `recipeName` TEXT NOT NULL, `recipeImageUrl` TEXT, `date` TEXT NOT NULL, `mealType` TEXT NOT NULL, `servings` REAL NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeName",
+            "columnName": "recipeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeImageUrl",
+            "columnName": "recipeImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealType",
+            "columnName": "mealType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c891076f624aea1f6b4867b82a88b408')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
@@ -7,7 +7,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [RecipeEntity::class, ImportDebugEntity::class, PendingImportEntity::class, MealPlanEntity::class],
-    version = 7,
+    version = 8,
     exportSchema = true
 )
 abstract class RecipeDatabase : RoomDatabase() {
@@ -93,6 +93,12 @@ abstract class RecipeDatabase : RoomDatabase() {
         val MIGRATION_6_7 = object : Migration(6, 7) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE recipes ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE recipes ADD COLUMN equipmentJson TEXT NOT NULL DEFAULT '[]'")
             }
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeEntity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeEntity.kt
@@ -19,6 +19,7 @@ data class RecipeEntity(
     val totalTime: String?,
     val ingredientSectionsJson: String,
     val instructionSectionsJson: String,
+    val equipmentJson: String = "[]",
     val tagsJson: String,
     val imageUrl: String?,
     val originalHtml: String?,
@@ -29,6 +30,7 @@ data class RecipeEntity(
 ) {
     fun toRecipe(
         instructionSections: List<InstructionSection>,
+        equipment: List<String>,
         tags: List<String>
     ): Recipe {
         return Recipe(
@@ -41,6 +43,7 @@ data class RecipeEntity(
             cookTime = cookTime,
             totalTime = totalTime,
             instructionSections = instructionSections,
+            equipment = equipment,
             tags = tags,
             imageUrl = imageUrl,
             createdAt = Instant.fromEpochMilliseconds(createdAt),
@@ -53,6 +56,7 @@ data class RecipeEntity(
         fun fromRecipe(
             recipe: Recipe,
             instructionSectionsJson: String,
+            equipmentJson: String,
             tagsJson: String,
             originalHtml: String? = null
         ): RecipeEntity {
@@ -67,6 +71,7 @@ data class RecipeEntity(
                 totalTime = recipe.totalTime,
                 ingredientSectionsJson = "[]",
                 instructionSectionsJson = instructionSectionsJson,
+                equipmentJson = equipmentJson,
                 tagsJson = tagsJson,
                 imageUrl = recipe.imageUrl,
                 originalHtml = originalHtml,

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -209,6 +209,7 @@ For successful parsing, return:
         ]
       }
     ],
+    "equipment": ["9-inch round cake pan", "stand mixer", "wire cooling rack"],
     "tags": ["dessert", "cake", "baking"]
   }
 }
@@ -274,6 +275,14 @@ INGREDIENTS LIVE ON STEPS ONLY:
 - There is NO global ingredient list. All ingredients belong to the step that uses them.
 - If an ingredient is split across steps (e.g., 1/2 cup water in step 1 and 1/2 cup water in step 3), list it on each step separately with its per-step amount. The app aggregates totals.
 - Include the same ingredient name consistently across steps for correct aggregation.
+
+EQUIPMENT:
+- Extract any equipment, tools, or appliances mentioned in the recipe into the "equipment" array.
+- Each item is a simple string (e.g., "9-inch round cake pan", "stand mixer", "parchment paper").
+- Include sizes/specifications when mentioned (e.g., "12-inch skillet", "8x8-inch baking dish").
+- Only include equipment explicitly mentioned or clearly required by the recipe.
+- Omit basic items everyone has (e.g., bowls, spoons, measuring cups) unless a specific type is called for.
+- Omit the "equipment" field entirely if no notable equipment is mentioned.
 
 ADDITIONAL GUIDELINES:
 - If the recipe has distinct sections (e.g., cake and frosting), create separate instructionSections.

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/RecipeParseResult.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/RecipeParseResult.kt
@@ -12,6 +12,7 @@ data class RecipeParseResult(
     val cookTime: String? = null,
     val totalTime: String? = null,
     val instructionSections: List<InstructionSection>,
+    val equipment: List<String> = emptyList(),
     val tags: List<String>,
     val imageUrl: String? = null
 )

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
@@ -67,6 +67,7 @@ class RecipeRepository @Inject constructor(
         val entity = RecipeEntity.fromRecipe(
             recipe = recipe,
             instructionSectionsJson = json.encodeToString(recipe.instructionSections),
+            equipmentJson = json.encodeToString(recipe.equipment),
             tagsJson = json.encodeToString(recipe.tags),
             originalHtml = originalHtml
         )
@@ -125,6 +126,9 @@ class RecipeRepository @Inject constructor(
         val instructionSections: List<InstructionSection> = safeDecodeJson(
             entity.instructionSectionsJson, entity.name, entity.id, "instructions", emptyList(), onError("instructions")
         )
+        val equipment: List<String> = safeDecodeJson(
+            entity.equipmentJson, entity.name, entity.id, "equipment", emptyList(), onError("equipment")
+        )
         val tags: List<String> = safeDecodeJson(
             entity.tagsJson, entity.name, entity.id, "tags", emptyList(), onError("tags")
         )
@@ -141,6 +145,7 @@ class RecipeRepository @Inject constructor(
 
         return entity.toRecipe(
             instructionSections = instructionSections,
+            equipment = equipment,
             tags = tags
         )
     }
@@ -153,12 +158,16 @@ class RecipeRepository @Inject constructor(
         val instructionSections: List<InstructionSection> = safeDecodeJson(
             entity.instructionSectionsJson, entity.name, entity.id, "instructions", emptyList()
         )
+        val equipment: List<String> = safeDecodeJson(
+            entity.equipmentJson, entity.name, entity.id, "equipment", emptyList()
+        )
         val tags: List<String> = safeDecodeJson(
             entity.tagsJson, entity.name, entity.id, "tags", emptyList()
         )
 
         return entity.toRecipe(
             instructionSections = instructionSections,
+            equipment = equipment,
             tags = tags
         )
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
@@ -34,7 +34,8 @@ object DatabaseModule {
                 RecipeDatabase.MIGRATION_3_4,
                 RecipeDatabase.MIGRATION_4_5,
                 RecipeDatabase.MIGRATION_5_6,
-                RecipeDatabase.MIGRATION_6_7
+                RecipeDatabase.MIGRATION_6_7,
+                RecipeDatabase.MIGRATION_7_8
             )
             .build()
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
@@ -29,6 +29,7 @@ data class Recipe(
     val cookTime: String? = null,
     val totalTime: String? = null,
     val instructionSections: List<InstructionSection> = emptyList(),
+    val equipment: List<String> = emptyList(),
     val tags: List<String> = emptyList(),
     val imageUrl: String? = null,
     val createdAt: Instant,

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -171,6 +171,7 @@ class ParseHtmlUseCase @Inject constructor(
             cookTime = parsed.cookTime,
             totalTime = parsed.totalTime,
             instructionSections = parsed.instructionSections,
+            equipment = parsed.equipment,
             tags = parsed.tags,
             imageUrl = imageUrl,
             createdAt = now,

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeMarkdownFormatter.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeMarkdownFormatter.kt
@@ -57,6 +57,16 @@ object RecipeMarkdownFormatter {
         formatIngredientSections(ingredientSections)
         appendLine()
 
+        // Equipment section
+        if (recipe.equipment.isNotEmpty()) {
+            appendLine("## Equipment")
+            appendLine()
+            recipe.equipment.forEach { item ->
+                appendLine("- $item")
+            }
+            appendLine()
+        }
+
         // Instructions section
         appendLine("## Instructions")
         appendLine()

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
@@ -150,6 +150,24 @@ fun RecipeContent(
                 )
             }
 
+            // Equipment
+            if (recipe.equipment.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(24.dp))
+                Text(
+                    text = stringResource(R.string.equipment),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                recipe.equipment.forEach { item ->
+                    Text(
+                        text = "\u2022 $item",
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(start = 8.dp, bottom = 4.dp)
+                    )
+                }
+            }
+
             // Instructions
             Spacer(modifier = Modifier.height(24.dp))
             Text(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="delete_recipe_action">Delete recipe</string>
     <string name="ingredients">Ingredients</string>
     <string name="instructions">Instructions</string>
+    <string name="equipment">Equipment</string>
     <string name="scale_label">Scale:</string>
     <string name="decrease_scale">Decrease scale</string>
     <string name="increase_scale">Increase scale</string>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -357,7 +357,7 @@ app: {
 
       recipe: {
         label: Recipe
-        tooltip: "@Immutable. Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, tags, imageUrl, timestamps, isFavorite"
+        tooltip: "@Immutable. Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, equipment, tags, imageUrl, timestamps, isFavorite"
       }
       ingredient: {
         label: Ingredient


### PR DESCRIPTION
## Summary
- Adds an `equipment` field to the Recipe domain model as a `List<String>` for storing tools/appliances needed
- Updates the AI system prompt to extract equipment from recipe pages during import
- Displays equipment as a bulleted list between ingredients and instructions in the recipe detail view
- Includes equipment in Markdown export
- Adds Room database migration (v7 → v8) with `equipmentJson` column

## Changes across layers
- **Domain**: `Recipe` model gains `equipment: List<String>` field
- **Data**: `RecipeEntity` gains `equipmentJson` column; `RecipeParseResult` gains `equipment` field; repository handles serialization/deserialization
- **AI**: System prompt instructs Claude to extract equipment from recipes
- **UI**: Equipment section rendered in `RecipeContent.kt` with bullet points
- **Export**: `RecipeMarkdownFormatter` includes equipment section; `RecipeSerializer` picks it up automatically via `kotlinx.serialization`

Closes #7

## Test plan
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes
- [ ] Import a recipe from a URL and verify equipment is extracted and displayed
- [ ] Verify existing recipes load correctly (equipment defaults to empty list)
- [ ] Share a recipe as text and verify equipment appears in Markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)