### PR TITLE
build: upgrade Coil 2.7.0 → 3.3.0

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/components/RecipeThumbnail.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/components/RecipeThumbnail.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import coil.compose.SubcomposeAsyncImage
+import coil3.compose.SubcomposeAsyncImage
 
 /**
  * A recipe thumbnail that always reserves space for consistent layout alignment.

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
@@ -34,8 +34,8 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import coil.compose.SubcomposeAsyncImage
-import coil.compose.SubcomposeAsyncImageContent
+import coil3.compose.SubcomposeAsyncImage
+import coil3.compose.SubcomposeAsyncImageContent
 import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.IngredientUsageStatus
 import com.lionotter.recipes.domain.model.InstructionIngredientKey

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ kotlinxDatetime = "0.7.1"
 datastore = "1.2.0"
 securityCrypto = "1.1.0"
 navigationCompose = "2.9.7"
-coil = "2.7.0"
+coil = "3.3.0"
 ksp = "2.3.4"
 readability4j = "1.0.8"
 jsoup = "1.22.1"
@@ -78,7 +78,7 @@ datastore-preferences = { group = "androidx.datastore", name = "datastore-prefer
 security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 
 # Coil
-coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 
 # Readability
 readability4j = { group = "net.dankito.readability4j", name = "readability4j", version.ref = "readability4j" }


### PR DESCRIPTION
## Summary
- Upgrades Coil from 2.7.0 to 3.3.0 (latest stable)
- Updates Maven group ID from `io.coil-kt` to `io.coil-kt.coil3` in version catalog
- Updates package imports from `coil.compose` to `coil3.compose` in source files

No network dependency (`coil-network-okhttp` or `coil-network-ktor`) was added since the app only loads local `file://` URIs (images are downloaded separately by `ImageDownloadService`).

Closes #253

## Test plan
- [x] `./ci-local.sh` passes (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Manual test: verify recipe thumbnails load in recipe list
- [ ] Manual test: verify hero images load in recipe detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)