### PR TITLE
feat: add save as copy button to recipe edit screen

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
@@ -170,6 +170,12 @@ fun NavGraph(
                         ?.savedStateHandle
                         ?.set("edit_success", true)
                     navigateBack()
+                },
+                onCopySuccess = { newRecipeId ->
+                    // Navigate to the new recipe, clearing the edit screen from the back stack
+                    navController.navigate(Screen.RecipeDetail.createRoute(newRecipeId)) {
+                        popUpTo(Screen.RecipeDetail.route) { inclusive = false }
+                    }
                 }
             )
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Psychology
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -57,6 +58,7 @@ import com.lionotter.recipes.ui.screens.settings.components.ModelSelectionSectio
 fun EditRecipeScreen(
     onBackClick: () -> Unit,
     onEditSuccess: () -> Unit,
+    onCopySuccess: (newRecipeId: String) -> Unit,
     viewModel: EditRecipeViewModel = hiltViewModel()
 ) {
     val recipe by viewModel.recipe.collectAsStateWithLifecycle()
@@ -75,8 +77,13 @@ fun EditRecipeScreen(
     LaunchedEffect(editState) {
         when (editState) {
             is EditUiState.Success -> {
+                val newRecipeId = (editState as EditUiState.Success).newRecipeId
                 viewModel.resetEditState()
-                onEditSuccess()
+                if (newRecipeId != null) {
+                    onCopySuccess(newRecipeId)
+                } else {
+                    onEditSuccess()
+                }
             }
             else -> {}
         }
@@ -160,6 +167,7 @@ fun EditRecipeScreen(
                     onExtendedThinkingChange = viewModel::setExtendedThinking,
                     editState = editState,
                     onSave = viewModel::saveEdits,
+                    onSaveAsCopy = viewModel::saveAsCopy,
                     onCancel = onBackClick,
                     modifier = Modifier.padding(paddingValues)
                 )
@@ -241,6 +249,7 @@ private fun EditContent(
     onExtendedThinkingChange: (Boolean) -> Unit,
     editState: EditUiState,
     onSave: () -> Unit,
+    onSaveAsCopy: () -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -302,6 +311,20 @@ private fun EditContent(
         ) {
             OutlinedButton(onClick = onCancel) {
                 Text(stringResource(R.string.cancel))
+            }
+            OutlinedButton(
+                onClick = onSaveAsCopy,
+                enabled = markdownText.isNotBlank()
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ContentCopy,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Text(
+                    text = stringResource(R.string.save_as_copy),
+                    modifier = Modifier.padding(start = 8.dp)
+                )
             }
             Button(
                 onClick = onSave,

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeEditWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeEditWorker.kt
@@ -27,10 +27,12 @@ class RecipeEditWorker @AssistedInject constructor(
         const val KEY_MARKDOWN_TEXT = "markdown_text"
         const val KEY_MODEL = "model"
         const val KEY_EXTENDED_THINKING = "extended_thinking"
+        const val KEY_SAVE_AS_COPY = "save_as_copy"
         const val KEY_ERROR_MESSAGE = "error_message"
         const val KEY_PROGRESS = "progress"
         const val KEY_RESULT_TYPE = "result_type"
         const val KEY_RECIPE_NAME = "recipe_name"
+        const val KEY_NEW_RECIPE_ID = "new_recipe_id"
 
         const val RESULT_SUCCESS = "success"
         const val RESULT_ERROR = "error"
@@ -43,13 +45,15 @@ class RecipeEditWorker @AssistedInject constructor(
             recipeId: String,
             markdownText: String,
             model: String?,
-            extendedThinking: Boolean?
+            extendedThinking: Boolean?,
+            saveAsCopy: Boolean = false
         ): Data {
             return workDataOf(
                 KEY_RECIPE_ID to recipeId,
                 KEY_MARKDOWN_TEXT to markdownText,
                 KEY_MODEL to model,
-                KEY_EXTENDED_THINKING to extendedThinking
+                KEY_EXTENDED_THINKING to extendedThinking,
+                KEY_SAVE_AS_COPY to saveAsCopy
             )
         }
     }
@@ -75,12 +79,14 @@ class RecipeEditWorker @AssistedInject constructor(
         } else {
             null
         }
+        val saveAsCopy = inputData.getBoolean(KEY_SAVE_AS_COPY, false)
 
-        setForegroundProgress("Updating recipe...")
+        setForegroundProgress(if (saveAsCopy) "Saving copy..." else "Updating recipe...")
 
         val result = editRecipeUseCase.execute(
             recipeId = recipeId,
             markdownText = markdownText,
+            saveAsCopy = saveAsCopy,
             model = model,
             extendedThinking = extendedThinking,
             onProgress = { progress ->
@@ -123,7 +129,8 @@ class RecipeEditWorker @AssistedInject constructor(
                     workDataOf(
                         KEY_RECIPE_ID to recipeId,
                         KEY_RESULT_TYPE to RESULT_SUCCESS,
-                        KEY_RECIPE_NAME to result.recipe.name
+                        KEY_RECIPE_NAME to result.recipe.name,
+                        KEY_NEW_RECIPE_ID to if (saveAsCopy) result.recipe.id else null
                     )
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="edit_recipe_action">Edit recipe</string>
     <string name="edit_recipe_description">Edit the recipe text below. When you save, the AI will clean up the formatting and regenerate structured data like ingredient amounts and densities.</string>
     <string name="edit_save_success">Recipe updated successfully</string>
+    <string name="save_as_copy">Save as Copy</string>
     <string name="edit_background_notice">You can leave this screen. You\'ll be notified when the update is complete.</string>
     <string name="cancel_edit">Cancel Edit</string>
     <string name="regenerate_from_original">Regenerate from original</string>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -65,7 +65,7 @@ app: {
       }
       edit: {
         label: EditRecipeScreen
-        tooltip: "Full-screen markdown editor for recipes. Shows markdown version of the recipe (same format as share-as-text). Users edit the markdown and save to have AI clean up formatting and regenerate structured data (densities, etc.). Includes model selection and extended thinking toggle. Also supports regeneration from original source via refresh icon (when original HTML or source URL is available)."
+        tooltip: "Full-screen markdown editor for recipes. Shows markdown version of the recipe (same format as share-as-text). Users edit the markdown and save to have AI clean up formatting and regenerate structured data (densities, etc.). Includes model selection and extended thinking toggle. Also supports regeneration from original source via refresh icon (when original HTML or source URL is available). Save as Copy creates a new recipe from the edited markdown instead of updating the existing one."
       }
       add: AddRecipeScreen
       settings: SettingsScreen
@@ -135,7 +135,7 @@ app: {
       detail_vm: RecipeDetailViewModel
       edit_vm: {
         label: EditRecipeViewModel
-        tooltip: "Manages edit recipe screen state. Loads recipe as markdown, tracks model/thinking settings, and enqueues RecipeEditWorker for save or RecipeRegenerateWorker for regeneration from original source."
+        tooltip: "Manages edit recipe screen state. Loads recipe as markdown, tracks model/thinking settings, and enqueues RecipeEditWorker for save (or save as copy) or RecipeRegenerateWorker for regeneration from original source."
       }
       add_vm: AddRecipeViewModel
       settings_vm: SettingsViewModel
@@ -222,7 +222,7 @@ app: {
       }
       edit_worker: {
         label: RecipeEditWorker
-        tooltip: "CoroutineWorker that processes user-edited recipe markdown through AI re-parsing via EditRecipeUseCase. Preserves recipe metadata (ID, favorite, image, source URL, original HTML)."
+        tooltip: "CoroutineWorker that processes user-edited recipe markdown through AI re-parsing via EditRecipeUseCase. Preserves recipe metadata (ID, favorite, image, source URL, original HTML). Supports save-as-copy mode which creates a new recipe with a fresh ID."
       }
       paprika_import_worker: {
         label: PaprikaImportWorker
@@ -309,7 +309,7 @@ app: {
       }
       edit_recipe: {
         label: EditRecipeUseCase
-        tooltip: "Edits a recipe by sending user-modified markdown text through ParseHtmlUseCase.parseText() for AI re-parsing. Preserves recipe ID, createdAt, favorite status, image, source URL, and original HTML (for future regeneration)."
+        tooltip: "Edits a recipe by sending user-modified markdown text through ParseHtmlUseCase.parseText() for AI re-parsing. Preserves recipe ID, createdAt, favorite status, image, source URL, and original HTML (for future regeneration). Supports saveAsCopy mode which generates a new UUID and fresh timestamps for the copied recipe."
       }
       aggregate_grocery: {
         label: AggregateGroceryListUseCase
@@ -711,9 +711,9 @@ legend: {
   }
   edit1: "1. User taps edit (pencil icon) on recipe detail screen"
   edit2: "2. EditRecipeScreen shows markdown of recipe (same as share-as-text)"
-  edit3: "3. User edits markdown, selects model/thinking, taps Save"
+  edit3: "3. User edits markdown, selects model/thinking, taps Save or Save as Copy"
   edit4: "4. RecipeEditWorker sends markdown to AI via EditRecipeUseCase"
-  edit5: "5. AI re-parses into structured recipe, preserving ID/metadata"
+  edit5: "5. AI re-parses into structured recipe (Save preserves ID/metadata; Save as Copy creates new recipe)"
 
   edit1 -> edit2 -> edit3 -> edit4 -> edit5
 


### PR DESCRIPTION
## Summary
- Adds a "Save as Copy" button to the recipe edit screen alongside the existing Save button
- When tapped, saves the edited markdown as a new recipe with a fresh UUID and timestamps instead of updating the existing one
- On success, navigates to the newly created recipe's detail screen

## Changes
- **EditRecipeUseCase**: Added `saveAsCopy` parameter that generates a new UUID and fresh timestamps for the copied recipe
- **RecipeEditWorker**: Passes through `saveAsCopy` flag and returns the new recipe ID on success
- **EditRecipeViewModel**: Added `saveAsCopy()` function and updated `EditUiState.Success` to carry optional new recipe ID
- **EditRecipeScreen**: Added "Save as Copy" outlined button with copy icon in the bottom action bar
- **NavGraph**: Added `onCopySuccess` callback that navigates to the new recipe's detail screen
- **strings.xml**: Added `save_as_copy` string resource
- **architecture.d2**: Updated tooltips and flow descriptions to reflect save-as-copy capability

## Test plan
- [ ] Open an existing recipe and tap the edit (pencil) icon
- [ ] Verify the "Save as Copy" button appears between Cancel and Save
- [ ] Edit the recipe markdown and tap "Save as Copy"
- [ ] Verify a new recipe is created and you're navigated to its detail screen
- [ ] Verify the original recipe is unchanged
- [ ] Verify the regular "Save" button still works as before (updates in place)

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)