### PR TITLE
fix: restrict share target to supported file types

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,10 +26,21 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!-- Handle shared text (URLs), HTML, and Markdown -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/html" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/markdown" />
             </intent-filter>
 
             <!-- Handle .lorecipes files opened from file manager or shared from other apps -->
@@ -47,17 +58,24 @@
                 <data android:mimeType="*/*" />
                 <data android:pathPattern=".*\\.lorecipes" />
             </intent-filter>
+
+            <!-- Handle .paprikarecipes files opened from file manager -->
             <intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="content" />
                 <data android:mimeType="application/zip" />
+                <data android:pathPattern=".*\\.paprikarecipes" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="application/octet-stream" />
+                <data android:scheme="file" />
+                <data android:mimeType="*/*" />
+                <data android:pathPattern=".*\\.paprikarecipes" />
             </intent-filter>
+
+            <!-- Handle ZIP backup files shared from other apps -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
## Summary
- Removed overly broad `application/octet-stream` ACTION_SEND intent filter that caused the app to appear as a share target for any binary file from any app
- Narrowed `application/zip` ACTION_VIEW filter to only match `.paprikarecipes` files (with pathPattern) instead of all ZIP files
- Added `text/html` and `text/markdown` ACTION_SEND filters for sharing HTML and Markdown recipe content
- Added `.paprikarecipes`-specific ACTION_VIEW filter for `file://` scheme

The app now only shows as a share target for:
- `text/plain` (URLs shared as text)
- `text/html` (HTML content)
- `text/markdown` (Markdown content)
- `.lorecipes` files (via ACTION_VIEW)
- `.paprikarecipes` files (via ACTION_VIEW)
- `application/zip` (ZIP backup files via ACTION_SEND)

Fixes #215

## Test plan
- [ ] Share a URL from a browser — app should appear as share target
- [ ] Share a `.lorecipes` file — app should appear as share target
- [ ] Share/open a `.paprikarecipes` file — app should appear as share target
- [ ] Share a ZIP file — app should appear as share target
- [ ] Share a random binary file (e.g. APK, PDF) — app should NOT appear as share target
- [ ] Share from a random app (e.g. social media) — app should NOT appear unless sharing text/URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)