### PR TITLE
feat: add user notes section to recipe detail

### DIFF
--- a/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/11.json
+++ b/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/11.json
@@ -1,0 +1,353 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "edc96ed71a221a1403a9d3173ce9cb3b",
+    "entities": [
+      {
+        "tableName": "recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sourceUrl` TEXT, `story` TEXT, `servings` INTEGER, `prepTime` TEXT, `cookTime` TEXT, `totalTime` TEXT, `ingredientSectionsJson` TEXT NOT NULL, `instructionSectionsJson` TEXT NOT NULL, `equipmentJson` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `imageUrl` TEXT, `sourceImageUrl` TEXT, `originalHtml` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, `userNotes` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "story",
+            "columnName": "story",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "prepTime",
+            "columnName": "prepTime",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cookTime",
+            "columnName": "cookTime",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalTime",
+            "columnName": "totalTime",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ingredientSectionsJson",
+            "columnName": "ingredientSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructionSectionsJson",
+            "columnName": "instructionSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipmentJson",
+            "columnName": "equipmentJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userNotes",
+            "columnName": "userNotes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "import_debug",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceUrl` TEXT, `originalHtml` TEXT, `cleanedContent` TEXT, `aiOutputJson` TEXT, `originalLength` INTEGER NOT NULL, `cleanedLength` INTEGER NOT NULL, `inputTokens` INTEGER, `outputTokens` INTEGER, `aiModel` TEXT, `thinkingEnabled` INTEGER NOT NULL, `recipeId` TEXT, `recipeName` TEXT, `errorMessage` TEXT, `isError` INTEGER NOT NULL, `durationMs` INTEGER, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cleanedContent",
+            "columnName": "cleanedContent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aiOutputJson",
+            "columnName": "aiOutputJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLength",
+            "columnName": "originalLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanedLength",
+            "columnName": "cleanedLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "aiModel",
+            "columnName": "aiModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thinkingEnabled",
+            "columnName": "thinkingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recipeName",
+            "columnName": "recipeName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isError",
+            "columnName": "isError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "pending_imports",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `name` TEXT, `imageUrl` TEXT, `status` TEXT NOT NULL, `workManagerId` TEXT, `errorMessage` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workManagerId",
+            "columnName": "workManagerId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "meal_plans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `recipeId` TEXT NOT NULL, `recipeName` TEXT NOT NULL, `recipeImageUrl` TEXT, `date` TEXT NOT NULL, `mealType` TEXT NOT NULL, `servings` REAL NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeName",
+            "columnName": "recipeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeImageUrl",
+            "columnName": "recipeImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealType",
+            "columnName": "mealType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'edc96ed71a221a1403a9d3173ce9cb3b')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDao.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -38,4 +39,7 @@ interface RecipeDao {
 
     @Query("UPDATE recipes SET isFavorite = :isFavorite WHERE id = :id")
     suspend fun setFavorite(id: String, isFavorite: Boolean)
+
+    @Query("UPDATE recipes SET userNotes = :userNotes, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun setUserNotes(id: String, userNotes: String?, updatedAt: Instant)
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
@@ -8,7 +8,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [RecipeEntity::class, ImportDebugEntity::class, PendingImportEntity::class, MealPlanEntity::class],
-    version = 10,
+    version = 11,
     exportSchema = true
 )
 @TypeConverters(InstantConverter::class)
@@ -115,6 +115,12 @@ abstract class RecipeDatabase : RoomDatabase() {
          * First purges any soft-deleted rows, then recreates the tables without
          * the deleted column.
          */
+        val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE recipes ADD COLUMN userNotes TEXT")
+            }
+        }
+
         val MIGRATION_9_10 = object : Migration(9, 10) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // Purge soft-deleted rows before dropping the column

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeEntity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeEntity.kt
@@ -26,7 +26,8 @@ data class RecipeEntity(
     val originalHtml: String?,
     val createdAt: Instant,
     val updatedAt: Instant,
-    val isFavorite: Boolean = false
+    val isFavorite: Boolean = false,
+    val userNotes: String? = null
 ) {
     fun toRecipe(
         instructionSections: List<InstructionSection>,
@@ -49,7 +50,8 @@ data class RecipeEntity(
             sourceImageUrl = sourceImageUrl,
             createdAt = createdAt,
             updatedAt = updatedAt,
-            isFavorite = isFavorite
+            isFavorite = isFavorite,
+            userNotes = userNotes
         )
     }
 
@@ -79,7 +81,8 @@ data class RecipeEntity(
                 originalHtml = originalHtml,
                 createdAt = recipe.createdAt,
                 updatedAt = recipe.updatedAt,
-                isFavorite = recipe.isFavorite
+                isFavorite = recipe.isFavorite,
+                userNotes = recipe.userNotes
             )
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
@@ -81,6 +81,10 @@ class RecipeRepository @Inject constructor(
         recipeDao.setFavorite(id, isFavorite)
     }
 
+    suspend fun setUserNotes(id: String, userNotes: String?) {
+        recipeDao.setUserNotes(id, userNotes, kotlin.time.Clock.System.now())
+    }
+
     suspend fun getAllRecipeIdsAndNames(): List<RecipeIdAndName> {
         return recipeDao.getAllRecipeIdsAndNames()
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
@@ -37,7 +37,8 @@ object DatabaseModule {
                 RecipeDatabase.MIGRATION_6_7,
                 RecipeDatabase.MIGRATION_7_8,
                 RecipeDatabase.MIGRATION_8_9,
-                RecipeDatabase.MIGRATION_9_10
+                RecipeDatabase.MIGRATION_9_10,
+                RecipeDatabase.MIGRATION_10_11
             )
             .build()
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/model/Recipe.kt
@@ -33,7 +33,8 @@ data class Recipe(
     val sourceImageUrl: String? = null,
     val createdAt: Instant,
     val updatedAt: Instant,
-    val isFavorite: Boolean = false
+    val isFavorite: Boolean = false,
+    val userNotes: String? = null
 ) {
     /**
      * Aggregates all ingredients from all steps across all instruction sections.

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/EditRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/EditRecipeUseCase.kt
@@ -85,7 +85,8 @@ class EditRecipeUseCase @Inject constructor(
                     isFavorite = existingRecipe.isFavorite,
                     sourceUrl = existingRecipe.sourceUrl,
                     imageUrl = parseResult.recipe.imageUrl ?: existingRecipe.imageUrl,
-                    sourceImageUrl = parseResult.recipe.sourceImageUrl ?: existingRecipe.sourceImageUrl
+                    sourceImageUrl = parseResult.recipe.sourceImageUrl ?: existingRecipe.sourceImageUrl,
+                    userNotes = existingRecipe.userNotes
                 )
 
                 onProgress(EditProgress.SavingRecipe)

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/RegenerateRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/RegenerateRecipeUseCase.kt
@@ -99,7 +99,8 @@ class RegenerateRecipeUseCase @Inject constructor(
                     updatedAt = Clock.System.now(),
                     isFavorite = existingRecipe.isFavorite,
                     sourceUrl = existingRecipe.sourceUrl,
-                    imageUrl = parseResult.recipe.imageUrl ?: existingRecipe.imageUrl
+                    imageUrl = parseResult.recipe.imageUrl ?: existingRecipe.imageUrl,
+                    userNotes = existingRecipe.userNotes
                 )
 
                 onProgress(RegenerateProgress.SavingRecipe)

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeMarkdownFormatter.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeMarkdownFormatter.kt
@@ -72,6 +72,14 @@ object RecipeMarkdownFormatter {
         appendLine("## Instructions")
         appendLine()
         formatInstructionSections(recipe.instructionSections)
+
+        // User notes section
+        recipe.userNotes?.let { notes ->
+            appendLine()
+            appendLine("## Notes")
+            appendLine()
+            appendLine(notes)
+        }
     }
 
     private fun StringBuilder.formatIngredientSections(sections: List<IngredientSection>) {

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailScreen.kt
@@ -259,6 +259,7 @@ fun RecipeDetailScreen(
                     onToggleInstructionIngredient = viewModel::toggleInstructionIngredientUsed,
                     highlightedInstructionStep = highlightedInstructionStep,
                     onToggleHighlightedInstruction = viewModel::toggleHighlightedInstructionStep,
+                    onSaveNotes = viewModel::saveUserNotes,
                     volumeUnitSystem = volumeUnitSystem,
                     weightUnitSystem = weightUnitSystem,
                     modifier = Modifier.padding(paddingValues)

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/RecipeDetailViewModel.kt
@@ -253,6 +253,19 @@ class RecipeDetailViewModel @Inject constructor(
         }
     }
 
+    // --- User Notes ---
+
+    /**
+     * Saves user notes for the current recipe.
+     * Pass null or empty string to clear notes.
+     */
+    fun saveUserNotes(notes: String?) {
+        viewModelScope.launch {
+            val normalizedNotes = notes?.takeIf { it.isNotBlank() }
+            recipeRepository.setUserNotes(recipeId, normalizedNotes)
+        }
+    }
+
     // --- Recipe Export ---
 
     private val _exportedFileUri = MutableSharedFlow<Uri>()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="servings_label">Servings: %1$s</string>
     <string name="remaining_amount_with_unit">%1$s %2$s left</string>
     <string name="remaining_amount">%1$s left</string>
+    <string name="notes">Notes</string>
+    <string name="add_notes">Add notes\u2026</string>
 
     <!-- Edit Recipe -->
     <string name="edit_recipe">Edit Recipe</string>

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/integration/RecipeFlowUiTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/integration/RecipeFlowUiTest.kt
@@ -192,7 +192,8 @@ class RecipeFlowUiTest {
                     ingredientUsageBySection = emptyMap(),
                     onToggleInstructionIngredient = { _, _, _ -> },
                     highlightedInstructionStep = null,
-                    onToggleHighlightedInstruction = { _, _ -> }
+                    onToggleHighlightedInstruction = { _, _ -> },
+                    onSaveNotes = {}
                 )
             }
         }
@@ -476,7 +477,8 @@ class RecipeFlowUiTest {
                         ingredientUsageBySection = emptyMap(),
                         onToggleInstructionIngredient = { _, _, _ -> },
                         highlightedInstructionStep = null,
-                        onToggleHighlightedInstruction = { _, _ -> }
+                        onToggleHighlightedInstruction = { _, _ -> },
+                        onSaveNotes = {}
                     )
                 }
             }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -61,7 +61,7 @@ app: {
       list: RecipeListScreen
       detail: {
         label: RecipeDetailScreen
-        tooltip: "Displays recipe details with edit (pencil icon), share menu (Markdown text or .lorecipes file), favorite, and delete buttons. All text is selectable."
+        tooltip: "Displays recipe details with edit (pencil icon), share menu (Markdown text or .lorecipes file), favorite, and delete buttons. All text is selectable. Includes editable user notes section with auto-save."
       }
       edit: {
         label: EditRecipeScreen
@@ -355,7 +355,7 @@ app: {
 
       recipe: {
         label: Recipe
-        tooltip: "@Immutable. Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, equipment, tags, imageUrl (local file:// URI), sourceImageUrl (original remote URL), timestamps, isFavorite"
+        tooltip: "@Immutable. Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, equipment, tags, imageUrl (local file:// URI), sourceImageUrl (original remote URL), timestamps, isFavorite, userNotes (free-form user notes, preserved across AI edits/regeneration, included in markdown sent to AI)"
       }
       ingredient: {
         label: Ingredient
@@ -477,7 +477,7 @@ app: {
       dao: RecipeDao
       entity: {
         label: RecipeEntity
-        tooltip: "Room entity for recipes: id, name, sourceUrl, story, servings, times, JSON fields, imageUrl (local file:// URI), originalHtml, createdAt, updatedAt, isFavorite"
+        tooltip: "Room entity for recipes: id, name, sourceUrl, story, servings, times, JSON fields, imageUrl (local file:// URI), originalHtml, createdAt, updatedAt, isFavorite, userNotes"
       }
       import_debug_dao: ImportDebugDao
       pending_import_dao: PendingImportDao


### PR DESCRIPTION
## Summary
- Adds a free-form user notes field to recipes, displayed as an editable text section at the end of the recipe detail screen
- Notes auto-save after 1 second of inactivity or when the field loses focus
- Notes are preserved across AI edits and regeneration (never overwritten by AI)
- Notes are included in the markdown sent to the AI when editing recipes, so the AI can account for user annotations
- Notes are included in markdown export (share as text) and .lorecipes export

## Changes
- **Domain model**: Added `userNotes: String?` field to `Recipe`
- **Database**: Added `userNotes` column to `RecipeEntity` with migration 10→11
- **DAO/Repository**: Added `setUserNotes()` method for efficient direct updates
- **Use cases**: `EditRecipeUseCase` and `RegenerateRecipeUseCase` now preserve `userNotes` across AI re-parsing
- **Formatter**: `RecipeMarkdownFormatter` includes notes in markdown output (used for AI editing and sharing)
- **UI**: Added editable notes section to `RecipeContent` with debounced auto-save
- **Architecture**: Updated `architecture.d2` to document the new field

## Test plan
- [x] CI passes (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Verify notes section appears at end of recipe detail screen
- [ ] Verify typing notes and leaving the field saves them
- [ ] Verify notes persist when navigating away and returning
- [ ] Verify editing a recipe (AI re-parse) preserves existing notes
- [ ] Verify regenerating a recipe preserves existing notes
- [ ] Verify sharing as text includes notes in markdown
- [ ] Verify .lorecipes export/import includes notes

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)