### PR TITLE
refactor: use structured Firestore data instead of JSON dumps

### DIFF
--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -530,7 +530,7 @@ app: {
       }
       firestore_svc: {
         label: FirestoreService
-        tooltip: "Handles Firebase Auth (Google Sign-In), and Firestore document operations for recipe and meal plan sync. Data stored at users/{userId}/recipes/{recipeId} and users/{userId}/mealPlans/{mealPlanId}."
+        tooltip: "Handles Firebase Auth (Google Sign-In), and Firestore document operations for recipe and meal plan sync. Data stored as structured Firestore documents with native types (Timestamps for Instants, nested maps for complex objects) at users/{userId}/recipes/{recipeId} and users/{userId}/mealPlans/{mealPlanId}."
       }
     }
 


### PR DESCRIPTION
## Summary
- Replace JSON string serialization in FirestoreService with native Firestore types
- Store recipe and meal plan fields as individual Firestore document fields instead of JSON blobs
- Convert `Instant` timestamps to Firestore `Timestamp` (with nanosecond precision) instead of epoch milliseconds
- Store nested objects (instructions, ingredients, amounts) as nested maps/lists
- Store enums (`MealType`) as strings, `LocalDate` as ISO-8601 strings
- Remove `Json` dependency from `FirestoreService` constructor

## Test plan
- [x] CI checks pass (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Manual test: sign in to Firebase and trigger sync to verify structured data is written correctly
- [ ] Manual test: verify recipes sync correctly in both directions with the new format

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)