### PR TITLE
fix: never silently discard exceptions (#224)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,6 @@
+- Never silently discard exceptions. Always log exceptions with `Log.w`/`Log.e` at minimum.
+  In user-facing operations, propagate errors so the UI can inform the user the action failed.
+  It is better to tell the user something went wrong than to silently pretend everything is fine.
 - Commit after finishing fixes or features
 - Prefer to amend if fixing the current commit
 - ALWAYS check the current commit before amending

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/FirestoreService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/FirestoreService.kt
@@ -124,8 +124,8 @@ class FirestoreService @Inject constructor(
             auth.signOut()
             try {
                 credentialManager.clearCredentialState(ClearCredentialStateRequest())
-            } catch (_: Exception) {
-                // Best-effort clear
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to clear credential state during sign-out", e)
             }
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/WebScraperService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/WebScraperService.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.data.remote
 
+import android.util.Log
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -78,11 +79,13 @@ class WebScraperService @Inject constructor(
                 ?: doc.selectFirst("meta[name=image]")?.attr("content")
                     ?.takeIf { it.isNotBlank() }
         } catch (e: Exception) {
+            Log.w(TAG, "Failed to extract image URL from HTML", e)
             null
         }
     }
 
     companion object {
+        private const val TAG = "WebScraperService"
         private const val USER_AGENT = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportSingleRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportSingleRecipeUseCase.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.domain.usecase
 
+import android.util.Log
 import com.lionotter.recipes.data.repository.RecipeRepository
 import com.lionotter.recipes.domain.model.Recipe
 import com.lionotter.recipes.domain.util.RecipeSerializer
@@ -22,6 +23,9 @@ class ExportSingleRecipeUseCase @Inject constructor(
     private val recipeRepository: RecipeRepository,
     private val recipeSerializer: RecipeSerializer
 ) {
+    companion object {
+        private const val TAG = "ExportSingleRecipe"
+    }
     sealed class ExportResult {
         data class Success(val fileName: String) : ExportResult()
         data class Error(val message: String) : ExportResult()
@@ -61,6 +65,7 @@ class ExportSingleRecipeUseCase @Inject constructor(
             val fileName = "${recipeSerializer.sanitizeFolderName(recipe.name)}.lorecipes"
             ExportResult.Success(fileName)
         } catch (e: Exception) {
+            Log.e(TAG, "Failed to export recipe: ${recipe.name}", e)
             ExportResult.Error("Failed to export recipe: ${e.message}")
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportToZipUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportToZipUseCase.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.domain.usecase
 
+import android.util.Log
 import com.lionotter.recipes.data.repository.MealPlanRepository
 import com.lionotter.recipes.data.repository.RecipeRepository
 import com.lionotter.recipes.domain.model.MealPlanEntry
@@ -26,6 +27,7 @@ class ExportToZipUseCase @Inject constructor(
     private val json: Json
 ) {
     companion object {
+        private const val TAG = "ExportToZipUseCase"
         const val MEAL_PLANS_FOLDER = "meal-plans"
     }
 
@@ -96,6 +98,7 @@ class ExportToZipUseCase @Inject constructor(
 
                         exportedCount++
                     } catch (e: Exception) {
+                        Log.e(TAG, "Failed to export recipe: ${recipe.name}", e)
                         failedCount++
                     }
                 }
@@ -110,8 +113,8 @@ class ExportToZipUseCase @Inject constructor(
                             zipOut.putNextEntry(ZipEntry("$MEAL_PLANS_FOLDER/$date.json"))
                             zipOut.write(mealPlanJson.toByteArray(Charsets.UTF_8))
                             zipOut.closeEntry()
-                        } catch (_: Exception) {
-                            // Non-critical: continue with other dates
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Failed to export meal plans for date $date", e)
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/GetTagsUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/GetTagsUseCase.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.domain.usecase
 
+import android.util.Log
 import com.lionotter.recipes.domain.model.Recipe
 import org.ojalgo.optimisation.ExpressionsBasedModel
 import org.ojalgo.optimisation.Optimisation
@@ -7,6 +8,7 @@ import javax.inject.Inject
 
 class GetTagsUseCase @Inject constructor() {
     companion object {
+        private const val TAG = "GetTagsUseCase"
         internal const val MAX_TAGS = 10
         internal const val GAMMA_MULTIPLIER = 10.0 // γ = GAMMA_MULTIPLIER * maxTagSize
     }
@@ -48,7 +50,8 @@ class GetTagsUseCase @Inject constructor() {
 
         return try {
             solveIlp(recipes, tagToRecipes)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.w(TAG, "ILP solver failed, falling back to greedy algorithm", e)
             solveGreedy(recipes, tagToRecipes)
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportFromZipUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportFromZipUseCase.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.domain.usecase
 
+import android.util.Log
 import com.lionotter.recipes.domain.util.RecipeSerializer
 import com.lionotter.recipes.domain.util.ZipImportHelper
 import kotlinx.coroutines.ensureActive
@@ -21,6 +22,9 @@ class ImportFromZipUseCase @Inject constructor(
     private val zipImportHelper: ZipImportHelper,
     private val recipeSerializer: RecipeSerializer
 ) {
+    companion object {
+        private const val TAG = "ImportFromZipUseCase"
+    }
     sealed class ImportResult {
         data class Success(
             val importedCount: Int,
@@ -70,7 +74,8 @@ class ImportFromZipUseCase @Inject constructor(
                         try {
                             val recipe = recipeSerializer.deserializeRecipe(jsonContent)
                             recipe.id in selectedRecipeIds
-                        } catch (_: Exception) {
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Failed to deserialize recipe during pre-filter, including for error reporting", e)
                             true // include failures so they're counted as failed
                         }
                     }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportPaprikaUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportPaprikaUseCase.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.domain.usecase
 
+import android.util.Log
 import com.lionotter.recipes.data.paprika.PaprikaParser
 import com.lionotter.recipes.data.paprika.PaprikaRecipe
 import com.lionotter.recipes.data.remote.WebScraperService
@@ -23,6 +24,9 @@ class ImportPaprikaUseCase @Inject constructor(
     private val parseHtmlUseCase: ParseHtmlUseCase,
     private val webScraperService: WebScraperService
 ) {
+    companion object {
+        private const val TAG = "ImportPaprikaUseCase"
+    }
     sealed class ImportResult {
         data class Success(
             val importedCount: Int,
@@ -158,6 +162,7 @@ class ImportPaprikaUseCase @Inject constructor(
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {
+            Log.e(TAG, "Failed to import Paprika recipe: ${paprikaRecipe.name}", e)
             null
         }
     }
@@ -182,6 +187,7 @@ class ImportPaprikaUseCase @Inject constructor(
                 val pageResult = webScraperService.fetchPage(paprikaRecipe.sourceUrl)
                 pageResult.getOrNull()?.imageUrl
             } catch (e: Exception) {
+                Log.w(TAG, "Failed to fetch image URL from source: ${paprikaRecipe.sourceUrl}", e)
                 null
             }
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportRecipeUseCase.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.domain.usecase
 
+import android.util.Log
 import com.lionotter.recipes.data.remote.WebScraperService
 import com.lionotter.recipes.domain.model.Recipe
 import kotlinx.coroutines.ensureActive
@@ -108,7 +109,12 @@ class ImportRecipeUseCase @Inject constructor(
                 ?.takeIf { it.isNotBlank() }
                 ?: doc.title().takeIf { it.isNotBlank() }
         } catch (e: Exception) {
+            Log.w(TAG, "Failed to extract page title from HTML", e)
             null
         }
+    }
+
+    companion object {
+        private const val TAG = "ImportRecipeUseCase"
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.domain.usecase
 
+import android.util.Log
 import com.lionotter.recipes.data.local.ImportDebugEntity
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.remote.AnthropicService
@@ -31,6 +32,9 @@ class ParseHtmlUseCase @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val imageDownloadService: ImageDownloadService
 ) {
+    companion object {
+        private const val TAG = "ParseHtmlUseCase"
+    }
     sealed class ParseResult {
         data class Success(val recipe: Recipe) : ParseResult()
         data class Error(val message: String) : ParseResult()
@@ -269,6 +273,7 @@ class ParseHtmlUseCase @Inject constructor(
                 append(content)
             }
         } catch (e: Exception) {
+            Log.w(TAG, "Failed to extract content from HTML, falling back to raw HTML", e)
             html
         }
     }
@@ -285,6 +290,7 @@ class ParseHtmlUseCase @Inject constructor(
                 ?: doc.selectFirst("meta[name=image]")?.attr("content")
                     ?.takeIf { it.isNotBlank() }
         } catch (e: Exception) {
+            Log.w(TAG, "Failed to extract image URL from HTML", e)
             null
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/util/ZipImportHelper.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/util/ZipImportHelper.kt
@@ -69,6 +69,7 @@ class ZipImportHelper @Inject constructor(
                 }
             }
         } catch (e: Exception) {
+            Log.e(TAG, "Failed to read ZIP contents", e)
             return null
         }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/notification/RecipeNotificationHelper.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/notification/RecipeNotificationHelper.kt
@@ -168,12 +168,12 @@ class RecipeNotificationHelper @Inject constructor(
     }
 
     @SuppressLint("MissingPermission")
-    fun showSyncSuccessNotification(uploaded: Int, downloaded: Int, updated: Int, deleted: Int) {
+    fun showSyncSuccessNotification(uploaded: Int, downloaded: Int, updated: Int, deleted: Int, errors: Int = 0) {
         if (!notificationManager.areNotificationsEnabled()) return
 
         notificationManager.cancel(NOTIFICATION_ID_PROGRESS)
 
-        val totalChanges = uploaded + downloaded + updated + deleted
+        val totalChanges = uploaded + downloaded + updated + deleted + errors
         if (totalChanges == 0) {
             // No changes - don't show a notification
             return
@@ -185,11 +185,14 @@ class RecipeNotificationHelper @Inject constructor(
             if (downloaded > 0) parts.add("$downloaded downloaded")
             if (updated > 0) parts.add("$updated updated")
             if (deleted > 0) parts.add("$deleted deleted")
+            if (errors > 0) parts.add("$errors failed")
             append(parts.joinToString(", "))
         }
 
+        val title = if (errors > 0) "Sync Completed with Errors" else "Sync Complete"
+
         val notification = baseNotification()
-            .setContentTitle("Sync Complete")
+            .setContentTitle(title)
             .setContentText(message)
             .build()
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/firebase/FirebaseSyncViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/firebase/FirebaseSyncViewModel.kt
@@ -185,7 +185,8 @@ class FirebaseSyncViewModel @Inject constructor(
                     val downloaded = workInfo.outputData.getInt(FirestoreSyncWorker.KEY_DOWNLOADED_COUNT, 0)
                     val updated = workInfo.outputData.getInt(FirestoreSyncWorker.KEY_UPDATED_COUNT, 0)
                     val deleted = workInfo.outputData.getInt(FirestoreSyncWorker.KEY_DELETED_COUNT, 0)
-                    _operationState.value = SyncOperationState.SyncComplete(uploaded, downloaded, updated, deleted)
+                    val errors = workInfo.outputData.getInt(FirestoreSyncWorker.KEY_ERROR_COUNT, 0)
+                    _operationState.value = SyncOperationState.SyncComplete(uploaded, downloaded, updated, deleted, errors)
                 } else {
                     _operationState.value = SyncOperationState.Idle
                 }
@@ -227,6 +228,6 @@ sealed class FirebaseSyncUiState {
 sealed class SyncOperationState {
     object Idle : SyncOperationState()
     object Syncing : SyncOperationState()
-    data class SyncComplete(val uploaded: Int, val downloaded: Int, val updated: Int, val deleted: Int) : SyncOperationState()
+    data class SyncComplete(val uploaded: Int, val downloaded: Int, val updated: Int, val deleted: Int, val errors: Int = 0) : SyncOperationState()
     data class Error(val message: String) : SyncOperationState()
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/FirestoreSyncWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/FirestoreSyncWorker.kt
@@ -28,6 +28,7 @@ class FirestoreSyncWorker @AssistedInject constructor(
         const val KEY_DOWNLOADED_COUNT = "downloaded_count"
         const val KEY_UPDATED_COUNT = "updated_count"
         const val KEY_DELETED_COUNT = "deleted_count"
+        const val KEY_ERROR_COUNT = "error_count"
         const val KEY_ERROR_MESSAGE = "error_message"
         const val KEY_PROGRESS = "progress"
         const val KEY_CURRENT = "current"
@@ -113,7 +114,8 @@ class FirestoreSyncWorker @AssistedInject constructor(
                     uploaded = result.uploaded,
                     downloaded = result.downloaded,
                     updated = result.updated,
-                    deleted = result.deleted
+                    deleted = result.deleted,
+                    errors = result.errors
                 )
                 Result.success(
                     workDataOf(
@@ -121,7 +123,8 @@ class FirestoreSyncWorker @AssistedInject constructor(
                         KEY_UPLOADED_COUNT to result.uploaded,
                         KEY_DOWNLOADED_COUNT to result.downloaded,
                         KEY_UPDATED_COUNT to result.updated,
-                        KEY_DELETED_COUNT to result.deleted
+                        KEY_DELETED_COUNT to result.deleted,
+                        KEY_ERROR_COUNT to result.errors
                     )
                 )
             }


### PR DESCRIPTION
## Summary
- Add logging to all catch blocks that previously silently swallowed exceptions across 13 files
- Refactor `FirestoreMealPlanSyncUseCase.SyncResult` to a sealed class with `Success` and `Error` variants so sync failures are propagated to the UI instead of returning an empty result pretending success
- Track per-recipe error counts during sync and propagate through Worker → Notification → ViewModel so users see "Sync Completed with Errors" with a failure count when individual items fail
- Update CLAUDE.md with policy to never silently discard exceptions

## Test plan
- [ ] Verify CI passes (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Verify sync with some network errors shows "Sync Completed with Errors" notification
- [ ] Verify export/import errors are logged in logcat
- [ ] Verify no behavioral regressions for successful operations

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)