### PR TITLE
fix: display fl_oz as "fl oz" in ingredient formatting

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
@@ -170,7 +170,7 @@ data class Ingredient(
                 if (unit != null) {
                     append(" ")
                     val count = if (value > 1.0) 2 else 1
-                    append(unit.singularize().pluralize(count))
+                    append(displayUnit(unit.singularize().pluralize(count)))
                 }
             }
             append(" ")
@@ -308,6 +308,9 @@ data class InstructionStep(
 // --- Unit conversion utilities ---
 
 enum class UnitCategory { WEIGHT, VOLUME }
+
+/** Convert internal unit identifiers to display-friendly strings (e.g. "fl_oz" → "fl oz"). */
+private fun displayUnit(unit: String): String = unit.replace('_', ' ')
 
 private val WEIGHT_UNITS = setOf("mg", "g", "kg", "oz", "lb")
 private val VOLUME_UNITS = setOf("mL", "L", "tsp", "tbsp", "cup", "fl_oz", "pint", "quart", "gal")

--- a/app/src/test/kotlin/com/lionotter/recipes/domain/model/IngredientTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/domain/model/IngredientTest.kt
@@ -639,4 +639,24 @@ class IngredientTest {
         )
         assertEquals("8 oz cheese", ingredient.format(weightSystem = UnitSystem.CUSTOMARY))
     }
+
+    // --- Unit display name tests ---
+
+    @Test
+    fun `fl_oz displays as fl oz`() {
+        val ingredient = Ingredient(
+            name = "water",
+            amount = Amount(value = 2.0, unit = "fl_oz")
+        )
+        assertEquals("2 fl oz water", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
+    }
+
+    @Test
+    fun `singular fl_oz displays as fl oz`() {
+        val ingredient = Ingredient(
+            name = "vanilla",
+            amount = Amount(value = 1.0, unit = "fl_oz")
+        )
+        assertEquals("1 fl oz vanilla", ingredient.format(volumeSystem = UnitSystem.CUSTOMARY))
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a `displayUnit()` helper that replaces underscores with spaces in unit identifiers before rendering
- Applies the helper in `Ingredient.format()` so `fl_oz` displays as `fl oz`
- No other current units are affected (only `fl_oz` contains an underscore)
- Adds two tests verifying singular and plural `fl oz` display

Fixes #198

## Test plan
- [x] Existing unit tests pass (`./gradlew testDebugUnitTest`)
- [x] New tests for `fl_oz` → `fl oz` display (singular and plural)
- [x] Debug build succeeds (`./gradlew assembleDebug`)
- [x] Lint passes (`./gradlew lintDebug`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)