### PR TITLE
fix: show regenerate button for recipes with source URL

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -64,7 +64,7 @@ fun RecipeDetailScreen(
     val keepScreenOn by viewModel.keepScreenOn.collectAsStateWithLifecycle()
     val volumeUnitSystem by viewModel.volumeUnitSystem.collectAsStateWithLifecycle()
     val weightUnitSystem by viewModel.weightUnitSystem.collectAsStateWithLifecycle()
-    val hasOriginalHtml by viewModel.hasOriginalHtml.collectAsStateWithLifecycle()
+    val canRegenerate by viewModel.canRegenerate.collectAsStateWithLifecycle()
     val regenerateState by viewModel.regenerateState.collectAsStateWithLifecycle()
     val regenerateModel by viewModel.regenerateModel.collectAsStateWithLifecycle()
     val regenerateThinking by viewModel.regenerateThinking.collectAsStateWithLifecycle()
@@ -160,7 +160,7 @@ fun RecipeDetailScreen(
                 onBackClick = onBackClick,
                 actions = {
                     if (recipe != null) {
-                        if (hasOriginalHtml) {
+                        if (canRegenerate) {
                             IconButton(onClick = { showRegenerateDialog = true }) {
                                 Icon(
                                     imageVector = Icons.Default.Refresh,

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeRegenerateWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeRegenerateWorker.kt
@@ -36,6 +36,7 @@ class RecipeRegenerateWorker @AssistedInject constructor(
         const val RESULT_NO_API_KEY = "no_api_key"
         const val RESULT_NO_ORIGINAL_HTML = "no_original_html"
 
+        const val PROGRESS_FETCHING = "fetching"
         const val PROGRESS_PARSING = "parsing"
         const val PROGRESS_SAVING = "saving"
 
@@ -75,6 +76,13 @@ class RecipeRegenerateWorker @AssistedInject constructor(
             extendedThinking = extendedThinking,
             onProgress = { progress ->
                 val progressMessage = when (progress) {
+                    is RegenerateRecipeUseCase.RegenerateProgress.FetchingFromUrl -> {
+                        setProgress(workDataOf(
+                            KEY_RECIPE_ID to recipeId,
+                            KEY_PROGRESS to PROGRESS_FETCHING
+                        ))
+                        "Fetching recipe page..."
+                    }
                     is RegenerateRecipeUseCase.RegenerateProgress.ParsingRecipe -> {
                         setProgress(workDataOf(
                             KEY_RECIPE_ID to recipeId,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,7 +56,7 @@
 
     <!-- Regenerate Recipe -->
     <string name="regenerate_recipe">Regenerate Recipe</string>
-    <string name="regenerate_recipe_description">Re-parse this recipe from the original page content using AI. You can choose a different model or thinking mode. The current recipe will be replaced.</string>
+    <string name="regenerate_recipe_description">Re-parse this recipe from the original page content using AI. If the original content is not available, it will be re-fetched from the source URL. You can choose a different model or thinking mode. The current recipe will be replaced.</string>
     <string name="regenerate">Regenerate</string>
     <string name="regenerating_recipe">Regenerating recipe\u2026</string>
     <string name="regenerate_success">Recipe regenerated successfully</string>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -68,7 +68,7 @@ app: {
       list: RecipeListScreen
       detail: {
         label: RecipeDetailScreen
-        tooltip: "Displays recipe details with share menu (Markdown text or .lorecipes file), regenerate, and delete buttons. Regenerate re-parses from original HTML with selectable model/thinking mode. All text is selectable."
+        tooltip: "Displays recipe details with share menu (Markdown text or .lorecipes file), regenerate, and delete buttons. Regenerate re-parses from original HTML (or re-fetches from source URL if no cached HTML) with selectable model/thinking mode. All text is selectable."
       }
       add: AddRecipeScreen
       settings: SettingsScreen
@@ -315,7 +315,7 @@ app: {
       }
       regenerate: {
         label: RegenerateRecipeUseCase
-        tooltip: "Re-parses a recipe from its stored original HTML via ParseHtmlUseCase.parseHtml(). Passes model/thinking overrides as parameters, preserves recipe ID, favorite status, and creation timestamp."
+        tooltip: "Re-parses a recipe from its stored original HTML via ParseHtmlUseCase.parseHtml(). If no cached HTML exists, fetches fresh HTML from the recipe's source URL via WebScraperService. Passes model/thinking overrides as parameters, preserves recipe ID, favorite status, and creation timestamp."
       }
       sync_meal_plans: {
         label: FirestoreMealPlanSyncUseCase
@@ -626,6 +626,7 @@ app: {
   domain.usecases -> data.repository: access data
   domain.usecases.import_paprika -> data.paprika.parser: parse export
   domain.usecases.import_paprika -> domain.usecases.parse_html: parseText
+  domain.usecases.regenerate -> data.remote.scraper: fetch HTML if not cached
   domain.usecases.import_paprika -> data.remote.scraper: fetch source image
   data.remote.scraper -> external.web: fetch HTML
   data.remote.anthropic_svc -> external.anthropic: parse recipe


### PR DESCRIPTION
## Summary
- Show the regenerate (refresh) button on recipes that have a `sourceUrl` even when no cached `originalHtml` exists
- When regenerating without cached HTML, fetch fresh HTML from the source URL via `WebScraperService` before re-parsing with AI
- Add "Fetching recipe page..." progress state for the URL fetch step

## Details
Some recipes (e.g. imported from Paprika) have a `sourceUrl` but no stored `originalHtml`, which caused the regenerate button to be hidden. This was especially frustrating when users needed to re-import recipes to fix issues like broken images (#200).

**Changes:**
- `RegenerateRecipeUseCase`: Falls back to fetching from `sourceUrl` when no cached HTML exists, with a new `FetchingFromUrl` progress state
- `RecipeDetailViewModel`: New `canRegenerate` state that checks for either cached HTML or a source URL
- `RecipeDetailScreen`: Uses `canRegenerate` instead of `hasOriginalHtml` to control button visibility
- `RecipeRegenerateWorker`: Handles the new `PROGRESS_FETCHING` state
- Updated architecture diagram and string resources

## Test plan
- [ ] Open a recipe imported from Paprika (has sourceUrl, no originalHtml) — regenerate button should now appear
- [ ] Tap regenerate on such a recipe — should fetch from URL, then re-parse with AI
- [ ] Open a recipe with cached HTML — regenerate should still work as before
- [ ] Open a recipe with neither sourceUrl nor originalHtml — regenerate button should remain hidden

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)