### PR TITLE
fix: resolve deprecation warnings across codebase

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.core.content.IntentCompat
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -89,7 +90,7 @@ class MainActivity : ComponentActivity() {
         return when (intent?.action) {
             Intent.ACTION_SEND -> {
                 // Only extract text URL if there's no file stream (to avoid treating file shares as URL shares)
-                if (intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM) != null) null
+                if (IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri::class.java) != null) null
                 else intent.getStringExtra(Intent.EXTRA_TEXT)?.takeIf { it.isNotBlank() }
             }
             else -> null
@@ -100,8 +101,7 @@ class MainActivity : ComponentActivity() {
         return when (intent?.action) {
             Intent.ACTION_VIEW -> intent.data
             Intent.ACTION_SEND -> {
-                @Suppress("DEPRECATION")
-                intent.getParcelableExtra(Intent.EXTRA_STREAM)
+                IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri::class.java)
             }
             else -> null
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // TODO: migrate EncryptedSharedPreferences to DataStore + Tink
+
 package com.lionotter.recipes.data.local
 
 import android.content.Context
@@ -28,7 +30,7 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 
 @Singleton
 class SettingsDataStore @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) {
     private object Keys {
         val AI_MODEL = stringPreferencesKey("ai_model")

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/ImageDownloadService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/ImageDownloadService.kt
@@ -24,7 +24,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class ImageDownloadService @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val httpClient: HttpClient
 ) {
     /**

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/IngredientAggregation.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/IngredientAggregation.kt
@@ -33,7 +33,7 @@ data class BaseUnitAccumulator(
  */
 fun Ingredient.getBaseValue(yields: Int): Double? {
     val rawValue = amount?.value?.let { it * yields } ?: return null
-    val unit = amount?.unit ?: return rawValue  // count item
+    val unit = amount.unit ?: return rawValue  // count item
     return toBaseUnitValue(rawValue, unit) ?: rawValue
 }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/notification/RecipeNotificationHelper.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/notification/RecipeNotificationHelper.kt
@@ -19,7 +19,7 @@ import javax.inject.Singleton
 
 @Singleton
 class RecipeNotificationHelper @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) {
     companion object {
         const val CHANNEL_ID = "recipe_import"

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
@@ -7,7 +7,7 @@ import androidx.core.net.toUri
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lionotter.recipes.R
 import com.lionotter.recipes.ui.components.ErrorCard

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/grocerylist/GroceryListScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.MealType

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.ui.screens.importdebug
 
+import android.content.ClipData
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.horizontalScroll
@@ -23,8 +24,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -32,22 +33,24 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lionotter.recipes.R
 import com.lionotter.recipes.data.local.ImportDebugEntity
 import com.lionotter.recipes.ui.components.RecipeTopAppBar
 import kotlin.time.Instant
+import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.number
 import kotlinx.datetime.toLocalDateTime
@@ -96,6 +99,7 @@ fun ImportDebugDetailScreen(
     }
 }
 
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
 @Composable
 private fun DebugDetailContent(
     entry: ImportDebugEntity,
@@ -111,7 +115,7 @@ private fun DebugDetailContent(
     )
 
     Column(modifier = modifier.fillMaxSize()) {
-        TabRow(selectedTabIndex = selectedTabIndex) {
+        PrimaryTabRow(selectedTabIndex = selectedTabIndex) {
             tabs.forEachIndexed { index, title ->
                 Tab(
                     selected = selectedTabIndex == index,
@@ -352,7 +356,8 @@ private fun AiOutputTab(jsonString: String?) {
         }
     }
 
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     val prettyJson = remember(jsonString) {
         try {
             val json = Json { prettyPrint = true }
@@ -382,7 +387,7 @@ private fun AiOutputTab(jsonString: String?) {
         }
 
         IconButton(
-            onClick = { clipboardManager.setText(AnnotatedString(prettyJson)) },
+            onClick = { scope.launch { clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("JSON", prettyJson))) } },
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .padding(8.dp)

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/importdebug/ImportDebugListScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lionotter.recipes.R
 import com.lionotter.recipes.data.local.ImportDebugEntity

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.model.MealPlanEntry
@@ -251,6 +251,7 @@ private fun SwipeableMealPlanCard(
     onDeleteRequest: () -> Unit
 ) {
     var showMenu by remember { mutableStateOf(false) }
+    @Suppress("DEPRECATION") // TODO: migrate to AnchoredDraggable dynamic anchors
     val dismissState = rememberSwipeToDismissBoxState(
         confirmValueChange = { value ->
             when (value) {

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lionotter.recipes.R
 import com.lionotter.recipes.domain.util.RecipeMarkdownFormatter

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
@@ -67,7 +67,7 @@ class RecipeDetailViewModel @Inject constructor(
     private val workManager: WorkManager,
     private val exportSingleRecipeUseCase: ExportSingleRecipeUseCase,
     private val recipeSerializer: RecipeSerializer,
-    @ApplicationContext private val applicationContext: Context
+    @param:ApplicationContext private val applicationContext: Context
 ) : ViewModel() {
 
     private val recipeId: String = savedStateHandle.get<String>("recipeId")
@@ -197,6 +197,7 @@ class RecipeDetailViewModel @Inject constructor(
     ) { args ->
         @Suppress("UNCHECKED_CAST")
         val recipe = args[0] as Recipe?
+        @Suppress("UNCHECKED_CAST")
         val usedKeys = args[1] as Set<InstructionIngredientKey>
         val scale = args[2] as Double
         val preference = args[3] as MeasurementPreference

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/IngredientSectionContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/IngredientSectionContent.kt
@@ -65,7 +65,7 @@ internal fun IngredientSectionContent(
                         color = if (isFullyUsed) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.onSurface
                     )
                     // Show remaining amount if partially used
-                    if (hasPartialUsage && usage?.remainingAmount != null && usage.remainingAmount > 0) {
+                    if (hasPartialUsage && usage.remainingAmount != null && usage.remainingAmount > 0) {
                         Text(
                             text = formatRemainingAmount(usage.remainingAmount, usage.remainingUnit),
                             style = MaterialTheme.typography.bodySmall,
@@ -100,7 +100,7 @@ internal fun IngredientSectionContent(
                             color = if (altIsFullyUsed) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         // Show remaining amount if partially used
-                        if (altHasPartialUsage && altUsage?.remainingAmount != null && altUsage.remainingAmount > 0) {
+                        if (altHasPartialUsage && altUsage.remainingAmount != null && altUsage.remainingAmount > 0) {
                             Text(
                                 text = formatRemainingAmount(altUsage.remainingAmount, altUsage.remainingUnit),
                                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/InstructionSectionContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/InstructionSectionContent.kt
@@ -54,7 +54,7 @@ internal fun InstructionSectionContent(
 
         section.steps.forEachIndexed { stepIndex, step ->
             val isHighlighted = highlightedInstructionStep?.sectionIndex == sectionIndex &&
-                                highlightedInstructionStep?.stepIndex == stepIndex
+                                highlightedInstructionStep.stepIndex == stepIndex
 
             Column(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lionotter.recipes.R
 import com.lionotter.recipes.data.repository.RepositoryError

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/InProgressRecipeCard.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/InProgressRecipeCard.kt
@@ -40,6 +40,7 @@ fun InProgressRecipeCard(
     inProgressRecipe: InProgressRecipe,
     onCancelRequest: () -> Unit
 ) {
+    @Suppress("DEPRECATION") // TODO: migrate to AnchoredDraggable dynamic anchors
     val dismissState = rememberSwipeToDismissBoxState(
         confirmValueChange = { value ->
             if (value == SwipeToDismissBoxValue.EndToStart) {

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/SwipeableRecipeCard.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/SwipeableRecipeCard.kt
@@ -34,6 +34,7 @@ fun SwipeableRecipeCard(
     onFavoriteClick: () -> Unit
 ) {
     var showMenu by remember { mutableStateOf(false) }
+    @Suppress("DEPRECATION") // TODO: migrate to AnchoredDraggable dynamic anchors
     val dismissState = rememberSwipeToDismissBoxState(
         confirmValueChange = { value ->
             if (value == SwipeToDismissBoxValue.EndToStart) {

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lionotter.recipes.R
 import com.lionotter.recipes.ui.components.RecipeTopAppBar

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/MealPlannerSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/MealPlannerSection.kt
@@ -8,7 +8,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -74,7 +74,7 @@ fun MealPlannerSection(
                     onValueChange = {},
                     modifier = Modifier
                         .fillMaxWidth()
-                        .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                        .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
                     readOnly = true,
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) }
                 )

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ModelSelectionSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ModelSelectionSection.kt
@@ -9,7 +9,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -62,7 +62,7 @@ fun ModelSelectionSection(
                 onValueChange = {},
                 modifier = Modifier
                     .fillMaxWidth()
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
                 readOnly = true,
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) }
             )

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ThemeSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ThemeSection.kt
@@ -8,7 +8,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -57,7 +57,7 @@ fun ThemeSection(
                 onValueChange = {},
                 modifier = Modifier
                     .fillMaxWidth()
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
                 readOnly = true,
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) }
             )

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/state/InProgressRecipeManager.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/state/InProgressRecipeManager.kt
@@ -35,7 +35,7 @@ data class InProgressRecipe(
 class InProgressRecipeManager @Inject constructor(
     private val workManager: WorkManager,
     private val pendingImportRepository: PendingImportRepository,
-    @ApplicationScope private val appScope: CoroutineScope
+    @param:ApplicationScope private val appScope: CoroutineScope
 ) {
     companion object {
         private const val TAG = "InProgressRecipeManager"


### PR DESCRIPTION
## Summary
- Migrate `hiltViewModel` import to new package `androidx.hilt.lifecycle.viewmodel.compose` (9 files)
- Replace `MenuAnchorType` with `ExposedDropdownMenuAnchorType` in dropdown menus (3 files)
- Use `IntentCompat.getParcelableExtra` instead of deprecated `Intent.getParcelableExtra` in MainActivity
- Suppress `EncryptedSharedPreferences` deprecation at file level (requires DataStore+Tink migration, no drop-in replacement)
- Add `@param:` annotation targets for Hilt qualifiers to fix KT-73255 warnings (5 files)
- Replace `TabRow` with `PrimaryTabRow` in ImportDebugDetailScreen
- Migrate `LocalClipboardManager` to `LocalClipboard` with suspend `setClipEntry` API
- Suppress `SwipeToDismissBox` `confirmValueChange` deprecation (requires AnchoredDraggable migration, no drop-in replacement)
- Remove unnecessary safe calls after Kotlin smart casts (3 files)
- Add missing `@Suppress("UNCHECKED_CAST")` annotation in RecipeDetailViewModel

## Test plan
- [x] `assembleDebug` builds with zero compiler warnings
- [x] `assembleRelease` builds successfully
- [x] `ci-local.sh` passes (assembleDebug, testDebugUnitTest, lintDebug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)