### PR TITLE
feat: migrate EncryptedSharedPreferences to Tink AEAD encryption

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,8 +130,8 @@ dependencies {
     // DataStore
     implementation(libs.datastore.preferences)
 
-    // Security
-    implementation(libs.security.crypto)
+    // Encryption
+    implementation(libs.tink.android)
 
     // Coil
     implementation(libs.coil.compose)

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/TinkEncryption.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/TinkEncryption.kt
@@ -1,0 +1,67 @@
+package com.lionotter.recipes.data.local
+
+import android.content.Context
+import android.util.Base64
+import android.util.Log
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.integration.android.AndroidKeysetManager
+
+/**
+ * Provides Tink AEAD encryption/decryption for sensitive data stored in DataStore.
+ * Replaces the deprecated EncryptedSharedPreferences from androidx.security:security-crypto.
+ *
+ * The Tink keyset is stored in SharedPreferences and protected by the Android Keystore.
+ */
+class TinkEncryption(context: Context) {
+
+    private val aead: Aead
+
+    init {
+        try {
+            AeadConfig.register()
+            aead = AndroidKeysetManager.Builder()
+                .withKeyTemplate(KeyTemplates.get("AES256_GCM"))
+                .withSharedPref(context, KEYSET_NAME, PREF_FILE_NAME)
+                .withMasterKeyUri(MASTER_KEY_URI)
+                .build()
+                .keysetHandle
+                .getPrimitive(Aead::class.java)
+        } catch (e: java.security.GeneralSecurityException) {
+            Log.e(TAG, "Failed to initialize Tink AEAD", e)
+            throw IllegalStateException("Tink AEAD could not be initialized", e)
+        }
+    }
+
+    /**
+     * Encrypts a plaintext string, returning a Base64-encoded ciphertext.
+     */
+    fun encrypt(plaintext: String): String {
+        val ciphertext = aead.encrypt(plaintext.toByteArray(Charsets.UTF_8), ASSOCIATED_DATA)
+        return Base64.encodeToString(ciphertext, Base64.NO_WRAP)
+    }
+
+    /**
+     * Decrypts a Base64-encoded ciphertext, returning the original plaintext string.
+     * Returns null if decryption fails (e.g. corrupted data or wrong key).
+     */
+    fun decrypt(ciphertext: String): String? {
+        return try {
+            val encrypted = Base64.decode(ciphertext, Base64.NO_WRAP)
+            val plaintext = aead.decrypt(encrypted, ASSOCIATED_DATA)
+            String(plaintext, Charsets.UTF_8)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to decrypt data", e)
+            null
+        }
+    }
+
+    companion object {
+        private const val TAG = "TinkEncryption"
+        private const val KEYSET_NAME = "tink_api_key_keyset"
+        private const val PREF_FILE_NAME = "tink_api_key_keyset_prefs"
+        private const val MASTER_KEY_URI = "android-keystore://tink_master_key"
+        private val ASSOCIATED_DATA = "api_key".toByteArray(Charsets.UTF_8)
+    }
+}

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <!-- Exclude encrypted preferences containing API key -->
-    <exclude domain="sharedpref" path="secure_settings.xml" />
-    <!-- Exclude security-crypto master key prefs -->
-    <exclude domain="sharedpref" path="__androidx_security_crypto_encrypted_prefs__.xml" />
+    <!-- Exclude Tink-encrypted API key storage -->
+    <exclude domain="sharedpref" path="tink_encrypted_api_key.xml" />
+    <!-- Exclude Tink keyset prefs (contains encrypted keyset for AEAD) -->
+    <exclude domain="sharedpref" path="tink_api_key_keyset_prefs.xml" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- Exclude encrypted preferences containing API key from cloud backups -->
-        <exclude domain="sharedpref" path="secure_settings.xml" />
-        <exclude domain="sharedpref" path="__androidx_security_crypto_encrypted_prefs__.xml" />
+        <!-- Exclude Tink-encrypted API key from cloud backups -->
+        <exclude domain="sharedpref" path="tink_encrypted_api_key.xml" />
+        <exclude domain="sharedpref" path="tink_api_key_keyset_prefs.xml" />
     </cloud-backup>
     <device-transfer>
-        <!-- Exclude encrypted preferences from device-to-device transfers -->
-        <exclude domain="sharedpref" path="secure_settings.xml" />
-        <exclude domain="sharedpref" path="__androidx_security_crypto_encrypted_prefs__.xml" />
+        <!-- Exclude Tink-encrypted API key from device-to-device transfers -->
+        <exclude domain="sharedpref" path="tink_encrypted_api_key.xml" />
+        <exclude domain="sharedpref" path="tink_api_key_keyset_prefs.xml" />
     </device-transfer>
 </data-extraction-rules>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -445,10 +445,10 @@ app: {
         label: DataStore
         shape: cylinder
       }
-      encrypted_prefs: {
-        label: EncryptedSharedPreferences
+      tink_encrypted: {
+        label: Tink Encrypted Storage
         shape: cylinder
-        tooltip: "AES256-GCM encrypted storage for sensitive data like API keys"
+        tooltip: "Google Tink AEAD (AES256-GCM) encrypted SharedPreferences for sensitive data like API keys. Keyset protected by Android Keystore."
         style: {
           fill: "#c8e6c9"
         }
@@ -480,7 +480,7 @@ app: {
       }
       settings: {
         label: SettingsDataStore
-        tooltip: "Uses EncryptedSharedPreferences for API key, DataStore for non-sensitive settings (AI model, extended thinking enabled, keep screen on, theme mode, volume/weight unit system preferences, grocery list volume/weight unit system preferences, start of week, import debugging enabled)"
+        tooltip: "Uses Tink AEAD encryption for API key, DataStore for non-sensitive settings (AI model, extended thinking enabled, keep screen on, theme mode, volume/weight unit system preferences, grocery list volume/weight unit system preferences, start of week, import debugging enabled)"
       }
 
       dao -> room
@@ -492,7 +492,7 @@ app: {
       meal_plan_dao -> room
       meal_plan_entity -> room
       settings -> datastore: non-sensitive settings
-      settings -> encrypted_prefs: API key
+      settings -> tink_encrypted: API key
     }
 
     remote: {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ ktor = "3.4.0"
 kotlinxSerialization = "1.10.0"
 kotlinxDatetime = "0.7.1"
 datastore = "1.2.0"
-securityCrypto = "1.1.0"
+tinkAndroid = "1.20.0"
 navigationCompose = "2.9.7"
 coil = "3.3.0"
 ksp = "2.3.4"
@@ -74,8 +74,8 @@ kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime",
 # DataStore
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
-# Security
-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
+# Encryption
+tink-android = { group = "com.google.crypto.tink", name = "tink-android", version.ref = "tinkAndroid" }
 
 # Coil
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }


### PR DESCRIPTION
## Summary
- Replace deprecated `androidx.security:security-crypto` (`EncryptedSharedPreferences` + `MasterKey`) with Google Tink (`com.google.crypto.tink:tink-android:1.20.0`)
- New `TinkEncryption` helper encrypts the API key using Tink's AEAD primitive (AES256-GCM), with the keyset protected by Android Keystore
- Old `EncryptedSharedPreferences` files are cleaned up on startup
- Removed `@file:Suppress("DEPRECATION")` from `SettingsDataStore.kt`
- Updated backup/extraction rules for new storage files
- Updated architecture.d2 documentation

**Note:** Users upgrading will need to re-enter their API key once, since the old encrypted storage cannot be read without the deprecated library.

Closes #258

## Test plan
- [ ] Verify app builds and all tests pass
- [ ] Verify new API key can be saved and persists across app restarts
- [ ] Verify clearing API key works
- [ ] Verify old EncryptedSharedPreferences files are cleaned up on first launch
- [ ] Verify Tink keyset and encrypted API key files are excluded from backups

🤖 Generated with [Claude Code](https://claude.com/claude-code)