### PR TITLE
build: upgrade to AGP 9, Kotlin 2.3, and remaining dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
@@ -50,10 +49,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
     }
 
     buildFeatures {

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.test)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.baselineprofile)
 }
 
@@ -11,10 +10,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
     }
 
     defaultConfig {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.test) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,26 +1,26 @@
 [versions]
-agp = "8.13.2"
-kotlin = "2.1.21"
+agp = "9.0.1"
+kotlin = "2.3.0"
 coreKtx = "1.17.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.4"
 composeBom = "2026.01.01"
-hilt = "2.58"
+hilt = "2.59.1"
 hiltNavigationCompose = "1.3.0"
 workRuntimeKtx = "2.11.1"
 hiltWork = "1.3.0"
 room = "2.8.4"
-ktor = "3.1.3"
-kotlinxSerialization = "1.7.3"
+ktor = "3.4.0"
+kotlinxSerialization = "1.10.0"
 kotlinxDatetime = "0.6.1"
 datastore = "1.2.0"
 securityCrypto = "1.1.0"
-navigationCompose = "2.9.6"
+navigationCompose = "2.9.7"
 coil = "2.7.0"
-ksp = "2.1.21-2.0.2"
+ksp = "2.3.4"
 readability4j = "1.0.8"
 jsoup = "1.22.1"
-benchmarkMacroJunit4 = "1.4.1"
+androidxBenchmark = "1.5.0-alpha03"
 profileinstaller = "1.4.1"
 uiautomator = "2.3.0"
 androidxTestExtJunit = "1.2.1"
@@ -87,7 +87,7 @@ readability4j = { group = "net.dankito.readability4j", name = "readability4j", v
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 
 # Baseline Profile
-androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmarkMacroJunit4" }
+androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "androidxBenchmark" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
@@ -104,8 +104,7 @@ turbine = { group = "app.cash.turbine", name = "turbine", version = "1.2.1" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-test = { id = "com.android.test", version.ref = "agp" }
-baselineprofile = { id = "androidx.baselineprofile", version.ref = "benchmarkMacroJunit4" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+baselineprofile = { id = "androidx.baselineprofile", version.ref = "androidxBenchmark" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

Coordinated major version upgrade across the build toolchain, as described in #250:

- **Gradle:** 8.13 → 9.3.1
- **AGP:** 8.13.2 → 9.0.1
- **Kotlin:** 2.1.21 → 2.3.0
- **KSP:** 2.1.21-2.0.2 → 2.3.4 (new independent versioning for KSP2)
- **Hilt:** 2.58 → 2.59.1 (required for AGP 9 support)
- **Ktor:** 3.1.3 → 3.4.0 (unblocked by Kotlin 2.3)
- **kotlinx-serialization:** 1.7.3 → 1.10.0 (unblocked by Kotlin 2.3)
- **navigation-compose:** 2.9.6 → 2.9.7
- **Baseline Profile plugin:** 1.4.1 → 1.5.0-alpha03 (AGP 9 compatibility)

### AGP 9 migration changes
- Removed `org.jetbrains.kotlin.android` plugin from all build files (now built-in to AGP 9)
- Removed deprecated `kotlinOptions` blocks (`jvmTarget` now defaults to `compileOptions.targetCompatibility`)

### Not included (separate efforts per issue)
- kotlinx-datetime upgrade (breaking `Instant` changes)
- Coil 2.x → 3.x upgrade (new artifact coordinates)
- Compose BOM 2026.02.00 (not yet released)

Closes #250

## Test plan

- [x] `./ci-local.sh` passes (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Verify app launches and functions correctly on device/emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)