### PR TITLE
fix: add ProGuard rules for jsoup's optional re2j dependency

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -40,6 +40,9 @@
 -dontwarn java.lang.reflect.AnnotatedType
 -dontwarn com.github.victools.jsonschema.generator.**
 
+# jsoup (optional re2j dependency not present on Android)
+-dontwarn com.google.re2j.**
+
 # ojAlgo (ILP solver for tag selection)
 -keep class org.ojalgo.** { *; }
 -keepclassmembers class org.ojalgo.** { *; }


### PR DESCRIPTION
## Summary
- `assembleRelease` was failing during R8 minification because jsoup references `com.google.re2j.Matcher` and `com.google.re2j.Pattern` classes that are not present on Android
- Added `-dontwarn` rules to `proguard-rules.pro` to suppress the missing class errors (these are optional dependencies in jsoup, not needed at runtime)

## Test plan
- [x] `./gradlew assembleRelease` succeeds
- [x] `./ci-local.sh` passes (assembleDebug, testDebugUnitTest, lintDebug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)