### PR TITLE
Cascade-delete meal plans when recipe is deleted

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/MealPlanDao.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/MealPlanDao.kt
@@ -46,4 +46,10 @@ interface MealPlanDao {
 
     @Query("SELECT * FROM meal_plans WHERE date BETWEEN :startDate AND :endDate AND deleted = 0 ORDER BY date ASC, mealType ASC, recipeName ASC")
     suspend fun getMealPlansForDateRangeOnce(startDate: String, endDate: String): List<MealPlanEntity>
+
+    @Query("SELECT COUNT(*) FROM meal_plans WHERE recipeId = :recipeId AND deleted = 0")
+    suspend fun countMealPlansByRecipeId(recipeId: String): Int
+
+    @Query("UPDATE meal_plans SET deleted = 1, updatedAt = :updatedAt WHERE recipeId = :recipeId AND deleted = 0")
+    suspend fun softDeleteMealPlansByRecipeId(recipeId: String, updatedAt: Instant)
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/MealPlanRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/MealPlanRepository.kt
@@ -78,4 +78,19 @@ class MealPlanRepository @Inject constructor(
     suspend fun saveMealPlanFromSync(entry: MealPlanEntry) {
         mealPlanDao.insertMealPlan(MealPlanEntity.fromMealPlanEntry(entry))
     }
+
+    /**
+     * Count non-deleted meal plan entries that reference the given recipe.
+     */
+    suspend fun countMealPlansByRecipeId(recipeId: String): Int {
+        return mealPlanDao.countMealPlansByRecipeId(recipeId)
+    }
+
+    /**
+     * Soft-delete all meal plan entries that reference the given recipe.
+     */
+    suspend fun softDeleteMealPlansByRecipeId(recipeId: String) {
+        val now = Clock.System.now()
+        mealPlanDao.softDeleteMealPlansByRecipeId(recipeId, updatedAt = now)
+    }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/components/DeleteConfirmationDialog.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/components/DeleteConfirmationDialog.kt
@@ -4,19 +4,34 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import com.lionotter.recipes.R
 
 @Composable
 fun DeleteConfirmationDialog(
     recipeName: String,
+    affectedMealPlanCount: Int = 0,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
+    val message = buildString {
+        append(stringResource(R.string.delete_recipe_confirmation, recipeName))
+        if (affectedMealPlanCount > 0) {
+            append("\n\n")
+            append(
+                pluralStringResource(
+                    R.plurals.delete_recipe_meal_plan_warning,
+                    affectedMealPlanCount,
+                    affectedMealPlanCount
+                )
+            )
+        }
+    }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.delete_recipe)) },
-        text = { Text(stringResource(R.string.delete_recipe_confirmation, recipeName)) },
+        text = { Text(message) },
         confirmButton = {
             TextButton(onClick = onConfirm) {
                 Text(stringResource(R.string.delete))

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -79,8 +79,16 @@ fun RecipeDetailScreen(
     }
 
     var showDeleteDialog by remember { mutableStateOf(false) }
+    var affectedMealPlanCount by remember { mutableStateOf(0) }
     var showRegenerateDialog by remember { mutableStateOf(false) }
     var showShareMenu by remember { mutableStateOf(false) }
+
+    // Load affected meal plan count when delete dialog is shown
+    LaunchedEffect(showDeleteDialog) {
+        if (showDeleteDialog) {
+            affectedMealPlanCount = viewModel.getAffectedMealPlanCount()
+        }
+    }
 
     val snackbarHostState = remember { SnackbarHostState() }
     val regenerateSuccessMessage = stringResource(R.string.regenerate_success)
@@ -127,6 +135,7 @@ fun RecipeDetailScreen(
     if (showDeleteDialog && recipe != null) {
         DeleteConfirmationDialog(
             recipeName = recipe!!.name,
+            affectedMealPlanCount = affectedMealPlanCount,
             onConfirm = {
                 showDeleteDialog = false
                 viewModel.deleteRecipe()

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
@@ -81,6 +81,17 @@ fun RecipeListScreen(
 
     // State for delete confirmation dialog
     var recipeToDelete by remember { mutableStateOf<Recipe?>(null) }
+    var affectedMealPlanCount by remember { mutableStateOf(0) }
+
+    // Load affected meal plan count when a recipe is selected for deletion
+    LaunchedEffect(recipeToDelete) {
+        val recipe = recipeToDelete
+        affectedMealPlanCount = if (recipe != null) {
+            viewModel.getAffectedMealPlanCount(recipe.id)
+        } else {
+            0
+        }
+    }
 
     // State for cancel import confirmation dialog
     var importToCancel by remember { mutableStateOf<InProgressRecipe?>(null) }
@@ -89,6 +100,7 @@ fun RecipeListScreen(
     recipeToDelete?.let { recipe ->
         DeleteConfirmationDialog(
             recipeName = recipe.name,
+            affectedMealPlanCount = affectedMealPlanCount,
             onConfirm = {
                 viewModel.deleteRecipe(recipe.id)
                 recipeToDelete = null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,10 @@
     <!-- Delete Confirmation Dialog -->
     <string name="delete_recipe">Delete Recipe</string>
     <string name="delete_recipe_confirmation">Are you sure you want to delete \"%1$s\"? This action cannot be undone.</string>
+    <plurals name="delete_recipe_meal_plan_warning">
+        <item quantity="one">This will also remove %1$d meal plan entry using this recipe.</item>
+        <item quantity="other">This will also remove %1$d meal plan entries using this recipe.</item>
+    </plurals>
 
     <!-- Recipe List Screen -->
     <string name="add_recipe">Add recipe</string>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -595,8 +595,10 @@ app: {
 
   # Connections within app
   ui.viewmodels.list_vm -> data.repository.repo: recipes, delete
+  ui.viewmodels.list_vm -> data.repository.meal_plan_repo: cascade delete meal plans
   ui.viewmodels.list_vm -> domain.usecases.tags: top tags
   ui.viewmodels.detail_vm -> data.repository.repo: recipe, delete, favorite
+  ui.viewmodels.detail_vm -> data.repository.meal_plan_repo: cascade delete meal plans
   ui.viewmodels.detail_vm -> domain.usecases.calc_usage: ingredient usage
   ui.viewmodels.detail_vm -> domain.usecases.export_single: export .lorecipes
   ui.viewmodels.detail_vm -> data.local.settings: keep screen on, unit prefs


### PR DESCRIPTION
## Summary
- When a recipe is deleted, all meal plan entries referencing it are now automatically soft-deleted
- The delete confirmation dialog warns users how many meal plan entries will be affected (e.g., "This will also remove 3 meal plan entries using this recipe.")
- Triggers an incremental sync after cascade deletion so changes propagate to Firestore

Closes #232

## Changes
- **MealPlanDao**: Added `countMealPlansByRecipeId` and `softDeleteMealPlansByRecipeId` queries
- **MealPlanRepository**: Added `countMealPlansByRecipeId` and `softDeleteMealPlansByRecipeId` methods
- **RecipeDetailViewModel**: Injects `MealPlanRepository` and `MealPlanSyncTrigger`; cascade-deletes meal plans on recipe deletion; exposes `getAffectedMealPlanCount()`
- **RecipeListViewModel**: Same cascade-delete and count logic for list-based deletion
- **DeleteConfirmationDialog**: Accepts optional `affectedMealPlanCount` parameter; shows plural-aware warning when > 0
- **strings.xml**: Added `delete_recipe_meal_plan_warning` plurals resource
- **RecipeDetailScreen / RecipeListScreen**: Loads affected count when delete dialog opens and passes it to the dialog
- **architecture.d2**: Updated to reflect new ViewModel -> MealPlanRepository connections
- **RecipeDetailViewModelTest**: Updated for new constructor parameters and cascade-delete verification

## Test plan
- [ ] Delete a recipe that has meal plan entries — verify meal plan entries are also removed
- [ ] Delete a recipe with no meal plan entries — verify dialog shows no warning
- [ ] Delete a recipe with 1 meal plan entry — verify singular warning message
- [ ] Delete a recipe with multiple meal plan entries — verify plural warning message
- [ ] Verify sync triggers after cascade deletion
- [ ] Run existing unit tests (ci-local.sh passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)