### PR TITLE
feat: replace greedy tag selection with ILP optimization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -147,6 +147,9 @@ dependencies {
     // HTML parsing
     implementation(libs.jsoup)
 
+    // Optimization (ILP tag selection)
+    implementation(libs.ojalgo)
+
     // Google Drive
     implementation(libs.play.services.auth)
     implementation(libs.credentials)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -39,3 +39,8 @@
 -dontwarn java.lang.reflect.AnnotatedParameterizedType
 -dontwarn java.lang.reflect.AnnotatedType
 -dontwarn com.github.victools.jsonschema.generator.**
+
+# ojAlgo (ILP solver for tag selection)
+-keep class org.ojalgo.** { *; }
+-keepclassmembers class org.ojalgo.** { *; }
+-dontwarn org.ojalgo.**

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/GetTagsUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/GetTagsUseCase.kt
@@ -1,80 +1,175 @@
 package com.lionotter.recipes.domain.usecase
 
 import com.lionotter.recipes.domain.model.Recipe
+import org.ojalgo.optimisation.ExpressionsBasedModel
+import org.ojalgo.optimisation.Optimisation
 import javax.inject.Inject
 
 class GetTagsUseCase @Inject constructor() {
     companion object {
-        private const val MAX_TAGS = 10
+        internal const val MAX_TAGS = 10
+        internal const val GAMMA_MULTIPLIER = 10.0 // γ = GAMMA_MULTIPLIER * maxTagSize
     }
 
     /**
-     * Returns the top tags using a greedy set cover algorithm to maximize coverage,
-     * sorted by total recipe count.
+     * Returns the top tags using an ILP (Integer Linear Programming) optimization to maximize
+     * recipe coverage while preferring specific tags over generic ones.
      *
-     * Algorithm:
-     * 1. Start with a set of all recipes
-     * 2. Find the tag with the most recipes in that set
-     * 3. Add that tag to results and remove its recipes from the set
-     * 4. Repeat until we have 10 tags or no more tags exist
-     * 5. If set becomes empty but we have fewer than 10 tags, reset the set
-     * 6. Sort final tags by total recipe count (descending)
+     * Falls back to a greedy set cover algorithm if the ILP solver fails.
+     *
+     * ILP formulation:
+     *   Maximize: Σ_j (x_j · w_j) - γ · Σ_i u_i
+     *   Subject to:
+     *     Σ_j (x_j · a_ij) + u_i ≥ 1  for all recipes i (coverage with slack)
+     *     Σ_j x_j = k                   (select exactly k tags)
+     *     x_j ∈ {0,1}, u_i ∈ {0,1}
+     *
+     * Where:
+     *   w_j = |tag_j| · ln(N / |tag_j|)  — IDF-weighted coverage score
+     *   γ = GAMMA_MULTIPLIER * maxTagSize — uncovered recipe penalty
+     *
+     * The IDF-like weighting naturally balances coverage and specificity:
+     * - A tag covering all N recipes scores N·ln(1) = 0 (no filtering value)
+     * - A tag covering 1 recipe scores 1·ln(N) (maximum specificity)
+     * - The peak is at N/e ≈ 37% of recipes
      */
     fun execute(recipes: List<Recipe>): List<String> {
-        // Build tag -> recipe IDs map
-        val tagToRecipes = mutableMapOf<String, MutableSet<String>>()
-        for (recipe in recipes) {
-            for (tag in recipe.tags) {
-                tagToRecipes.getOrPut(tag) { mutableSetOf() }.add(recipe.id)
-            }
-        }
+        val tagToRecipes = buildTagMap(recipes)
 
         if (tagToRecipes.isEmpty()) {
             return emptyList()
         }
 
-        // If we have 10 or fewer tags, just return them sorted by count
         if (tagToRecipes.size <= MAX_TAGS) {
             return tagToRecipes.entries
                 .sortedByDescending { it.value.size }
                 .map { it.key }
         }
 
-        // Greedy set cover algorithm
+        return try {
+            solveIlp(recipes, tagToRecipes)
+        } catch (_: Exception) {
+            solveGreedy(recipes, tagToRecipes)
+        }
+    }
+
+    private fun buildTagMap(recipes: List<Recipe>): Map<String, Set<String>> {
+        val tagToRecipes = mutableMapOf<String, MutableSet<String>>()
+        for (recipe in recipes) {
+            for (tag in recipe.tags) {
+                tagToRecipes.getOrPut(tag) { mutableSetOf() }.add(recipe.id)
+            }
+        }
+        return tagToRecipes
+    }
+
+    internal fun solveIlp(
+        recipes: List<Recipe>,
+        tagToRecipes: Map<String, Set<String>>
+    ): List<String> {
+        val tags = tagToRecipes.keys.toList()
+        val recipeIds = recipes.map { it.id }.distinct()
+        val recipeCount = recipeIds.size
+        val maxTagSize = tagToRecipes.values.maxOf { it.size }
+
+        // Build recipe-to-index lookup
+        val recipeIndex = recipeIds.withIndex().associate { (idx, id) -> id to idx }
+
+        // Build tag membership matrix: a_ij = 1 if recipe i has tag j
+        val membership = Array(recipeCount) { BooleanArray(tags.size) }
+        for ((j, tag) in tags.withIndex()) {
+            for (recipeId in tagToRecipes[tag]!!) {
+                val i = recipeIndex[recipeId] ?: continue
+                membership[i][j] = true
+            }
+        }
+
+        val gamma = GAMMA_MULTIPLIER * maxTagSize
+
+        val model = ExpressionsBasedModel()
+
+        // x_j: binary variable for whether tag j is selected
+        val xVars = tags.mapIndexed { j, tag ->
+            model.addVariable("x_$j").binary().apply {
+                // IDF-weighted coverage: |tag_j| * ln(N / |tag_j|)
+                // Tags covering all recipes score 0; tags covering ~37% of recipes score highest.
+                val tagSize = tagToRecipes[tag]!!.size.toDouble()
+                weight(tagSize * Math.log(recipeCount.toDouble() / tagSize))
+            }
+        }
+
+        // u_i: binary slack variable for uncovered recipe i
+        val uVars = recipeIds.mapIndexed { i, _ ->
+            model.addVariable("u_$i").binary().apply {
+                weight(-gamma) // penalty for leaving recipe uncovered
+            }
+        }
+
+        // Constraint: Σ_j x_j = k (select exactly MAX_TAGS tags)
+        val tagCountExpr = model.addExpression("tag_count").level(MAX_TAGS.toLong())
+        for (j in tags.indices) {
+            tagCountExpr.set(xVars[j], 1)
+        }
+
+        // Constraint: Σ_j (x_j · a_ij) + u_i ≥ 1 for each recipe i
+        for (i in recipeIds.indices) {
+            val coverageExpr = model.addExpression("coverage_$i").lower(1)
+            for (j in tags.indices) {
+                if (membership[i][j]) {
+                    coverageExpr.set(xVars[j], 1)
+                }
+            }
+            coverageExpr.set(uVars[i], 1)
+        }
+
+        val result = model.maximise()
+
+        if (result.state != Optimisation.State.OPTIMAL &&
+            result.state != Optimisation.State.FEASIBLE
+        ) {
+            throw IllegalStateException("ILP solver returned state: ${result.state}")
+        }
+
+        // Extract selected tags
+        val selectedTags = tags.indices
+            .filter { j -> result.doubleValue(j) > 0.5 }
+            .map { j -> tags[j] }
+
+        // Sort by total recipe count (descending)
+        return selectedTags.sortedByDescending { tagToRecipes[it]?.size ?: 0 }
+    }
+
+    internal fun solveGreedy(
+        recipes: List<Recipe>,
+        tagToRecipes: Map<String, Set<String>>
+    ): List<String> {
         val allRecipeIds = recipes.map { it.id }.toSet()
         val selectedTags = mutableListOf<String>()
         var uncoveredRecipes = allRecipeIds.toMutableSet()
 
         while (selectedTags.size < MAX_TAGS) {
-            // Find tag that covers most uncovered recipes
             val bestTag = tagToRecipes
                 .filterKeys { it !in selectedTags }
                 .maxByOrNull { (_, recipeIds) ->
                     recipeIds.count { it in uncoveredRecipes }
                 }
                 ?.key
-                ?: break // No more tags available
+                ?: break
 
             selectedTags.add(bestTag)
-
-            // Remove covered recipes
             uncoveredRecipes.removeAll(tagToRecipes[bestTag] ?: emptySet())
 
-            // If all recipes are covered but we need more tags, reset the set
             if (uncoveredRecipes.isEmpty() && selectedTags.size < MAX_TAGS) {
                 uncoveredRecipes = allRecipeIds.toMutableSet()
-                // Remove recipes already covered by selected tags
                 for (tag in selectedTags) {
                     uncoveredRecipes.removeAll(tagToRecipes[tag] ?: emptySet())
                 }
-                // If still empty (all recipes covered), reset completely
                 if (uncoveredRecipes.isEmpty()) {
                     uncoveredRecipes = allRecipeIds.toMutableSet()
                 }
             }
         }
 
-        // Sort by total recipe count (descending)
         return selectedTags.sortedByDescending { tagToRecipes[it]?.size ?: 0 }
     }
 }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -325,7 +325,10 @@ app: {
         label: AggregateGroceryListUseCase
         tooltip: "Aggregates ingredients from selected meal plan recipes into a deduplicated grocery list. Normalizes ingredient names by removing size prefixes (small/medium/large), sums amounts in base units across recipes."
       }
-      tags: GetTagsUseCase
+      tags: {
+        label: GetTagsUseCase
+        tooltip: "Selects top k tags using ILP optimization (ojalgo) to maximize coverage while penalizing generic tags. Falls back to greedy set cover if solver fails."
+      }
       calc_usage: {
         label: CalculateIngredientUsageUseCase
         tooltip: "Pure domain logic for calculating ingredient usage status from checked instruction steps, scale, and measurement preference."

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ profileinstaller = "1.4.1"
 uiautomator = "2.3.0"
 androidxTestExtJunit = "1.2.1"
 anthropicSdk = "2.14.0"
+ojalgo = "56.2.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -103,6 +104,9 @@ androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchm
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
+
+# Optimization
+ojalgo = { group = "org.ojalgo", name = "ojalgo", version.ref = "ojalgo" }
 
 # Testing
 junit = { group = "junit", name = "junit", version = "4.13.2" }


### PR DESCRIPTION
## Summary

Closes #196

- Replace the greedy set cover tag selection algorithm with an Integer Linear Program (ILP) solved via [ojalgo](https://github.com/optimatika/ojAlgo) (pure Java, no native dependencies)
- ILP uses IDF-weighted coverage scoring (`|tag| * ln(N/|tag|)`) to naturally balance coverage and specificity — tags covering all recipes score 0, while moderately-sized tags score highest (peak at ~37% of total recipes)
- Coverage constraints with slack variables ensure graceful degradation when not all recipes can be covered with k=10 tags
- Falls back to the original greedy algorithm if the ILP solver fails for any reason
- Short-circuits and returns all tags if there are 10 or fewer total tags

## Test plan

- [x] All existing tests updated to work with ILP solver
- [x] New test: ILP deprioritizes near-universal tags (verifies tags covering all recipes get score 0)
- [x] New test: ILP handles degenerate case with more unique tags than k
- [x] New test: Greedy fallback works correctly when called directly
- [x] New test: ILP maximizes multi-tag coverage
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes (230 tests, 0 failures)
- [x] `./gradlew lintDebug` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)