### PR TITLE
fix: handle missing/broken recipe images consistently

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/ImageDownloadService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/ImageDownloadService.kt
@@ -1,0 +1,115 @@
+package com.lionotter.recipes.data.remote
+
+import android.content.Context
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import java.io.File
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Downloads recipe images and stores them locally in the app's internal storage.
+ * Returns a file:// URI that can be stored in the recipe's imageUrl field.
+ */
+@Singleton
+class ImageDownloadService @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val httpClient: HttpClient
+) {
+    companion object {
+        private const val TAG = "ImageDownloadService"
+        private const val IMAGE_DIR = "recipe_images"
+    }
+
+    private fun getImageDir(): File {
+        val dir = File(context.filesDir, IMAGE_DIR)
+        if (!dir.exists()) {
+            dir.mkdirs()
+        }
+        return dir
+    }
+
+    /**
+     * Downloads an image from a URL and stores it locally.
+     * Returns the local file URI string, or null if download fails.
+     *
+     * If the URL is already a local file URI, returns it as-is.
+     */
+    suspend fun downloadAndStore(imageUrl: String): String? {
+        // Skip if already a local file
+        if (imageUrl.startsWith("file://")) {
+            return imageUrl
+        }
+
+        return try {
+            val response = httpClient.get(imageUrl) {
+                header(HttpHeaders.UserAgent, "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36")
+                header(HttpHeaders.Accept, "image/*,*/*;q=0.8")
+            }
+
+            if (!response.status.isSuccess()) {
+                Log.w(TAG, "Failed to download image from $imageUrl: HTTP ${response.status}")
+                return null
+            }
+
+            // Determine file extension from content type
+            val extension = when (response.contentType()?.contentSubtype) {
+                "jpeg", "jpg" -> ".jpg"
+                "png" -> ".png"
+                "webp" -> ".webp"
+                "gif" -> ".gif"
+                else -> ".jpg" // Default to jpg
+            }
+
+            val fileName = "${UUID.randomUUID()}$extension"
+            val imageFile = File(getImageDir(), fileName)
+
+            response.bodyAsChannel().toInputStream().use { input ->
+                imageFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+
+            // Verify the file was written and has content
+            if (!imageFile.exists() || imageFile.length() == 0L) {
+                Log.w(TAG, "Image file is empty after download: $imageUrl")
+                imageFile.delete()
+                return null
+            }
+
+            val localUri = "file://${imageFile.absolutePath}"
+            Log.d(TAG, "Downloaded image: $imageUrl -> $localUri (${imageFile.length()} bytes)")
+            localUri
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to download image from $imageUrl", e)
+            null
+        }
+    }
+
+    /**
+     * Deletes a locally stored image file.
+     */
+    fun deleteLocalImage(localUri: String) {
+        if (!localUri.startsWith("file://")) return
+        try {
+            val path = localUri.removePrefix("file://")
+            val file = File(path)
+            if (file.exists() && file.parentFile?.name == IMAGE_DIR) {
+                file.delete()
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to delete image: $localUri", e)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/components/RecipeThumbnail.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/components/RecipeThumbnail.kt
@@ -1,0 +1,66 @@
+package com.lionotter.recipes.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Restaurant
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+
+/**
+ * A recipe thumbnail that always reserves space for consistent layout alignment.
+ * Shows the recipe image if available and loadable, otherwise shows a placeholder icon.
+ */
+@Composable
+fun RecipeThumbnail(
+    imageUrl: String?,
+    contentDescription: String,
+    size: Int,
+    modifier: Modifier = Modifier
+) {
+    val placeholderContent: @Composable () -> Unit = {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Restaurant,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size((size / 2).dp)
+            )
+        }
+    }
+
+    if (imageUrl != null) {
+        SubcomposeAsyncImage(
+            model = imageUrl,
+            contentDescription = contentDescription,
+            modifier = modifier
+                .size(size.dp)
+                .clip(MaterialTheme.shapes.small),
+            contentScale = ContentScale.Crop,
+            loading = { placeholderContent() },
+            error = { placeholderContent() }
+        )
+    } else {
+        Box(
+            modifier = modifier
+                .size(size.dp)
+                .clip(MaterialTheme.shapes.small)
+        ) {
+            placeholderContent()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/AddMealPlanDialog.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/AddMealPlanDialog.kt
@@ -47,16 +47,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
 import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.MealType
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.ui.components.RecipeThumbnail
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -316,17 +314,12 @@ private fun RecipeSelectionCard(
                 .padding(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            if (recipe.imageUrl != null) {
-                AsyncImage(
-                    model = recipe.imageUrl,
-                    contentDescription = recipe.name,
-                    modifier = Modifier
-                        .size(40.dp)
-                        .clip(MaterialTheme.shapes.small),
-                    contentScale = ContentScale.Crop
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-            }
+            RecipeThumbnail(
+                imageUrl = recipe.imageUrl,
+                contentDescription = recipe.name,
+                size = 40
+            )
+            Spacer(modifier = Modifier.width(8.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = recipe.name,

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -47,17 +46,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
 import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.MealPlanEntry
+import com.lionotter.recipes.ui.components.RecipeThumbnail
 import com.lionotter.recipes.domain.model.MealType
 import com.lionotter.recipes.ui.components.RecipeTopAppBar
 import kotlinx.datetime.DateTimeUnit
@@ -343,18 +340,13 @@ private fun MealPlanCard(
                     .padding(12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // Recipe image
-                if (entry.recipeImageUrl != null) {
-                    AsyncImage(
-                        model = entry.recipeImageUrl,
-                        contentDescription = entry.recipeName,
-                        modifier = Modifier
-                            .size(56.dp)
-                            .clip(MaterialTheme.shapes.small),
-                        contentScale = ContentScale.Crop
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                }
+                // Recipe image (always reserve space for consistent alignment)
+                RecipeThumbnail(
+                    imageUrl = entry.recipeImageUrl,
+                    contentDescription = entry.recipeName,
+                    size = 56
+                )
+                Spacer(modifier = Modifier.width(12.dp))
 
                 Column(modifier = Modifier.weight(1f)) {
                     Text(

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
@@ -21,6 +21,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
@@ -30,7 +34,8 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
+import coil.compose.SubcomposeAsyncImageContent
 import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.IngredientUsageStatus
 import com.lionotter.recipes.domain.model.InstructionIngredientKey
@@ -63,17 +68,23 @@ fun RecipeContent(
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
     ) {
-        // Hero image
+        // Hero image (only shown if image loads successfully)
         recipe.imageUrl?.let { imageUrl ->
-            AsyncImage(
-                model = imageUrl,
-                contentDescription = recipe.name,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(16f / 9f)
-                    .clip(MaterialTheme.shapes.medium),
-                contentScale = ContentScale.Crop
-            )
+            var showImage by remember(imageUrl) { mutableStateOf(true) }
+            if (showImage) {
+                SubcomposeAsyncImage(
+                    model = imageUrl,
+                    contentDescription = recipe.name,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(16f / 9f)
+                        .clip(MaterialTheme.shapes.medium),
+                    contentScale = ContentScale.Crop,
+                    loading = { },
+                    error = { showImage = false },
+                    success = { SubcomposeAsyncImageContent() }
+                )
+            }
         }
 
         Column(modifier = Modifier.padding(16.dp)) {

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/InProgressRecipeCard.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/InProgressRecipeCard.kt
@@ -26,14 +26,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import com.lionotter.recipes.R
 import com.lionotter.recipes.data.local.PendingImportEntity
+import com.lionotter.recipes.ui.components.RecipeThumbnail
 import com.lionotter.recipes.ui.state.InProgressRecipe
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -88,13 +86,10 @@ fun InProgressRecipeCard(
             ) {
                 // Image or loading indicator
                 if (inProgressRecipe.imageUrl != null) {
-                    AsyncImage(
-                        model = inProgressRecipe.imageUrl,
+                    RecipeThumbnail(
+                        imageUrl = inProgressRecipe.imageUrl,
                         contentDescription = inProgressRecipe.name,
-                        modifier = Modifier
-                            .size(80.dp)
-                            .clip(MaterialTheme.shapes.small),
-                        contentScale = ContentScale.Crop
+                        size = 80
                     )
                     Spacer(modifier = Modifier.width(12.dp))
                 } else {

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/RecipeCard.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/RecipeCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -29,14 +28,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.ui.components.RecipeThumbnail
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
@@ -64,18 +61,13 @@ internal fun RecipeCard(
                     .fillMaxWidth()
                     .padding(12.dp)
             ) {
-                // Recipe image
-                if (recipe.imageUrl != null) {
-                    AsyncImage(
-                        model = recipe.imageUrl,
-                        contentDescription = recipe.name,
-                        modifier = Modifier
-                            .size(80.dp)
-                            .clip(MaterialTheme.shapes.small),
-                        contentScale = ContentScale.Crop
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                }
+                // Recipe image (always reserve space for consistent alignment)
+                RecipeThumbnail(
+                    imageUrl = recipe.imageUrl,
+                    contentDescription = recipe.name,
+                    size = 80
+                )
+                Spacer(modifier = Modifier.width(12.dp))
 
                 Column(modifier = Modifier.weight(1f)) {
                     Text(

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -360,7 +360,7 @@ app: {
 
       recipe: {
         label: Recipe
-        tooltip: "@Immutable. Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, equipment, tags, imageUrl, timestamps, isFavorite"
+        tooltip: "@Immutable. Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, equipment, tags, imageUrl (local file:// URI), timestamps, isFavorite"
       }
       ingredient: {
         label: Ingredient
@@ -470,7 +470,7 @@ app: {
       dao: RecipeDao
       entity: {
         label: RecipeEntity
-        tooltip: "Room entity for recipes: id, name, sourceUrl, story, servings, times, JSON fields, imageUrl, originalHtml, createdAt, updatedAt, isFavorite, deleted (soft-delete flag for sync)"
+        tooltip: "Room entity for recipes: id, name, sourceUrl, story, servings, times, JSON fields, imageUrl (local file:// URI), originalHtml, createdAt, updatedAt, isFavorite, deleted (soft-delete flag for sync)"
       }
       import_debug_dao: ImportDebugDao
       pending_import_dao: PendingImportDao
@@ -486,6 +486,11 @@ app: {
       meal_plan_entity: {
         label: MealPlanEntity
         tooltip: "Room entity for meal plan entries: id, recipeId, recipeName, recipeImageUrl, date, mealType, servings, createdAt, updatedAt, deleted (soft-delete flag for sync)"
+      }
+      image_storage: {
+        label: Local Image Storage
+        shape: cylinder
+        tooltip: "Recipe images stored as files in app internal storage (filesDir/recipe_images/). Referenced by file:// URIs in Recipe.imageUrl."
       }
       settings: {
         label: SettingsDataStore
@@ -518,6 +523,10 @@ app: {
         label: WebScraperService
         tooltip: Uses Readability4J to extract article content
       }
+      image_dl: {
+        label: ImageDownloadService
+        tooltip: "Downloads recipe images from remote URLs and stores them locally in app internal storage. Returns file:// URIs for local access. Used during import, sync, and ZIP restore to ensure images are available offline."
+      }
       firestore_svc: {
         label: FirestoreService
         tooltip: "Handles Firebase Auth (Google Sign-In), and Firestore document operations for recipe and meal plan sync. Data stored at users/{userId}/recipes/{recipeId} and users/{userId}/mealPlans/{mealPlanId}."
@@ -545,6 +554,7 @@ app: {
     repository.import_debug_repo -> local.import_debug_dao
     repository.pending_import_repo -> local.pending_import_dao
     repository.meal_plan_repo -> local.meal_plan_dao
+    remote.image_dl -> local.image_storage: stores images
   }
 
   # Performance
@@ -627,7 +637,10 @@ app: {
   domain.usecases.import_paprika -> data.paprika.parser: parse export
   domain.usecases.import_paprika -> domain.usecases.parse_html: parseText
   domain.usecases.import_paprika -> data.remote.scraper: fetch source image
+  domain.usecases.parse_html -> data.remote.image_dl: download image
+  domain.usecases.sync_firestore -> data.remote.image_dl: download image
   data.remote.scraper -> external.web: fetch HTML
+  data.remote.image_dl -> external.web: download image
   data.remote.anthropic_svc -> external.anthropic: parse recipe
   data.remote.firestore_svc -> external.firebase: sync data
 }


### PR DESCRIPTION
## Summary
- Always show a placeholder thumbnail (restaurant icon) in recipe list, meal plan, and import cards when no image exists or the image fails to load, ensuring consistent alignment
- Hide the hero image block in recipe detail view when the image URL is null or fails to load, instead of showing blank space
- Download and store recipe images locally during import, sync, and ZIP restore to avoid hotlinking issues and ensure offline availability

## Changes
- **New `RecipeThumbnail` component** (`ui/components/RecipeThumbnail.kt`): Shared composable that always reserves space for a thumbnail, showing either the loaded image or a restaurant icon placeholder on a surfaceVariant background
- **New `ImageDownloadService`** (`data/remote/ImageDownloadService.kt`): Downloads remote images to app internal storage (`filesDir/recipe_images/`) and returns `file://` URIs
- **`RecipeCard`**: Always shows 80dp thumbnail space using `RecipeThumbnail` (was conditionally hidden)
- **`RecipeContent`**: Uses `SubcomposeAsyncImage` with error callback to hide hero image block entirely when image fails to load
- **`MealPlanScreen`**: Always shows 56dp thumbnail using `RecipeThumbnail`
- **`AddMealPlanDialog`**: Always shows 40dp thumbnail using `RecipeThumbnail`
- **`InProgressRecipeCard`**: Uses `RecipeThumbnail` for loaded images with error handling
- **`ParseHtmlUseCase`**: Downloads images locally before saving recipe
- **`FirestoreSyncUseCase`**: Downloads remote images when syncing from other devices
- **`ImportFromZipUseCase`**: Downloads/validates images during ZIP import
- **`FileImportViewModel`** & **`ImportSelectionViewModel`**: Download/validate images during .lorecipes and selection import
- **Architecture diagram**: Updated to reflect new `ImageDownloadService` and local image storage

## Test plan
- [ ] Import a recipe from a URL with an image — verify image is downloaded locally and displayed
- [ ] Import a recipe from a URL with no image — verify placeholder icon shown in list, no hero image in detail
- [ ] Verify recipe list alignment is consistent regardless of image presence
- [ ] Import from Paprika — verify image handling
- [ ] Test Firestore sync from another device — verify images are downloaded
- [ ] Test ZIP backup/restore — verify images are handled
- [ ] Verify broken image URLs show placeholder in list and hide header in detail

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)