### PR TITLE
feat: add manual recipe editing with AI re-parsing

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
@@ -1,0 +1,322 @@
+package com.lionotter.recipes.ui.screens.editrecipe
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Psychology
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lionotter.recipes.R
+import com.lionotter.recipes.ui.components.RecipeTopAppBar
+import com.lionotter.recipes.ui.screens.settings.components.ModelSelectionSection
+
+@Composable
+fun EditRecipeScreen(
+    onBackClick: () -> Unit,
+    onEditSuccess: () -> Unit,
+    viewModel: EditRecipeViewModel = hiltViewModel()
+) {
+    val recipe by viewModel.recipe.collectAsStateWithLifecycle()
+    val markdownText by viewModel.markdownText.collectAsStateWithLifecycle()
+    val editState by viewModel.editState.collectAsStateWithLifecycle()
+    val model by viewModel.model.collectAsStateWithLifecycle()
+    val extendedThinking by viewModel.extendedThinking.collectAsStateWithLifecycle()
+    val canRegenerate by viewModel.canRegenerate.collectAsStateWithLifecycle()
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showRegenerateConfirmDialog by remember { mutableStateOf(false) }
+
+    val isLoading = editState is EditUiState.Loading
+
+    // Handle edit result — navigate back immediately on success
+    LaunchedEffect(editState) {
+        when (editState) {
+            is EditUiState.Success -> {
+                viewModel.resetEditState()
+                onEditSuccess()
+            }
+            else -> {}
+        }
+    }
+
+    // Regenerate confirmation dialog
+    if (showRegenerateConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showRegenerateConfirmDialog = false },
+            title = { Text(stringResource(R.string.regenerate_from_original)) },
+            text = {
+                Text(
+                    text = stringResource(R.string.regenerate_from_original_description),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showRegenerateConfirmDialog = false
+                        viewModel.regenerateFromOriginal()
+                    }
+                ) {
+                    Text(stringResource(R.string.regenerate))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRegenerateConfirmDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            RecipeTopAppBar(
+                title = stringResource(R.string.edit_recipe),
+                onBackClick = if (!isLoading) onBackClick else null,
+                actions = {
+                    if (canRegenerate && !isLoading) {
+                        IconButton(
+                            onClick = { showRegenerateConfirmDialog = true }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Refresh,
+                                contentDescription = stringResource(R.string.regenerate_from_original)
+                            )
+                        }
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        when {
+            recipe == null -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            isLoading -> {
+                EditLoadingContent(
+                    progress = (editState as EditUiState.Loading).progress,
+                    onCancelClick = viewModel::cancelProcessing,
+                    modifier = Modifier.padding(paddingValues)
+                )
+            }
+            else -> {
+                EditContent(
+                    markdownText = markdownText,
+                    onMarkdownChange = viewModel::setMarkdownText,
+                    model = model,
+                    onModelChange = viewModel::setModel,
+                    extendedThinking = extendedThinking,
+                    onExtendedThinkingChange = viewModel::setExtendedThinking,
+                    editState = editState,
+                    onSave = viewModel::saveEdits,
+                    onCancel = onBackClick,
+                    modifier = Modifier.padding(paddingValues)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EditLoadingContent(
+    progress: String,
+    onCancelClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.Psychology,
+            contentDescription = progress,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        CircularProgressIndicator()
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = progress,
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = stringResource(R.string.may_take_a_moment),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        ) {
+            Text(
+                text = stringResource(R.string.edit_background_notice),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        TextButton(onClick = onCancelClick) {
+            Text(stringResource(R.string.cancel_edit))
+        }
+    }
+}
+
+@Composable
+private fun EditContent(
+    markdownText: String,
+    onMarkdownChange: (String) -> Unit,
+    model: String,
+    onModelChange: (String) -> Unit,
+    extendedThinking: Boolean,
+    onExtendedThinkingChange: (Boolean) -> Unit,
+    editState: EditUiState,
+    onSave: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
+    ) {
+        // Scrollable content area
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.edit_recipe_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            OutlinedTextField(
+                value = markdownText,
+                onValueChange = onMarkdownChange,
+                modifier = Modifier.fillMaxWidth(),
+                textStyle = TextStyle(
+                    fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                    fontSize = 14.sp
+                ),
+                minLines = 15,
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Sentences
+                )
+            )
+
+            ModelSelectionSection(
+                currentModel = model,
+                onModelChange = onModelChange,
+                extendedThinkingEnabled = extendedThinking,
+                onExtendedThinkingChange = onExtendedThinkingChange
+            )
+
+            if (editState is EditUiState.Error) {
+                Text(
+                    text = editState.message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+
+        // Bottom action bar
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End)
+        ) {
+            OutlinedButton(onClick = onCancel) {
+                Text(stringResource(R.string.cancel))
+            }
+            Button(
+                onClick = onSave,
+                enabled = markdownText.isNotBlank()
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Save,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Text(
+                    text = stringResource(R.string.save),
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeViewModel.kt
@@ -1,0 +1,251 @@
+package com.lionotter.recipes.ui.screens.editrecipe
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.lionotter.recipes.data.local.SettingsDataStore
+import com.lionotter.recipes.data.remote.AnthropicService
+import com.lionotter.recipes.data.repository.RecipeRepository
+import com.lionotter.recipes.domain.model.Recipe
+import com.lionotter.recipes.domain.util.RecipeMarkdownFormatter
+import com.lionotter.recipes.worker.RecipeEditWorker
+import com.lionotter.recipes.worker.RecipeRegenerateWorker
+import com.lionotter.recipes.worker.observeWorkByTag
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+sealed class EditUiState {
+    object Idle : EditUiState()
+    data class Loading(val progress: String) : EditUiState()
+    object Success : EditUiState()
+    data class Error(val message: String) : EditUiState()
+}
+
+@HiltViewModel
+class EditRecipeViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val recipeRepository: RecipeRepository,
+    private val settingsDataStore: SettingsDataStore,
+    private val workManager: WorkManager
+) : ViewModel() {
+
+    private val recipeId: String = savedStateHandle.get<String>("recipeId")
+        ?: throw IllegalArgumentException("EditRecipeViewModel requires a 'recipeId' argument in SavedStateHandle")
+
+    val recipe: StateFlow<Recipe?> = recipeRepository.getRecipeById(recipeId)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = null
+        )
+
+    private val _markdownText = MutableStateFlow("")
+    val markdownText: StateFlow<String> = _markdownText.asStateFlow()
+
+    private val _editState = MutableStateFlow<EditUiState>(EditUiState.Idle)
+    val editState: StateFlow<EditUiState> = _editState.asStateFlow()
+
+    private val _model = MutableStateFlow(AnthropicService.DEFAULT_MODEL)
+    val model: StateFlow<String> = _model.asStateFlow()
+
+    private val _extendedThinking = MutableStateFlow(true)
+    val extendedThinking: StateFlow<Boolean> = _extendedThinking.asStateFlow()
+
+    private val _hasOriginalHtml = MutableStateFlow(false)
+    val hasOriginalHtml: StateFlow<Boolean> = _hasOriginalHtml.asStateFlow()
+
+    /**
+     * Whether regeneration from original source is available.
+     * True if the recipe has cached original HTML or a source URL to re-fetch from.
+     */
+    val canRegenerate: StateFlow<Boolean> = combine(
+        _hasOriginalHtml,
+        recipe
+    ) { hasHtml, recipe ->
+        hasHtml || !recipe?.sourceUrl.isNullOrBlank()
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = false
+    )
+
+    private var currentEditWorkId: UUID? = null
+    private var currentRegenerateWorkId: UUID? = null
+
+    fun setMarkdownText(text: String) {
+        _markdownText.value = text
+    }
+
+    fun setModel(model: String) {
+        _model.value = model
+    }
+
+    fun setExtendedThinking(enabled: Boolean) {
+        _extendedThinking.value = enabled
+    }
+
+    fun resetEditState() {
+        _editState.value = EditUiState.Idle
+    }
+
+    fun cancelProcessing() {
+        currentEditWorkId?.let { workManager.cancelWorkById(it) }
+        currentRegenerateWorkId?.let { workManager.cancelWorkById(it) }
+    }
+
+    /**
+     * Save the edited markdown by sending it through AI for re-parsing.
+     */
+    fun saveEdits() {
+        val workRequest = OneTimeWorkRequestBuilder<RecipeEditWorker>()
+            .setInputData(
+                RecipeEditWorker.createInputData(
+                    recipeId = recipeId,
+                    markdownText = _markdownText.value,
+                    model = _model.value,
+                    extendedThinking = _extendedThinking.value
+                )
+            )
+            .addTag(RecipeEditWorker.TAG_RECIPE_EDIT)
+            .build()
+
+        currentEditWorkId = workRequest.id
+        workManager.enqueue(workRequest)
+        _editState.value = EditUiState.Loading("Preparing...")
+    }
+
+    /**
+     * Regenerate the recipe from the original source HTML/URL.
+     */
+    fun regenerateFromOriginal() {
+        val workRequest = OneTimeWorkRequestBuilder<RecipeRegenerateWorker>()
+            .setInputData(
+                RecipeRegenerateWorker.createInputData(
+                    recipeId = recipeId,
+                    model = _model.value,
+                    extendedThinking = _extendedThinking.value
+                )
+            )
+            .addTag(RecipeRegenerateWorker.TAG_RECIPE_REGENERATE)
+            .build()
+
+        currentRegenerateWorkId = workRequest.id
+        workManager.enqueue(workRequest)
+        _editState.value = EditUiState.Loading("Preparing...")
+    }
+
+    private fun loadInitialData() {
+        viewModelScope.launch {
+            // Load settings defaults
+            _model.value = settingsDataStore.aiModel.first()
+            _extendedThinking.value = settingsDataStore.extendedThinkingEnabled.first()
+
+            // Check for original HTML
+            val html = recipeRepository.getOriginalHtml(recipeId)
+            _hasOriginalHtml.value = !html.isNullOrBlank()
+
+            // Load recipe and generate markdown (only if user hasn't started typing)
+            val currentRecipe = recipe.first { it != null } ?: return@launch
+            if (_markdownText.value.isBlank()) {
+                _markdownText.value = RecipeMarkdownFormatter.format(currentRecipe)
+            }
+        }
+    }
+
+    private fun observeEditWorkStatus() {
+        viewModelScope.launch {
+            workManager.observeWorkByTag(RecipeEditWorker.TAG_RECIPE_EDIT) { currentEditWorkId }
+                .collect { workInfo ->
+                    when (workInfo.state) {
+                        WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED -> {
+                            _editState.value = EditUiState.Loading("Preparing...")
+                        }
+                        WorkInfo.State.RUNNING -> {
+                            val progress = workInfo.progress.getString(RecipeEditWorker.KEY_PROGRESS)
+                            val message = when (progress) {
+                                RecipeEditWorker.PROGRESS_PARSING -> "AI is processing your changes..."
+                                RecipeEditWorker.PROGRESS_SAVING -> "Saving recipe..."
+                                else -> "Starting..."
+                            }
+                            _editState.value = EditUiState.Loading(message)
+                        }
+                        WorkInfo.State.SUCCEEDED -> {
+                            _editState.value = EditUiState.Success
+                            currentEditWorkId = null
+                            workManager.pruneWork()
+                        }
+                        WorkInfo.State.FAILED -> {
+                            val errorMessage = workInfo.outputData.getString(RecipeEditWorker.KEY_ERROR_MESSAGE)
+                                ?: "Unknown error"
+                            _editState.value = EditUiState.Error(errorMessage)
+                            currentEditWorkId = null
+                            workManager.pruneWork()
+                        }
+                        WorkInfo.State.CANCELLED -> {
+                            _editState.value = EditUiState.Idle
+                            currentEditWorkId = null
+                            workManager.pruneWork()
+                        }
+                    }
+                }
+        }
+    }
+
+    private fun observeRegenerateWorkStatus() {
+        viewModelScope.launch {
+            workManager.observeWorkByTag(RecipeRegenerateWorker.TAG_RECIPE_REGENERATE) { currentRegenerateWorkId }
+                .collect { workInfo ->
+                    when (workInfo.state) {
+                        WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED -> {
+                            _editState.value = EditUiState.Loading("Preparing...")
+                        }
+                        WorkInfo.State.RUNNING -> {
+                            val progress = workInfo.progress.getString(RecipeRegenerateWorker.KEY_PROGRESS)
+                            val message = when (progress) {
+                                RecipeRegenerateWorker.PROGRESS_FETCHING -> "Fetching recipe page..."
+                                RecipeRegenerateWorker.PROGRESS_PARSING -> "AI is re-analyzing..."
+                                RecipeRegenerateWorker.PROGRESS_SAVING -> "Saving recipe..."
+                                else -> "Starting..."
+                            }
+                            _editState.value = EditUiState.Loading(message)
+                        }
+                        WorkInfo.State.SUCCEEDED -> {
+                            _editState.value = EditUiState.Success
+                            currentRegenerateWorkId = null
+                            workManager.pruneWork()
+                        }
+                        WorkInfo.State.FAILED -> {
+                            val errorMessage = workInfo.outputData.getString(RecipeRegenerateWorker.KEY_ERROR_MESSAGE)
+                                ?: "Unknown error"
+                            _editState.value = EditUiState.Error(errorMessage)
+                            currentRegenerateWorkId = null
+                            workManager.pruneWork()
+                        }
+                        WorkInfo.State.CANCELLED -> {
+                            _editState.value = EditUiState.Idle
+                            currentRegenerateWorkId = null
+                            workManager.pruneWork()
+                        }
+                    }
+                }
+        }
+    }
+
+    init {
+        loadInitialData()
+        observeEditWorkStatus()
+        observeRegenerateWorkStatus()
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeEditWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeEditWorker.kt
@@ -1,0 +1,147 @@
+package com.lionotter.recipes.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.lionotter.recipes.domain.usecase.EditRecipeUseCase
+import com.lionotter.recipes.notification.RecipeNotificationHelper
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class RecipeEditWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val editRecipeUseCase: EditRecipeUseCase,
+    notificationHelper: RecipeNotificationHelper
+) : BaseRecipeWorker(context, workerParams, notificationHelper) {
+
+    override val notificationTitle = "Updating Recipe"
+
+    companion object {
+        const val TAG_RECIPE_EDIT = "recipe_edit"
+
+        const val KEY_RECIPE_ID = "recipe_id"
+        const val KEY_MARKDOWN_TEXT = "markdown_text"
+        const val KEY_MODEL = "model"
+        const val KEY_EXTENDED_THINKING = "extended_thinking"
+        const val KEY_ERROR_MESSAGE = "error_message"
+        const val KEY_PROGRESS = "progress"
+        const val KEY_RESULT_TYPE = "result_type"
+        const val KEY_RECIPE_NAME = "recipe_name"
+
+        const val RESULT_SUCCESS = "success"
+        const val RESULT_ERROR = "error"
+        const val RESULT_NO_API_KEY = "no_api_key"
+
+        const val PROGRESS_PARSING = "parsing"
+        const val PROGRESS_SAVING = "saving"
+
+        fun createInputData(
+            recipeId: String,
+            markdownText: String,
+            model: String?,
+            extendedThinking: Boolean?
+        ): Data {
+            return workDataOf(
+                KEY_RECIPE_ID to recipeId,
+                KEY_MARKDOWN_TEXT to markdownText,
+                KEY_MODEL to model,
+                KEY_EXTENDED_THINKING to extendedThinking
+            )
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        val recipeId = inputData.getString(KEY_RECIPE_ID)
+            ?: return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "No recipe ID provided"
+                )
+            )
+        val markdownText = inputData.getString(KEY_MARKDOWN_TEXT)
+            ?: return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "No markdown text provided"
+                )
+            )
+        val model = inputData.getString(KEY_MODEL)
+        val extendedThinking = if (inputData.keyValueMap.containsKey(KEY_EXTENDED_THINKING)) {
+            inputData.getBoolean(KEY_EXTENDED_THINKING, true)
+        } else {
+            null
+        }
+
+        setForegroundProgress("Updating recipe...")
+
+        val result = editRecipeUseCase.execute(
+            recipeId = recipeId,
+            markdownText = markdownText,
+            model = model,
+            extendedThinking = extendedThinking,
+            onProgress = { progress ->
+                val progressMessage = when (progress) {
+                    is EditRecipeUseCase.EditProgress.ParsingRecipe -> {
+                        setProgress(workDataOf(
+                            KEY_RECIPE_ID to recipeId,
+                            KEY_PROGRESS to PROGRESS_PARSING
+                        ))
+                        "AI is processing your changes..."
+                    }
+                    is EditRecipeUseCase.EditProgress.RecipeNameAvailable -> {
+                        setProgress(workDataOf(
+                            KEY_RECIPE_ID to recipeId,
+                            KEY_PROGRESS to PROGRESS_PARSING,
+                            KEY_RECIPE_NAME to progress.name
+                        ))
+                        "AI is processing your changes..."
+                    }
+                    is EditRecipeUseCase.EditProgress.SavingRecipe -> {
+                        setProgress(workDataOf(
+                            KEY_RECIPE_ID to recipeId,
+                            KEY_PROGRESS to PROGRESS_SAVING
+                        ))
+                        "Saving recipe..."
+                    }
+                    is EditRecipeUseCase.EditProgress.Complete -> "Complete!"
+                }
+                setForegroundProgress(progressMessage)
+            }
+        )
+
+        return when (result) {
+            is EditRecipeUseCase.EditResult.Success -> {
+                notificationHelper.showSuccessNotification(
+                    recipeName = result.recipe.name,
+                    recipeId = result.recipe.id
+                )
+                Result.success(
+                    workDataOf(
+                        KEY_RECIPE_ID to recipeId,
+                        KEY_RESULT_TYPE to RESULT_SUCCESS,
+                        KEY_RECIPE_NAME to result.recipe.name
+                    )
+                )
+            }
+            is EditRecipeUseCase.EditResult.Error -> errorResult(
+                errorNotificationTitle = "Edit Failed",
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                errorType = RESULT_ERROR,
+                errorMessage = result.message,
+                KEY_RECIPE_ID to recipeId
+            )
+            EditRecipeUseCase.EditResult.NoApiKey -> notAvailableResult(
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                resultType = RESULT_NO_API_KEY,
+                errorMessage = "API key not configured",
+                KEY_RECIPE_ID to recipeId
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,13 +54,18 @@
     <string name="remaining_amount_with_unit">%1$s %2$s left</string>
     <string name="remaining_amount">%1$s left</string>
 
+    <!-- Edit Recipe -->
+    <string name="edit_recipe">Edit Recipe</string>
+    <string name="edit_recipe_action">Edit recipe</string>
+    <string name="edit_recipe_description">Edit the recipe text below. When you save, the AI will clean up the formatting and regenerate structured data like ingredient amounts and densities.</string>
+    <string name="edit_save_success">Recipe updated successfully</string>
+    <string name="edit_background_notice">You can leave this screen. You\'ll be notified when the update is complete.</string>
+    <string name="cancel_edit">Cancel Edit</string>
+    <string name="regenerate_from_original">Regenerate from original</string>
+    <string name="regenerate_from_original_description">Re-parse this recipe from the original page content using AI. This will discard any edits you\'ve made and replace the recipe with a fresh parse from the original source.</string>
+
     <!-- Regenerate Recipe -->
-    <string name="regenerate_recipe">Regenerate Recipe</string>
-    <string name="regenerate_recipe_description">Re-parse this recipe from the original page content using AI. If the original content is not available, it will be re-fetched from the source URL. You can choose a different model or thinking mode. The current recipe will be replaced.</string>
     <string name="regenerate">Regenerate</string>
-    <string name="regenerating_recipe">Regenerating recipe\u2026</string>
-    <string name="regenerate_success">Recipe regenerated successfully</string>
-    <string name="regenerate_no_original_html">Cannot regenerate: original page content is not available for this recipe.</string>
 
     <!-- Add Recipe Screen -->
     <string name="import_recipe">Import Recipe</string>
@@ -70,6 +75,7 @@
     <string name="recipe_url_placeholder">https://example.com/recipe</string>
     <string name="api_key_required">API Key Required</string>
     <string name="api_key_required_message">You need to set up your Anthropic API key before importing recipes.</string>
+    <string name="api_key_required_for_editing">Editing a recipe requires an Anthropic API key to re-parse the changes. Please set up your API key in settings.</string>
     <string name="go_to_settings">Go to Settings</string>
     <string name="preparing_import">Preparing import\u2026</string>
     <string name="starting">Starting\u2026</string>

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.lionotter.recipes.ui.screens.recipedetail
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.work.WorkManager
 import app.cash.turbine.test
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.repository.MealPlanRepository
@@ -46,7 +45,6 @@ class RecipeDetailViewModelTest {
     private lateinit var recipeRepository: RecipeRepository
     private lateinit var mealPlanRepository: MealPlanRepository
     private lateinit var settingsDataStore: SettingsDataStore
-    private lateinit var workManager: WorkManager
     private lateinit var viewModel: RecipeDetailViewModel
     private val testDispatcher = StandardTestDispatcher()
 
@@ -71,17 +69,15 @@ class RecipeDetailViewModelTest {
         recipeRepository = mockk()
         mealPlanRepository = mockk()
         settingsDataStore = mockk()
-        workManager = mockk()
 
         // Default mock setup
         every { recipeRepository.getRecipeById("recipe-1") } returns flowOf(createTestRecipe())
-        coEvery { recipeRepository.getOriginalHtml("recipe-1") } returns null
         every { settingsDataStore.keepScreenOn } returns flowOf(true)
         every { settingsDataStore.volumeUnitSystem } returns flowOf(UnitSystem.CUSTOMARY)
         every { settingsDataStore.weightUnitSystem } returns flowOf(UnitSystem.METRIC)
         every { settingsDataStore.aiModel } returns flowOf("claude-sonnet-4-5")
         every { settingsDataStore.extendedThinkingEnabled } returns flowOf(true)
-        every { workManager.getWorkInfosByTagFlow(any()) } returns flowOf(emptyList())
+        every { settingsDataStore.anthropicApiKey } returns flowOf("test-api-key")
     }
 
     @After
@@ -96,7 +92,6 @@ class RecipeDetailViewModelTest {
             mealPlanRepository = mealPlanRepository,
             settingsDataStore = settingsDataStore,
             calculateIngredientUsage = CalculateIngredientUsageUseCase(),
-            workManager = workManager,
             exportSingleRecipeUseCase = mockk<ExportSingleRecipeUseCase>(),
             recipeSerializer = mockk<RecipeSerializer>(),
             applicationContext = mockk(relaxed = true)

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -61,7 +61,11 @@ app: {
       list: RecipeListScreen
       detail: {
         label: RecipeDetailScreen
-        tooltip: "Displays recipe details with share menu (Markdown text or .lorecipes file), regenerate, and delete buttons. Regenerate re-parses from original HTML (or re-fetches from source URL if no cached HTML) with selectable model/thinking mode. All text is selectable."
+        tooltip: "Displays recipe details with edit (pencil icon), share menu (Markdown text or .lorecipes file), favorite, and delete buttons. All text is selectable."
+      }
+      edit: {
+        label: EditRecipeScreen
+        tooltip: "Full-screen markdown editor for recipes. Shows markdown version of the recipe (same format as share-as-text). Users edit the markdown and save to have AI clean up formatting and regenerate structured data (densities, etc.). Includes model selection and extended thinking toggle. Also supports regeneration from original source via refresh icon (when original HTML or source URL is available)."
       }
       add: AddRecipeScreen
       settings: SettingsScreen
@@ -90,6 +94,7 @@ app: {
       }
 
       list -> detail: tap recipe
+      detail -> edit: tap edit (pencil icon)
       list -> add: tap +
       list -> settings: tap gear
       list -> meal_plan: tap calendar
@@ -128,6 +133,10 @@ app: {
 
       list_vm: RecipeListViewModel
       detail_vm: RecipeDetailViewModel
+      edit_vm: {
+        label: EditRecipeViewModel
+        tooltip: "Manages edit recipe screen state. Loads recipe as markdown, tracks model/thinking settings, and enqueues RecipeEditWorker for save or RecipeRegenerateWorker for regeneration from original source."
+      }
       add_vm: AddRecipeViewModel
       settings_vm: SettingsViewModel
       zip_vm: {
@@ -170,6 +179,7 @@ app: {
 
     screens.list -> viewmodels.list_vm
     screens.detail -> viewmodels.detail_vm
+    screens.edit -> viewmodels.edit_vm
     screens.add -> viewmodels.add_vm
     screens.settings -> viewmodels.settings_vm
     screens.settings -> viewmodels.zip_vm: backup/restore
@@ -210,6 +220,10 @@ app: {
         label: RecipeRegenerateWorker
         tooltip: "CoroutineWorker that re-parses a recipe from its stored original HTML using the AI. Supports selecting a different model and thinking mode. Overwrites the existing recipe, preserving ID, favorite status, and creation timestamp."
       }
+      edit_worker: {
+        label: RecipeEditWorker
+        tooltip: "CoroutineWorker that processes user-edited recipe markdown through AI re-parsing via EditRecipeUseCase. Preserves recipe metadata (ID, favorite, image, source URL, original HTML)."
+      }
       paprika_import_worker: {
         label: PaprikaImportWorker
         tooltip: "Imports recipes from a Paprika export file (.paprikarecipes). Parses ZIP of gzip-compressed JSON, sends content through AI pipeline."
@@ -224,6 +238,7 @@ app: {
       }
       import_worker -> base_worker: extends
       regenerate_worker -> base_worker: extends
+      edit_worker -> base_worker: extends
       paprika_import_worker -> base_worker: extends
       zip_export_worker -> base_worker: extends
       zip_import_worker -> base_worker: extends
@@ -247,6 +262,7 @@ app: {
 
     worker.import_worker -> notification.helper: notify progress
     worker.regenerate_worker -> notification.helper: notify progress
+    worker.edit_worker -> notification.helper: notify progress
     worker.paprika_import_worker -> notification.helper: notify progress
     worker.zip_export_worker -> notification.helper: notify progress
     worker.zip_import_worker -> notification.helper: notify progress
@@ -290,6 +306,10 @@ app: {
       regenerate: {
         label: RegenerateRecipeUseCase
         tooltip: "Re-parses a recipe from its stored original HTML via ParseHtmlUseCase.parseHtml(). If no cached HTML exists, fetches fresh HTML from the recipe's source URL via WebScraperService. Passes model/thinking overrides as parameters, preserves recipe ID, favorite status, and creation timestamp."
+      }
+      edit_recipe: {
+        label: EditRecipeUseCase
+        tooltip: "Edits a recipe by sending user-modified markdown text through ParseHtmlUseCase.parseText() for AI re-parsing. Preserves recipe ID, createdAt, favorite status, image, source URL, and original HTML (for future regeneration)."
       }
       aggregate_grocery: {
         label: AggregateGroceryListUseCase
@@ -390,6 +410,7 @@ app: {
 
     usecases.import -> usecases.parse_html: uses
     usecases.regenerate -> usecases.parse_html: uses
+    usecases.edit_recipe -> usecases.parse_html: uses
     usecases.parse_html -> data.repository.import_debug_repo: save debug data
     usecases.export_zip -> util.serializer: serialize
     usecases.export_zip -> data.remote.image_dl: read local images
@@ -583,8 +604,11 @@ app: {
   ui.viewmodels.detail_vm -> domain.usecases.calc_usage: ingredient usage
   ui.viewmodels.detail_vm -> domain.usecases.export_single: export .lorecipes
   ui.viewmodels.detail_vm -> data.local.settings: keep screen on, unit prefs
-  ui.viewmodels.detail_vm -> background.worker.regenerate_worker: regenerate
-  ui.viewmodels.detail_vm -> background.worker.work_ext: observe regenerate
+  ui.viewmodels.edit_vm -> data.repository.repo: recipe, original HTML
+  ui.viewmodels.edit_vm -> data.local.settings: model, thinking prefs
+  ui.viewmodels.edit_vm -> background.worker.edit_worker: save edits
+  ui.viewmodels.edit_vm -> background.worker.regenerate_worker: regenerate from original
+  ui.viewmodels.edit_vm -> background.worker.work_ext: observe edit/regenerate
   ui.viewmodels.import_selection_vm -> data.repository.repo: check duplicates
   ui.viewmodels.import_selection_vm -> domain.util.serializer: deserialize (for selection preview)
   ui.viewmodels.import_selection_vm -> domain.util.zip_import_helper: read ZIP contents
@@ -608,6 +632,7 @@ app: {
   ui.viewmodels.import_debug_detail_vm -> data.repository.import_debug_repo: get entry
   background.worker.import_worker -> domain.usecases.import: execute
   background.worker.regenerate_worker -> domain.usecases.regenerate: execute
+  background.worker.edit_worker -> domain.usecases.edit_recipe: execute
   background.worker.paprika_import_worker -> domain.usecases.import_paprika: execute
   background.worker.zip_export_worker -> domain.usecases.export_zip: execute
   background.worker.zip_import_worker -> domain.usecases.import_zip: execute
@@ -676,6 +701,21 @@ legend: {
   pap5: "5. Repository saves each parsed recipe to Room"
 
   pap1 -> pap2 -> pap3 -> pap4 -> pap5
+
+  edit_flow: {
+    label: "Recipe Edit Flow"
+    style: {
+      font-size: 14
+      bold: true
+    }
+  }
+  edit1: "1. User taps edit (pencil icon) on recipe detail screen"
+  edit2: "2. EditRecipeScreen shows markdown of recipe (same as share-as-text)"
+  edit3: "3. User edits markdown, selects model/thinking, taps Save"
+  edit4: "4. RecipeEditWorker sends markdown to AI via EditRecipeUseCase"
+  edit5: "5. AI re-parses into structured recipe, preserving ID/metadata"
+
+  edit1 -> edit2 -> edit3 -> edit4 -> edit5
 
   share_flow: {
     label: "Recipe Sharing Flow"


### PR DESCRIPTION
## Summary
- Replace the regenerate button in recipe detail with an edit button (pencil icon) that opens a full-screen markdown editor
- Users can edit the recipe text and save to have AI clean up formatting and regenerate structured data (ingredient amounts, densities, etc.)
- The edit screen includes model selection and extended thinking toggle (previously only in the regenerate dialog)
- Regeneration from original source is still available via a refresh icon in the edit screen's top bar when original HTML or source URL exists
- Removed unused regeneration code from RecipeDetailViewModel

## New components
- `EditRecipeUseCase`: sends edited markdown through `ParseHtmlUseCase.parseText()` for AI re-parsing, preserving recipe metadata
- `RecipeEditWorker`: background worker for AI processing of edited recipes
- `EditRecipeViewModel`: manages edit screen state (markdown text, model/thinking settings, work observation)
- `EditRecipeScreen`: full-screen markdown editor with model selection, extended thinking toggle, and save/cancel buttons

## Test plan
- [x] CI checks pass (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Open a recipe, verify edit (pencil) icon appears in the top bar
- [ ] Tap edit to navigate to edit screen showing markdown of the recipe
- [ ] Verify model selection and extended thinking toggle are present
- [ ] Edit the markdown text and tap Save — verify AI processes and updates the recipe
- [ ] For recipes with original HTML/source URL, verify the refresh icon appears in the edit screen and can regenerate from original
- [ ] Verify back/cancel returns to recipe detail without changes

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)