### PR TITLE
feat: save images permanently and include in imports/exports

### DIFF
--- a/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/9.json
+++ b/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/9.json
@@ -1,0 +1,394 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "3e7d25964c8c3fa7ef80d2115d780456",
+    "entities": [
+      {
+        "tableName": "recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sourceUrl` TEXT, `story` TEXT, `servings` INTEGER, `prepTime` TEXT, `cookTime` TEXT, `totalTime` TEXT, `ingredientSectionsJson` TEXT NOT NULL, `instructionSectionsJson` TEXT NOT NULL, `equipmentJson` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `imageUrl` TEXT, `sourceImageUrl` TEXT, `originalHtml` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "story",
+            "columnName": "story",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "prepTime",
+            "columnName": "prepTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cookTime",
+            "columnName": "cookTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalTime",
+            "columnName": "totalTime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ingredientSectionsJson",
+            "columnName": "ingredientSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructionSectionsJson",
+            "columnName": "instructionSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipmentJson",
+            "columnName": "equipmentJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "import_debug",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceUrl` TEXT, `originalHtml` TEXT, `cleanedContent` TEXT, `aiOutputJson` TEXT, `originalLength` INTEGER NOT NULL, `cleanedLength` INTEGER NOT NULL, `inputTokens` INTEGER, `outputTokens` INTEGER, `aiModel` TEXT, `thinkingEnabled` INTEGER NOT NULL, `recipeId` TEXT, `recipeName` TEXT, `errorMessage` TEXT, `isError` INTEGER NOT NULL, `durationMs` INTEGER, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cleanedContent",
+            "columnName": "cleanedContent",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "aiOutputJson",
+            "columnName": "aiOutputJson",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "originalLength",
+            "columnName": "originalLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanedLength",
+            "columnName": "cleanedLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "aiModel",
+            "columnName": "aiModel",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thinkingEnabled",
+            "columnName": "thinkingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recipeName",
+            "columnName": "recipeName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isError",
+            "columnName": "isError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pending_imports",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `name` TEXT, `imageUrl` TEXT, `status` TEXT NOT NULL, `workManagerId` TEXT, `errorMessage` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workManagerId",
+            "columnName": "workManagerId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "meal_plans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `recipeId` TEXT NOT NULL, `recipeName` TEXT NOT NULL, `recipeImageUrl` TEXT, `date` TEXT NOT NULL, `mealType` TEXT NOT NULL, `servings` REAL NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeName",
+            "columnName": "recipeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeImageUrl",
+            "columnName": "recipeImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealType",
+            "columnName": "mealType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3e7d25964c8c3fa7ef80d2115d780456')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
@@ -8,7 +8,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [RecipeEntity::class, ImportDebugEntity::class, PendingImportEntity::class, MealPlanEntity::class],
-    version = 8,
+    version = 9,
     exportSchema = true
 )
 @TypeConverters(InstantConverter::class)
@@ -101,6 +101,12 @@ abstract class RecipeDatabase : RoomDatabase() {
         val MIGRATION_7_8 = object : Migration(7, 8) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE recipes ADD COLUMN equipmentJson TEXT NOT NULL DEFAULT '[]'")
+            }
+        }
+
+        val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE recipes ADD COLUMN sourceImageUrl TEXT")
             }
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeEntity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeEntity.kt
@@ -22,6 +22,7 @@ data class RecipeEntity(
     val equipmentJson: String = "[]",
     val tagsJson: String,
     val imageUrl: String?,
+    val sourceImageUrl: String? = null,
     val originalHtml: String?,
     val createdAt: Instant,
     val updatedAt: Instant,
@@ -46,6 +47,7 @@ data class RecipeEntity(
             equipment = equipment,
             tags = tags,
             imageUrl = imageUrl,
+            sourceImageUrl = sourceImageUrl,
             createdAt = createdAt,
             updatedAt = updatedAt,
             isFavorite = isFavorite
@@ -74,6 +76,7 @@ data class RecipeEntity(
                 equipmentJson = equipmentJson,
                 tagsJson = tagsJson,
                 imageUrl = recipe.imageUrl,
+                sourceImageUrl = recipe.sourceImageUrl,
                 originalHtml = originalHtml,
                 createdAt = recipe.createdAt,
                 updatedAt = recipe.updatedAt,

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/FirestoreService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/FirestoreService.kt
@@ -354,6 +354,7 @@ class FirestoreService @Inject constructor(
             "equipment" to recipe.equipment,
             "tags" to recipe.tags,
             "imageUrl" to recipe.imageUrl,
+            "sourceImageUrl" to recipe.sourceImageUrl,
             "createdAt" to recipe.createdAt.toFirestoreTimestamp(),
             FIELD_UPDATED_AT to recipe.updatedAt.toFirestoreTimestamp(),
             "isFavorite" to recipe.isFavorite,
@@ -436,6 +437,7 @@ class FirestoreService @Inject constructor(
             equipment = equipment,
             tags = tags,
             imageUrl = doc.getString("imageUrl"),
+            sourceImageUrl = doc.getString("sourceImageUrl"),
             createdAt = createdAt,
             updatedAt = updatedAt,
             isFavorite = doc.getBoolean("isFavorite") ?: false

--- a/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
@@ -35,7 +35,8 @@ object DatabaseModule {
                 RecipeDatabase.MIGRATION_4_5,
                 RecipeDatabase.MIGRATION_5_6,
                 RecipeDatabase.MIGRATION_6_7,
-                RecipeDatabase.MIGRATION_7_8
+                RecipeDatabase.MIGRATION_7_8,
+                RecipeDatabase.MIGRATION_8_9
             )
             .build()
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
@@ -32,6 +32,7 @@ data class Recipe(
     val equipment: List<String> = emptyList(),
     val tags: List<String> = emptyList(),
     val imageUrl: String? = null,
+    val sourceImageUrl: String? = null,
     val createdAt: Instant,
     val updatedAt: Instant,
     val isFavorite: Boolean = false

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -183,6 +183,7 @@ class ParseHtmlUseCase @Inject constructor(
             equipment = parsed.equipment,
             tags = parsed.tags,
             imageUrl = localImageUrl,
+            sourceImageUrl = imageUrl,
             createdAt = now,
             updatedAt = now
         )

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeSerializer.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeSerializer.kt
@@ -11,6 +11,7 @@ import javax.inject.Inject
  * - recipe.json: The structured recipe data
  * - original.html: The original HTML page (if available)
  * - recipe.md: A human-readable Markdown version
+ * - image.* (jpg/png/webp/gif): The recipe image (if available)
  *
  * This is used by ZIP export/import to ensure a consistent format.
  */
@@ -21,6 +22,8 @@ class RecipeSerializer @Inject constructor(
         const val RECIPE_JSON_FILENAME = "recipe.json"
         const val RECIPE_HTML_FILENAME = "original.html"
         const val RECIPE_MARKDOWN_FILENAME = "recipe.md"
+        const val IMAGE_FILENAME_PREFIX = "image"
+        val IMAGE_EXTENSIONS = setOf(".jpg", ".jpeg", ".png", ".webp", ".gif")
     }
 
     /**

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importselection/ImportSelectionViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importselection/ImportSelectionViewModel.kt
@@ -171,8 +171,8 @@ class ImportSelectionViewModel @Inject constructor(
             }
 
             try {
-                val folderContents = inputStream.use { zipImportHelper.readZipContents(it) }
-                if (folderContents == null || folderContents.isEmpty()) {
+                val zipContents = inputStream.use { zipImportHelper.readZipContents(it) }
+                if (zipContents == null || zipContents.textFiles.isEmpty()) {
                     _uiState.value = ImportSelectionUiState.Error("No recipes found in file")
                     return@withContext
                 }
@@ -181,7 +181,7 @@ class ImportSelectionViewModel @Inject constructor(
                 val existingIds = existingRecipes.map { it.id }.toSet()
                 val existingNames = existingRecipes.map { it.name.lowercase() }.toSet()
 
-                val items = folderContents.entries
+                val items = zipContents.textFiles.entries
                     .filter { it.key != ZipImportHelper.MEAL_PLANS_FOLDER }
                     .mapNotNull { (_, files) ->
                         val jsonContent = files[RecipeSerializer.RECIPE_JSON_FILENAME]

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -291,19 +291,19 @@ app: {
       }
       import_paprika: {
         label: ImportPaprikaUseCase
-        tooltip: "Imports recipes from Paprika export (.paprikarecipes). Parses export, sends recipe content through ParseHtmlUseCase.parseText(), resolves images from Paprika data or source page. Supports cooperative cancellation — checks coroutine state between recipes and preserves already-imported recipes on cancel."
+        tooltip: "Imports recipes from Paprika export (.paprikarecipes). Parses export, sends recipe content through ParseHtmlUseCase.parseText(). Resolves images by priority: base64 photo_data (saved directly to local storage), image_url, or og:image from source page. Supports cooperative cancellation — checks coroutine state between recipes and preserves already-imported recipes on cancel."
       }
       sync_firestore: {
         label: FirestoreSyncUseCase
-        tooltip: "Bidirectional sync: compares local vs remote recipes, uploads new, downloads new, updates changed (latest timestamp wins), deletes remote recipes that were soft-deleted locally. Runs via WorkManager on startup and periodically."
+        tooltip: "Bidirectional sync: compares local vs remote recipes, uploads new, downloads new, updates changed (latest timestamp wins), deletes remote recipes that were soft-deleted locally. Runs via WorkManager on startup and periodically. Uses sourceImageUrl for cross-device image re-download when local file:// URIs aren't available."
       }
       export_zip: {
         label: ExportToZipUseCase
-        tooltip: "Exports all recipes to a ZIP file using RecipeSerializer."
+        tooltip: "Exports all recipes to a ZIP file using RecipeSerializer. Includes recipe images as binary files in each recipe folder."
       }
       export_single: {
         label: ExportSingleRecipeUseCase
-        tooltip: "Exports a single recipe to a .lorecipes file (ZIP format) for sharing. Uses RecipeSerializer for consistent format."
+        tooltip: "Exports a single recipe to a .lorecipes file (ZIP format) for sharing. Uses RecipeSerializer for consistent format. Includes recipe image if available."
       }
       import_zip: {
         label: ImportFromZipUseCase
@@ -343,11 +343,11 @@ app: {
       }
       serializer: {
         label: RecipeSerializer
-        tooltip: "Shared logic for serializing/deserializing recipes in the standard folder export format (recipe.json + original.html + recipe.md). Used by ZIP export/import."
+        tooltip: "Shared logic for serializing/deserializing recipes in the standard folder export format (recipe.json + original.html + recipe.md + image.*). Used by ZIP export/import."
       }
       zip_import_helper: {
         label: ZipImportHelper
-        tooltip: "Shared helper for importing recipes and meal plans from ZIP files. Consolidates ZIP reading, recipe import (deserialize, deduplicate, download image, save), and meal plan import logic. Used by ImportFromZipUseCase and ImportSelectionViewModel."
+        tooltip: "Shared helper for importing recipes and meal plans from ZIP files. Consolidates ZIP reading (text + image files), recipe import (deserialize, deduplicate, import bundled image or download, save), and meal plan import logic. Used by ImportFromZipUseCase and ImportSelectionViewModel."
       }
       serializer -> markdown: format
       zip_import_helper -> serializer: deserialize
@@ -361,7 +361,7 @@ app: {
 
       recipe: {
         label: Recipe
-        tooltip: "@Immutable. Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, equipment, tags, imageUrl (local file:// URI), timestamps, isFavorite"
+        tooltip: "@Immutable. Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, equipment, tags, imageUrl (local file:// URI), sourceImageUrl (original remote URL for cross-device sync), timestamps, isFavorite"
       }
       ingredient: {
         label: Ingredient
@@ -410,7 +410,10 @@ app: {
     usecases.regenerate -> usecases.parse_html: uses
     usecases.parse_html -> data.repository.import_debug_repo: save debug data
     usecases.export_zip -> util.serializer: serialize
+    usecases.export_zip -> data.remote.image_dl: read local images
     usecases.export_single -> util.serializer: serialize
+    usecases.export_single -> data.remote.image_dl: read local images
+    usecases.import_paprika -> data.remote.image_dl: save base64 images
     usecases.import_zip -> util.zip_import_helper: import
   }
 
@@ -526,7 +529,7 @@ app: {
       }
       image_dl: {
         label: ImageDownloadService
-        tooltip: "Downloads recipe images from remote URLs and stores them locally in app internal storage. Returns file:// URIs for local access. Used during import, sync, and ZIP restore to ensure images are available offline."
+        tooltip: "Downloads recipe images from remote URLs and stores them locally in app internal storage. Also supports saving images from byte streams (ZIP import) and base64 data (Paprika photo_data). Returns file:// URIs for local access. Used during import, export, sync, and ZIP restore to ensure images are available offline."
       }
       firestore_svc: {
         label: FirestoreService


### PR DESCRIPTION
## Summary

- Include recipe images as binary files in `.lorecipes` ZIP exports, so images survive export/import cycles even if the original URL is down
- Import bundled images from ZIP files first, falling back to re-download only if needed
- Import Paprika `photo_data` (base64-encoded JPEG) directly, eliminating the need for network access to re-download images from source pages
- Add `sourceImageUrl` field to track the original remote image URL, enabling cross-device Firebase sync to re-download images when local `file://` URIs don't exist on the new device

## Changes

### New capabilities in `ImageDownloadService`
- `saveImageFromStream()` - saves image bytes from an InputStream (used for ZIP import)
- `saveImageFromBase64()` - saves base64-encoded image data (used for Paprika import)
- `getLocalImageFile()` - retrieves the local File for a `file://` URI (used for export)

### Export (`.lorecipes` ZIP)
- `ExportToZipUseCase` and `ExportSingleRecipeUseCase` now include the recipe image file in each recipe's folder
- Format: `recipe-name/image.jpg` (or `.png`, `.webp`, `.gif`)

### Import (`.lorecipes` ZIP)
- `ZipImportHelper.readZipContents()` now returns `ZipContents` with separate text and binary image maps
- `importRecipe()` tries bundled image first, then `sourceImageUrl`, then falls back to `imageUrl` download
- `ImportFromZipUseCase` passes image files through to `ZipImportHelper`

### Paprika import
- `ImportPaprikaUseCase` now decodes `photo_data` (base64 JPEG) directly via `saveImageFromBase64()` as highest priority
- Falls back to `image_url` or og:image from source page if no photo_data

### Firebase sync
- `sourceImageUrl` stored in Firestore alongside `imageUrl`
- `FirestoreSyncUseCase.resolveImageForSync()` tries local `file://` URI first, then falls back to `sourceImageUrl` for cross-device re-download

### Database
- Room migration v8→v9: adds `sourceImageUrl` column to recipes table
- `RecipeEntity` and `Recipe` model updated with new field

Closes #212

## Test plan
- [x] CI passes (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Export a recipe with an image, verify the ZIP contains the image file
- [ ] Import the exported ZIP on a fresh install, verify image displays without network
- [ ] Import a Paprika export with photo_data, verify images display
- [ ] Sign in on two devices, verify images sync via sourceImageUrl

🤖 Generated with [Claude Code](https://claude.com/claude-code)