### PR TITLE
fix: retry image downloads with HTTPS when HTTP fails

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -166,7 +166,7 @@ class ParseHtmlUseCase @Inject constructor(
         onProgress(ParseProgress.RecipeNameAvailable(parsed.name))
 
         // Download image locally if available
-        val localImageUrl = imageUrl?.let { imageDownloadService.downloadAndStore(it) }
+        val downloadResult = imageUrl?.let { imageDownloadService.downloadAndStoreWithResult(it) }
 
         // Create Recipe
         val now = Clock.System.now()
@@ -182,8 +182,8 @@ class ParseHtmlUseCase @Inject constructor(
             instructionSections = parsed.instructionSections,
             equipment = parsed.equipment,
             tags = parsed.tags,
-            imageUrl = localImageUrl,
-            sourceImageUrl = imageUrl,
+            imageUrl = downloadResult?.localUri,
+            sourceImageUrl = downloadResult?.effectiveUrl ?: imageUrl,
             createdAt = now,
             updatedAt = now
         )

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -503,7 +503,7 @@ app: {
       }
       image_dl: {
         label: ImageDownloadService
-        tooltip: "Downloads recipe images from remote URLs and stores them locally in app internal storage. Also supports saving images from byte streams (ZIP import) and base64 data (Paprika photo_data). Returns file:// URIs for local access. Used during import, export, and ZIP restore to ensure images are available offline."
+        tooltip: "Downloads recipe images from remote URLs and stores them locally in app internal storage. Automatically retries with HTTPS if an HTTP download fails (e.g., cleartext traffic not permitted). Also supports saving images from byte streams (ZIP import) and base64 data (Paprika photo_data). Returns file:// URIs for local access. Used during import, export, and ZIP restore to ensure images are available offline."
       }
     }
 


### PR DESCRIPTION
## Summary
- When downloading recipe images, Android blocks cleartext HTTP traffic, causing `http://` image URLs to fail with `IOException: Cleartext HTTP traffic not permitted`
- `ImageDownloadService.downloadAndStore` now automatically retries with HTTPS if the original HTTP request fails
- A new `DownloadResult` type tracks the effective URL used, so `sourceImageUrl` is updated to the working HTTPS URL when the retry succeeds

## Test plan
- [ ] Import a recipe that has an `http://` image URL and verify the image downloads successfully via HTTPS fallback
- [ ] Import a recipe with an `https://` image URL and verify it still works normally
- [ ] Import a recipe with a broken image URL and verify it fails gracefully (no crash)
- [ ] Verify CI passes

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)