### PR TITLE
fix: harden Firestore callbackFlow error handling and simplify queries

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/dto/MealPlanDto.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/dto/MealPlanDto.kt
@@ -2,7 +2,6 @@ package com.lionotter.recipes.data.remote.dto
 
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentId
-import com.google.firebase.firestore.ServerTimestamp
 import com.lionotter.recipes.domain.model.MealPlanEntry
 import com.lionotter.recipes.domain.model.MealType
 import kotlin.time.Instant
@@ -16,8 +15,8 @@ data class MealPlanDto(
     val date: String = "",
     val mealType: String = "",
     val servings: Double = 1.0,
-    @ServerTimestamp val createdAt: Timestamp? = null,
-    @ServerTimestamp val updatedAt: Timestamp? = null
+    val createdAt: Timestamp? = null,
+    val updatedAt: Timestamp? = null
 ) {
     fun toDomain(): MealPlanEntry = MealPlanEntry(
         id = id,

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/dto/RecipeDto.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/dto/RecipeDto.kt
@@ -3,7 +3,6 @@ package com.lionotter.recipes.data.remote.dto
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentId
 import com.google.firebase.firestore.PropertyName
-import com.google.firebase.firestore.ServerTimestamp
 import com.lionotter.recipes.domain.model.Amount
 import com.lionotter.recipes.domain.model.Ingredient
 import com.lionotter.recipes.domain.model.InstructionSection
@@ -24,8 +23,8 @@ data class RecipeDto(
     val totalTime: String? = null,
     @get:PropertyName("isFavorite") @set:PropertyName("isFavorite")
     var isFavorite: Boolean = false,
-    @ServerTimestamp val createdAt: Timestamp? = null,
-    @ServerTimestamp val updatedAt: Timestamp? = null,
+    val createdAt: Timestamp? = null,
+    val updatedAt: Timestamp? = null,
     val tags: List<String> = emptyList(),
     val equipment: List<String> = emptyList(),
     val instructionSections: List<InstructionSectionDto> = emptyList()

--- a/app/src/test/kotlin/com/lionotter/recipes/integration/RecipeCrudIntegrationTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/integration/RecipeCrudIntegrationTest.kt
@@ -120,15 +120,9 @@ class RecipeCrudIntegrationTest : FirestoreIntegrationTest() {
     }
 
     @Test
-    fun `multiple recipes are returned ordered by updatedAt desc`() = runTest {
-        val recipe1 = createTestRecipe(
-            id = "recipe-1",
-            name = "Older Recipe"
-        ).copy(updatedAt = Instant.fromEpochMilliseconds(1000))
-        val recipe2 = createTestRecipe(
-            id = "recipe-2",
-            name = "Newer Recipe"
-        ).copy(updatedAt = Instant.fromEpochMilliseconds(2000))
+    fun `multiple recipes are all returned`() = runTest {
+        val recipe1 = createTestRecipe(id = "recipe-1", name = "Recipe A")
+        val recipe2 = createTestRecipe(id = "recipe-2", name = "Recipe B")
 
         recipeRepository.saveRecipe(recipe1)
         recipeRepository.saveRecipe(recipe2)
@@ -139,8 +133,9 @@ class RecipeCrudIntegrationTest : FirestoreIntegrationTest() {
             pumpLooper()
             val recipes = turbine.awaitItem()
             assertEquals(2, recipes.size)
-            assertEquals("Newer Recipe", recipes[0].name)
-            assertEquals("Older Recipe", recipes[1].name)
+            val names = recipes.map { it.name }.toSet()
+            assertTrue(names.contains("Recipe A"))
+            assertTrue(names.contains("Recipe B"))
             turbine.cancelAndIgnoreRemainingEvents()
         }
     }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -540,7 +540,7 @@ app: {
 
       recipe_dto: {
         label: RecipeDto
-        tooltip: "Firestore DTO for recipes. Uses @DocumentId, @ServerTimestamp, Long for integers. Includes toDomain() and Recipe.toDto() converters."
+        tooltip: "Firestore DTO for recipes. Uses @DocumentId, client-set timestamps, Long for integers. Includes toDomain() and Recipe.toDto() converters."
       }
       meal_plan_dto: {
         label: MealPlanDto


### PR DESCRIPTION
## Summary

Addresses remaining issues found during audit of the Firestore migration code (on top of PR #262):

- **Close callbackFlows on listener errors** instead of silently returning — the previous pattern (`return@addSnapshotListener`) left Flows suspended indefinitely, causing infinite spinners when any listener error occurred
- **Wrap `requireUid()` calls in try/catch** inside callbackFlows so auth failures are logged and the Flow closes with an error instead of crashing silently into `stateIn`'s internal machinery
- **Add `.conflate()`** to all callbackFlows so collectors always get the latest snapshot without backpressure stalls
- **Remove `orderBy("updatedAt")`** from `getAllRecipes()` — the UI sorts recipes its own way via `RecipeListViewModel.SortState`, so the Firestore-side ordering was unnecessary and required a composite index that could silently fail
- **Replace `@ServerTimestamp` with client-set timestamps** — `@ServerTimestamp` only fills null values on `.set()` and behaves unpredictably offline; using client-set `Timestamp` values from `toDto()` is simpler and works reliably offline

## Root cause analysis

The infinite spinner after favoriting was most likely caused by the callbackFlow error handling bug: when a Firestore snapshot listener received an error, the code logged it and returned from the lambda, but **never closed the Flow**. This left the downstream `StateFlow` (via `stateIn`) permanently suspended at its initial value (`null` for recipe detail, `emptyList()` for recipe list). Since the UI shows `CircularProgressIndicator` when `recipe == null`, this manifested as an infinite spinner.

## Test plan

- [x] `./ci-local.sh` passes (assembleDebug, testDebugUnitTest, lintDebug)
- [x] Updated `RecipeCrudIntegrationTest` to no longer assert ordering by `updatedAt` (since query no longer orders)
- [x] All existing integration tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*This comment was written by Claude.*