### PR TITLE
fix: allow custom units like "dashes" in AI recipe prompt

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -234,10 +234,11 @@ INGREDIENT FORMAT:
 - If the recipe provides both weight and volume, prefer weight.
 - Use the density reference table below. For ingredients not listed, estimate a reasonable density — cooking precision doesn't require exactness.
 
-SUPPORTED UNITS (use exactly these strings):
+SUPPORTED UNITS:
 - Weight: mg, g, kg, oz, lb
 - Volume: mL, L, tsp, tbsp, cup, fl_oz, pint, quart, gal
 - Count: omit unit field
+- Other: You may use other unit strings when appropriate (e.g., "dash" for cocktail bitters, "pinch", "drop", "sprig", "slice"). These won't support weight/volume conversion but will display correctly. Omit "density" for these units.
 
 INGREDIENT DENSITIES (g/mL — use these when known):
 water 0.96, milk 0.96, buttermilk 0.96, heavy cream 0.96, yogurt 0.96, sour cream 0.96,


### PR DESCRIPTION
## Summary
- Updated the AI recipe parsing prompt to allow custom unit strings beyond the standard weight/volume units
- Removed the restrictive "use exactly these strings" wording and added an "Other" category with examples like "dash", "pinch", "drop", "sprig", "slice"
- These custom units display correctly (e.g., "2 dashes bitters") but don't support weight/volume conversion, which is appropriate behavior

## Context
The issue (#199) reported that cocktail recipes show "2 bitters" instead of "2 dashes bitters" because the AI prompt explicitly restricted units to only weight/volume/count. The existing unit display and formatting code already handles unknown units gracefully -- `unitType()` returns null for unrecognized units, which causes the format function to display them as-is with proper pluralization.

## Test plan
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes
- [ ] Re-import a cocktail recipe with bitters to verify "dashes" unit is used

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)