### PR TITLE
feat: add ci-local.sh for single-command CI checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,5 @@
 - ALWAYS check the current commit before amending
 - Reference @docs/architecture.d2 and keep it up to date with any changes
 - Before committing, always run the CI checks locally to verify nothing is broken:
-  - `./gradlew assembleDebug` (debug build)
-  - `./gradlew testDebugUnitTest` (unit tests)
-  - `./gradlew lintDebug` (lint)
+  - `./ci-local.sh` (runs assembleDebug, testDebugUnitTest, and lintDebug in parallel)
   - See `.github/workflows/android-ci.yml` for the full CI pipeline

--- a/ci-local.sh
+++ b/ci-local.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local CI script: sets up google-services.json, then runs build, test, and lint.
+# Uses a single Gradle invocation with --continue so all tasks run even if some fail.
+# Output is written to a log file for inspection.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+LOG_DIR="$SCRIPT_DIR/build/ci-logs"
+mkdir -p "$LOG_DIR"
+
+# Ensure google-services.json exists
+GSERVICES="$SCRIPT_DIR/app/google-services.json"
+if [ ! -f "$GSERVICES" ]; then
+  echo "Creating dummy google-services.json..."
+  cat > "$GSERVICES" << 'GSEOF'
+{"project_info":{"project_number":"0","project_id":"dummy","storage_bucket":"dummy.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:0:android:0","android_client_info":{"package_name":"com.lionotter.recipes"}},"oauth_client":[],"api_key":[{"current_key":"dummy"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
+GSEOF
+else
+  echo "google-services.json already exists, skipping creation."
+fi
+
+LOG_FILE="$LOG_DIR/ci.log"
+
+echo ""
+echo "Running: ./gradlew assembleDebug testDebugUnitTest lintDebug --continue"
+echo "  log: $LOG_FILE"
+echo ""
+
+if ./gradlew assembleDebug testDebugUnitTest lintDebug --continue > "$LOG_FILE" 2>&1; then
+  exit_code=0
+else
+  exit_code=$?
+fi
+
+echo "Exit code: $exit_code"
+echo "     log: $LOG_FILE"
+echo ""
+
+if [ "$exit_code" -ne 0 ]; then
+  echo "CI checks FAILED. See log file for details."
+  echo ""
+  # Show the last few lines for quick diagnosis
+  tail -20 "$LOG_FILE"
+else
+  echo "All CI checks passed."
+fi
+
+exit "$exit_code"


### PR DESCRIPTION
## Summary
- Adds `ci-local.sh` script that creates a dummy `google-services.json` (if not present) and runs `assembleDebug`, `testDebugUnitTest`, and `lintDebug` in a single Gradle invocation with `--continue`
- Output is written to `build/ci-logs/ci.log` for inspection
- Updates `CLAUDE.md` to replace the 3 separate commands with a single `./ci-local.sh` reference

Closes #207

## Test plan
- [x] Verified `./ci-local.sh` creates `google-services.json` when missing
- [x] Verified all three CI tasks pass when run via the script
- [x] Verified log file is created at `build/ci-logs/ci.log`
- [x] Verified script exits non-zero on failure and displays the log tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)