### PR TITLE
build: update dependencies to latest stable versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 android {
     namespace = "com.lionotter.recipes"
-    compileSdk = 35
+    compileSdk = 36
 
     signingConfigs {
         getByName("debug") {
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId = "com.lionotter.recipes"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0.0"
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -84,6 +84,8 @@ fun SettingsScreen(
     }
 
     // Show snackbar for export operation results
+    // Context is used for string formatting in a side-effect, not for rendering
+    @Suppress("LocalContextGetResourceValueCall")
     LaunchedEffect(zipOperationState) {
         when (val state = zipOperationState) {
             is ZipOperationState.ExportComplete -> {

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "com.lionotter.recipes.baselineprofile"
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         minSdk = 28
-        targetSdk = 35
+        targetSdk = 36
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,25 +1,25 @@
 [versions]
 agp = "8.13.2"
-kotlin = "2.1.0"
-coreKtx = "1.15.0"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.9.3"
-composeBom = "2024.12.01"
-hilt = "2.54"
-hiltNavigationCompose = "1.2.0"
-workRuntimeKtx = "2.10.0"
-hiltWork = "1.2.0"
-room = "2.6.1"
-ktor = "3.0.3"
+kotlin = "2.1.21"
+coreKtx = "1.17.0"
+lifecycleRuntimeKtx = "2.10.0"
+activityCompose = "1.12.4"
+composeBom = "2026.01.01"
+hilt = "2.58"
+hiltNavigationCompose = "1.3.0"
+workRuntimeKtx = "2.11.1"
+hiltWork = "1.3.0"
+room = "2.8.4"
+ktor = "3.1.3"
 kotlinxSerialization = "1.7.3"
 kotlinxDatetime = "0.6.1"
-datastore = "1.1.1"
-securityCrypto = "1.1.0-alpha06"
-navigationCompose = "2.8.5"
+datastore = "1.2.0"
+securityCrypto = "1.1.0"
+navigationCompose = "2.9.6"
 coil = "2.7.0"
-ksp = "2.1.0-1.0.29"
+ksp = "2.1.21-2.0.2"
 readability4j = "1.0.8"
-jsoup = "1.18.1"
+jsoup = "1.22.1"
 benchmarkMacroJunit4 = "1.4.1"
 profileinstaller = "1.4.1"
 uiautomator = "2.3.0"
@@ -97,9 +97,9 @@ ojalgo = { group = "org.ojalgo", name = "ojalgo", version.ref = "ojalgo" }
 
 # Testing
 junit = { group = "junit", name = "junit", version = "4.13.2" }
-kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.9.0" }
-mockk = { group = "io.mockk", name = "mockk", version = "1.13.13" }
-turbine = { group = "app.cash.turbine", name = "turbine", version = "1.2.0" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.10.2" }
+mockk = { group = "io.mockk", name = "mockk", version = "1.14.9" }
+turbine = { group = "app.cash.turbine", name = "turbine", version = "1.2.1" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.danilopianini.gradle-pre-commit-git-hooks") version "2.1.5"
+    id("org.danilopianini.gradle-pre-commit-git-hooks") version "2.1.7"
 }
 
 gitHooks {


### PR DESCRIPTION
## Summary

- Update all dependencies to their latest stable versions that are compatible with the current Kotlin 2.1.x / AGP 8.x stack
- Bump compileSdk and targetSdk from 35 to 36 (required by updated AndroidX libraries)
- Suppress a new Compose lint false positive for `LocalContext` usage in side-effects

## Updated Dependencies

| Dependency | Old | New |
|---|---|---|
| Kotlin | 2.1.0 | 2.1.21 |
| KSP | 2.1.0-1.0.29 | 2.1.21-2.0.2 |
| core-ktx | 1.15.0 | 1.17.0 |
| lifecycle | 2.8.7 | 2.10.0 |
| activity-compose | 1.9.3 | 1.12.4 |
| compose-bom | 2024.12.01 | 2026.01.01 |
| navigation-compose | 2.8.5 | 2.9.6 |
| hilt | 2.54 | 2.58 |
| hilt-navigation-compose | 1.2.0 | 1.3.0 |
| hilt-work | 1.2.0 | 1.3.0 |
| work-runtime-ktx | 2.10.0 | 2.11.1 |
| room | 2.6.1 | 2.8.4 |
| ktor | 3.0.3 | 3.1.3 |
| datastore | 1.1.1 | 1.2.0 |
| security-crypto | 1.1.0-alpha06 | 1.1.0 |
| jsoup | 1.18.1 | 1.22.1 |
| mockk | 1.13.13 | 1.14.9 |
| kotlinx-coroutines-test | 1.9.0 | 1.10.2 |
| turbine | 1.2.0 | 1.2.1 |
| git-hooks plugin | 2.1.5 | 2.1.7 |
| compileSdk/targetSdk | 35 | 36 |

## Not Updated (compatibility constraints)

- **Hilt 2.59+** requires AGP 9.0
- **Ktor 3.2+** requires Kotlin 2.2+ (pulls in kotlin-stdlib 2.3.0)
- **kotlinx-serialization 1.10.0** requires Kotlin 2.3
- **kotlinx-datetime 0.7.x** has breaking `Instant` API changes
- **Coil 3.x** is a major migration with new artifact coordinates

## Test plan

- [x] `./ci-local.sh` passes (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Verify app launches and basic functionality works on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)