### PR TITLE
fix: consolidate duplicated formatting logic and fix mixed-unit aggregation bug

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/IngredientAggregation.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/IngredientAggregation.kt
@@ -1,0 +1,66 @@
+package com.lionotter.recipes.domain.model
+
+/**
+ * Shared accumulator for summing ingredient amounts in base units (grams for weight, mL for volume).
+ *
+ * Handles:
+ * - Converting amounts to base units before summing to avoid unit mismatch errors
+ *   (e.g., "1 cup" + "2 tbsp" sums correctly in mL)
+ * - Gracefully skipping amount-less occurrences (e.g., "a pinch of butter")
+ *   while still summing the amount-bearing ones
+ * - Tracking the unit category so the result can be converted back to a display unit
+ */
+data class BaseUnitAccumulator(
+    var baseValue: Double? = null,
+    val category: UnitCategory? = null
+) {
+    /**
+     * Add a base-unit value to this accumulator.
+     * If [value] is null (amount-less occurrence), it is skipped gracefully —
+     * the existing total is preserved.
+     */
+    fun add(value: Double?) {
+        if (value == null) return
+        baseValue = (baseValue ?: 0.0) + value
+    }
+}
+
+/**
+ * Compute the base-unit value for an ingredient's amount, scaled by [yields].
+ *
+ * Weight amounts are converted to grams, volume amounts to mL.
+ * Count items (no unit) are returned as-is. Null amounts return null.
+ */
+fun Ingredient.getBaseValue(yields: Int): Double? {
+    val rawValue = amount?.value?.let { it * yields } ?: return null
+    val unit = amount?.unit ?: return rawValue  // count item
+    return toBaseUnitValue(rawValue, unit) ?: rawValue
+}
+
+/**
+ * Aggregate a list of (ingredient, yields) pairs into a map of accumulated base-unit totals.
+ *
+ * Each ingredient's amount is converted to base units (grams or mL) before summing.
+ * Ingredients are keyed by lowercase name. Count items (no unit) are summed directly.
+ *
+ * @param ingredients pairs of (ingredient, yields multiplier)
+ * @return map of lowercase ingredient name -> BaseUnitAccumulator
+ */
+fun aggregateToBaseUnits(
+    ingredients: List<Pair<Ingredient, Int>>
+): Map<String, BaseUnitAccumulator> {
+    val totals = mutableMapOf<String, BaseUnitAccumulator>()
+    for ((ingredient, yields) in ingredients) {
+        val key = ingredient.name.lowercase()
+        val baseValue = ingredient.getBaseValue(yields)
+        val category = ingredient.amount?.unit?.let { unitType(it) }
+
+        val existing = totals[key]
+        if (existing != null) {
+            existing.add(baseValue)
+        } else {
+            totals[key] = BaseUnitAccumulator(baseValue = baseValue, category = category)
+        }
+    }
+    return totals
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/IngredientFormatter.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/IngredientFormatter.kt
@@ -1,0 +1,103 @@
+package com.lionotter.recipes.domain.model
+
+import com.lionotter.recipes.util.pluralize
+import com.lionotter.recipes.util.singularize
+
+/**
+ * Shared formatting functions for ingredient amounts.
+ * All ingredient display paths (recipe detail, remaining-amount, grocery list, markdown export)
+ * should use these functions so formatting stays consistent.
+ */
+
+private const val FRACTION_TOLERANCE = 0.05
+
+/**
+ * Format a quantity for display, converting common decimals to fractions.
+ * Used for volume and count items (e.g., "2 1/2 cups", "3 eggs").
+ */
+fun formatQuantity(qty: Double): String {
+    return if (qty == qty.toLong().toDouble()) {
+        qty.toLong().toString()
+    } else {
+        val fractions = mapOf(
+            0.25 to "1/4",
+            0.33 to "1/3",
+            0.5 to "1/2",
+            0.66 to "2/3",
+            0.75 to "3/4"
+        )
+        val whole = qty.toLong()
+        val decimal = qty - whole
+
+        val fraction = fractions.entries
+            .map { it.value to kotlin.math.abs(it.key - decimal) }
+            .minByOrNull { it.second }
+            ?.takeIf { it.second < FRACTION_TOLERANCE }
+            ?.first
+
+        when {
+            fraction != null && whole > 0 -> "$whole $fraction"
+            fraction != null -> fraction
+            else -> "%.2f".format(qty).trimEnd('0').trimEnd('.')
+        }
+    }
+}
+
+/**
+ * Format a weight quantity using decimals instead of fractions.
+ * People think about weights in decimals (2.5 g, 250 g), not fractions (1/4 kg).
+ */
+fun formatWeightQuantity(qty: Double): String {
+    return when {
+        qty == qty.toLong().toDouble() -> qty.toLong().toString()
+        qty >= 10 -> kotlin.math.round(qty).toLong().toString()
+        qty >= 1 -> "%.1f".format(qty).trimEnd('0').trimEnd('.')
+        else -> "%.2f".format(qty).trimEnd('0').trimEnd('.')
+    }
+}
+
+/**
+ * Format ounces as compound "X lb Y oz" like a kitchen scale would show.
+ * Drops the oz part if it rounds to 0.
+ */
+fun formatLbOz(totalOz: Double): String {
+    val wholeLbs = (totalOz / 16).toLong()
+    val remainingOz = totalOz - wholeLbs * 16
+    val roundedOz = kotlin.math.round(remainingOz * 10) / 10
+
+    return buildString {
+        append(wholeLbs)
+        append(" lb")
+        if (roundedOz >= 0.1) {
+            append(" ")
+            append(formatWeightQuantity(roundedOz))
+            append(" oz")
+        }
+    }
+}
+
+/** Convert internal unit identifiers to display-friendly strings (e.g. "fl_oz" -> "fl oz"). */
+fun displayUnit(unit: String): String = unit.replace('_', ' ')
+
+/**
+ * Format a value + unit for display, choosing the right formatter based on unit category.
+ * Handles compound lb+oz, weight decimals, volume/count fractions, and unit pluralization.
+ *
+ * @return the formatted amount string (e.g., "2 1/2 cups", "1 lb 4 oz", "250 g")
+ */
+fun formatAmount(value: Double, unit: String?): String {
+    val isWeight = unit != null && unitType(unit) == UnitCategory.WEIGHT
+
+    return buildString {
+        if (unit == "oz" && value >= 16) {
+            append(formatLbOz(value))
+        } else {
+            append(if (isWeight) formatWeightQuantity(value) else formatQuantity(value))
+            if (unit != null) {
+                append(" ")
+                val count = if (value > 1.0) 2 else 1
+                append(displayUnit(unit.singularize().pluralize(count)))
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/CalculateIngredientUsageUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/CalculateIngredientUsageUseCase.kt
@@ -1,11 +1,11 @@
 package com.lionotter.recipes.domain.usecase
 
+import com.lionotter.recipes.domain.model.BaseUnitAccumulator
 import com.lionotter.recipes.domain.model.Ingredient
 import com.lionotter.recipes.domain.model.IngredientUsageStatus
 import com.lionotter.recipes.domain.model.InstructionIngredientKey
 import com.lionotter.recipes.domain.model.MeasurementPreference
 import com.lionotter.recipes.domain.model.Recipe
-import com.lionotter.recipes.domain.model.UnitCategory
 import com.lionotter.recipes.domain.model.UnitSystem
 import com.lionotter.recipes.domain.model.createInstructionIngredientKey
 import com.lionotter.recipes.domain.model.fromBaseUnit
@@ -22,21 +22,6 @@ import javax.inject.Inject
  * use different units (e.g. cups in one step and tbsp in another).
  */
 class CalculateIngredientUsageUseCase @Inject constructor() {
-
-    /**
-     * Tracks accumulated base-unit value and the unit category for an ingredient.
-     */
-    private data class BaseUnitAccumulator(
-        var baseValue: Double? = null,
-        val category: UnitCategory? = null
-    ) {
-        fun add(value: Double?) {
-            baseValue = when {
-                baseValue == null || value == null -> null
-                else -> baseValue!! + value
-            }
-        }
-    }
 
     fun execute(
         recipe: Recipe,

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeMarkdownFormatter.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeMarkdownFormatter.kt
@@ -6,6 +6,7 @@ import com.lionotter.recipes.domain.model.IngredientSection
 import com.lionotter.recipes.domain.model.InstructionSection
 import com.lionotter.recipes.domain.model.InstructionStep
 import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.model.formatQuantity
 
 /**
  * Converts a Recipe to a human-readable Markdown format.
@@ -137,35 +138,6 @@ object RecipeMarkdownFormatter {
             "$formattedValue ${amount.unit}"
         } else {
             formattedValue
-        }
-    }
-
-    private fun formatQuantity(qty: Double): String {
-        return if (qty == qty.toLong().toDouble()) {
-            qty.toLong().toString()
-        } else {
-            // Convert to fractions for common values
-            val fractions = mapOf(
-                0.25 to "1/4",
-                0.33 to "1/3",
-                0.5 to "1/2",
-                0.66 to "2/3",
-                0.75 to "3/4"
-            )
-            val whole = qty.toLong()
-            val decimal = qty - whole
-
-            val fraction = fractions.entries.minByOrNull {
-                kotlin.math.abs(it.key - decimal)
-            }?.takeIf {
-                kotlin.math.abs(it.key - decimal) < 0.05
-            }?.value
-
-            when {
-                fraction != null && whole > 0 -> "$whole $fraction"
-                fraction != null -> fraction
-                else -> "%.2f".format(qty).trimEnd('0').trimEnd('.')
-            }
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListViewModel.kt
@@ -9,6 +9,8 @@ import com.lionotter.recipes.domain.model.Amount
 import com.lionotter.recipes.domain.model.MealPlanEntry
 import com.lionotter.recipes.domain.model.UnitCategory
 import com.lionotter.recipes.domain.model.UnitSystem
+import com.lionotter.recipes.domain.model.formatAmount
+import com.lionotter.recipes.domain.model.formatQuantity
 import com.lionotter.recipes.domain.model.fromBaseUnit
 import com.lionotter.recipes.domain.model.toBaseUnitValue
 import com.lionotter.recipes.domain.model.unitType
@@ -429,19 +431,10 @@ class GroceryListViewModel @Inject constructor(
 
     private fun formatAmountForDisplay(amount: Amount): String? {
         val value = amount.value ?: return null
-        val formatted = if (value == value.toLong().toDouble()) {
-            value.toLong().toString()
-        } else {
-            "%.1f".format(value).trimEnd('0').trimEnd('.')
-        }
-        return if (amount.unit != null) "$formatted ${amount.unit}" else formatted
+        return formatAmount(value, amount.unit)
     }
 
     private fun formatCountForDisplay(count: Double): String {
-        return if (count == count.toLong().toDouble()) {
-            count.toLong().toString()
-        } else {
-            "%.1f".format(count).trimEnd('0').trimEnd('.')
-        }
+        return formatQuantity(count)
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/IngredientSectionContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/IngredientSectionContent.kt
@@ -18,11 +18,8 @@ import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.IngredientSection
 import com.lionotter.recipes.domain.model.IngredientUsageStatus
 import com.lionotter.recipes.domain.model.MeasurementPreference
-import com.lionotter.recipes.domain.model.UnitCategory
 import com.lionotter.recipes.domain.model.UnitSystem
-import com.lionotter.recipes.domain.model.unitType
-import com.lionotter.recipes.util.pluralize
-import com.lionotter.recipes.util.singularize
+import com.lionotter.recipes.domain.model.formatAmount
 
 @Composable
 internal fun IngredientSectionContent(
@@ -125,76 +122,5 @@ internal fun IngredientSectionContent(
  * Formats the remaining amount for display (e.g., "1/2 cup left").
  */
 internal fun formatRemainingAmount(amount: Double, unit: String?): String {
-    // Compound lb+oz display for customary weight >= 16 oz
-    if (unit == "oz" && amount >= 16) {
-        return "${formatLbOz(amount)} left"
-    }
-    val isWeight = unit != null && unitType(unit) == UnitCategory.WEIGHT
-    val formattedAmount = if (isWeight) formatWeightQuantity(amount) else formatQuantity(amount)
-    return if (unit != null) {
-        val count = if (amount > 1.0) 2 else 1
-        val pluralizedUnit = unit.singularize().pluralize(count)
-        "$formattedAmount $pluralizedUnit left"
-    } else {
-        "$formattedAmount left"
-    }
-}
-
-internal fun formatQuantity(qty: Double): String {
-    return if (qty == qty.toLong().toDouble()) {
-        qty.toLong().toString()
-    } else {
-        val fractions = mapOf(
-            0.25 to "1/4",
-            0.33 to "1/3",
-            0.5 to "1/2",
-            0.66 to "2/3",
-            0.75 to "3/4"
-        )
-        val whole = qty.toLong()
-        val decimal = qty - whole
-
-        val fraction = fractions.entries.minByOrNull {
-            kotlin.math.abs(it.key - decimal)
-        }?.takeIf {
-            kotlin.math.abs(it.key - decimal) < 0.05
-        }?.value
-
-        when {
-            fraction != null && whole > 0 -> "$whole $fraction"
-            fraction != null -> fraction
-            else -> "%.2f".format(qty).trimEnd('0').trimEnd('.')
-        }
-    }
-}
-
-/**
- * Format a weight quantity using decimals instead of fractions.
- */
-internal fun formatWeightQuantity(qty: Double): String {
-    return when {
-        qty == qty.toLong().toDouble() -> qty.toLong().toString()
-        qty >= 10 -> kotlin.math.round(qty).toLong().toString()
-        qty >= 1 -> "%.1f".format(qty).trimEnd('0').trimEnd('.')
-        else -> "%.2f".format(qty).trimEnd('0').trimEnd('.')
-    }
-}
-
-/**
- * Format ounces as compound "X lbs Y oz" like a kitchen scale would show.
- */
-internal fun formatLbOz(totalOz: Double): String {
-    val wholeLbs = (totalOz / 16).toLong()
-    val remainingOz = totalOz - wholeLbs * 16
-    val roundedOz = kotlin.math.round(remainingOz * 10) / 10
-
-    return buildString {
-        append(wholeLbs)
-        append(if (wholeLbs == 1L) " lb" else " lbs")
-        if (roundedOz >= 0.1) {
-            append(" ")
-            append(formatWeightQuantity(roundedOz))
-            append(" oz")
-        }
-    }
+    return "${formatAmount(amount, unit)} left"
 }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -293,7 +293,7 @@ app: {
       }
       aggregate_grocery: {
         label: AggregateGroceryListUseCase
-        tooltip: "Aggregates ingredients from selected meal plan recipes into a deduplicated grocery list. Normalizes ingredient names by removing size prefixes (small/medium/large), sums amounts in base units across recipes."
+        tooltip: "Aggregates ingredients from selected meal plan recipes into a deduplicated grocery list. Normalizes ingredient names by removing size prefixes (small/medium/large). Uses Recipe.aggregateIngredients() which sums amounts in base units (grams/mL) via shared BaseUnitAccumulator to handle mixed-unit ingredients correctly."
       }
       tags: {
         label: GetTagsUseCase
@@ -368,6 +368,14 @@ app: {
       start_of_week: {
         label: StartOfWeek
         tooltip: "Enum: LOCALE_DEFAULT, MONDAY..SUNDAY. User preference for which day the week starts on in the meal planner. LOCALE_DEFAULT resolves to device locale's first day of week."
+      }
+      ingredient_formatter: {
+        label: IngredientFormatter
+        tooltip: "Shared formatting functions for ingredient amounts: formatQuantity (fractions), formatWeightQuantity (decimals), formatLbOz (compound lb+oz), formatAmount (convenience). Used by Ingredient.format(), IngredientSectionContent, RecipeMarkdownFormatter, and GroceryListViewModel."
+      }
+      ingredient_aggregation: {
+        label: IngredientAggregation
+        tooltip: "Shared BaseUnitAccumulator for summing ingredient amounts in base units (grams for weight, mL for volume). Used by Recipe.aggregateIngredients() and CalculateIngredientUsageUseCase."
       }
       meal_plan_entry -> meal_type: type
 


### PR DESCRIPTION
## Summary

- Extract shared formatting functions (`formatQuantity`, `formatWeightQuantity`, `formatLbOz`, `displayUnit`, `formatAmount`) into `IngredientFormatter.kt` — deletes all three duplicated copies
- Extract shared `BaseUnitAccumulator` into `IngredientAggregation.kt` — replaces the private inner class in `CalculateIngredientUsageUseCase`
- Fix `Recipe.aggregateIngredients()` to sum amounts in base units (grams/mL) instead of naively adding raw values, fixing the bug where mixed-unit ingredients produced incorrect totals (e.g., "1 lb butter" + "1 tsp butter" → "2 lb butter")
- Amount-less occurrences (e.g., "a pinch of butter") are now skipped gracefully instead of nulling out the entire total
- Grocery aggregate headers now use fractions and compound lb+oz formatting (consistent with recipe view)
- Remaining-amount display uses "lb" consistently (was "lbs" in one copy)

## Test plan

- [x] All existing unit tests pass (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Verify recipe ingredient list displays correctly with mixed-unit ingredients
- [ ] Verify grocery list aggregate headers show fractions (e.g., "2 1/2 tbsp" not "2.5 tbsp")
- [ ] Verify remaining-amount display shows "lb" not "lbs"
- [ ] Verify markdown export still formats amounts correctly

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)