### PR TITLE
feat: cheaper recipe editor with separate title/URL fields and density hints

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDao.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDao.kt
@@ -45,4 +45,7 @@ interface RecipeDao {
 
     @Query("UPDATE recipes SET imageUrl = :imageUrl, updatedAt = :updatedAt WHERE id = :id")
     suspend fun setImageUrl(id: String, imageUrl: String?, updatedAt: Instant)
+
+    @Query("UPDATE recipes SET name = :name, sourceUrl = :sourceUrl, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun updateTitleAndUrl(id: String, name: String, sourceUrl: String?, updatedAt: Instant)
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/RecipeRepository.kt
@@ -89,6 +89,10 @@ class RecipeRepository @Inject constructor(
         recipeDao.setImageUrl(id, imageUrl, kotlin.time.Clock.System.now())
     }
 
+    suspend fun updateTitleAndUrl(id: String, name: String, sourceUrl: String?) {
+        recipeDao.updateTitleAndUrl(id, name, sourceUrl, kotlin.time.Clock.System.now())
+    }
+
     suspend fun getAllRecipeIdsAndNames(): List<RecipeIdAndName> {
         return recipeDao.getAllRecipeIdsAndNames()
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -99,6 +99,7 @@ class ParseHtmlUseCase @Inject constructor(
      * @param originalHtml Optional original HTML for debug data and storage alongside the recipe
      * @param model AI model override (null = use current setting)
      * @param extendedThinking Extended thinking override (null = use current setting)
+     * @param densityOverrides Optional density overrides from existing recipe (merged with defaults for cheaper editing)
      * @param onProgress Callback for progress updates
      * @return The parsed recipe or error
      */
@@ -110,6 +111,7 @@ class ParseHtmlUseCase @Inject constructor(
         originalHtml: String? = null,
         model: String? = null,
         extendedThinking: Boolean? = null,
+        densityOverrides: Map<String, Double>? = null,
         onProgress: suspend (ParseProgress) -> Unit = {}
     ): ParseResult {
         // Check for API key
@@ -125,7 +127,7 @@ class ParseHtmlUseCase @Inject constructor(
         // Parse with AI
         onProgress(ParseProgress.ParsingRecipe)
         val startTime = System.currentTimeMillis()
-        val parseResult = anthropicService.parseRecipe(text, apiKey, model, extendedThinking)
+        val parseResult = anthropicService.parseRecipe(text, apiKey, model, extendedThinking, densityOverrides)
         val durationMs = System.currentTimeMillis() - startTime
         if (parseResult.isFailure) {
             val errorMessage = "Failed to parse recipe: ${parseResult.exceptionOrNull()?.message}"

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
@@ -77,6 +77,8 @@ fun EditRecipeScreen(
 ) {
     val recipe by viewModel.recipe.collectAsStateWithLifecycle()
     val imageUrl by viewModel.imageUrl.collectAsStateWithLifecycle()
+    val title by viewModel.title.collectAsStateWithLifecycle()
+    val sourceUrl by viewModel.sourceUrl.collectAsStateWithLifecycle()
     val markdownText by viewModel.markdownText.collectAsStateWithLifecycle()
     val editState by viewModel.editState.collectAsStateWithLifecycle()
     val model by viewModel.model.collectAsStateWithLifecycle()
@@ -190,6 +192,10 @@ fun EditRecipeScreen(
                         )
                     },
                     onRemoveImage = viewModel::removeImage,
+                    title = title,
+                    onTitleChange = viewModel::setTitle,
+                    sourceUrl = sourceUrl,
+                    onSourceUrlChange = viewModel::setSourceUrl,
                     markdownText = markdownText,
                     onMarkdownChange = viewModel::setMarkdownText,
                     model = model,
@@ -275,6 +281,10 @@ private fun EditContent(
     imageUrl: String?,
     onChangeImage: () -> Unit,
     onRemoveImage: () -> Unit,
+    title: String,
+    onTitleChange: (String) -> Unit,
+    sourceUrl: String?,
+    onSourceUrlChange: (String?) -> Unit,
     markdownText: String,
     onMarkdownChange: (String) -> Unit,
     model: String,
@@ -310,6 +320,33 @@ private fun EditContent(
                 imageUrl = imageUrl,
                 onChangeImage = onChangeImage,
                 onRemoveImage = onRemoveImage
+            )
+
+            HorizontalDivider()
+
+            // Title field
+            Text(
+                text = stringResource(R.string.recipe_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            OutlinedTextField(
+                value = title,
+                onValueChange = onTitleChange,
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Words
+                )
+            )
+
+            // Source URL field
+            OutlinedTextField(
+                value = sourceUrl ?: "",
+                onValueChange = { onSourceUrlChange(it.ifBlank { null }) },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text(stringResource(R.string.source_url_field)) },
+                singleLine = true
             )
 
             HorizontalDivider()
@@ -368,7 +405,7 @@ private fun EditContent(
             }
             OutlinedButton(
                 onClick = onSaveAsCopy,
-                enabled = markdownText.isNotBlank()
+                enabled = title.isNotBlank() && markdownText.isNotBlank()
             ) {
                 Icon(
                     imageVector = Icons.Default.ContentCopy,
@@ -382,7 +419,7 @@ private fun EditContent(
             }
             Button(
                 onClick = onSave,
-                enabled = markdownText.isNotBlank()
+                enabled = title.isNotBlank() && markdownText.isNotBlank()
             ) {
                 Icon(
                     imageVector = Icons.Default.Save,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,7 +59,7 @@
     <!-- Edit Recipe -->
     <string name="edit_recipe">Edit Recipe</string>
     <string name="edit_recipe_action">Edit recipe</string>
-    <string name="edit_recipe_description">Edit the recipe text below. When you save, the AI will clean up the formatting and regenerate structured data like ingredient amounts and densities.</string>
+    <string name="edit_recipe_description">Edit the recipe body below. Title and URL changes are saved directly. Body changes will be processed by the AI to regenerate structured data.</string>
     <string name="edit_save_success">Recipe updated successfully</string>
     <string name="save_as_copy">Save as Copy</string>
     <string name="edit_background_notice">You can leave this screen. You\'ll be notified when the update is complete.</string>
@@ -70,6 +70,8 @@
     <string name="change_image">Change Image</string>
     <string name="remove_image">Remove Image</string>
     <string name="no_image">No image</string>
+    <string name="recipe_title">Title</string>
+    <string name="source_url_field">Source URL</string>
     <string name="recipe_text">Recipe Text</string>
 
     <!-- Regenerate Recipe -->

--- a/app/src/test/kotlin/com/lionotter/recipes/data/remote/AnthropicServiceTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/data/remote/AnthropicServiceTest.kt
@@ -53,4 +53,33 @@ class AnthropicServiceTest {
     fun `DEFAULT_MODEL is set`() {
         assertTrue(AnthropicService.DEFAULT_MODEL.isNotEmpty())
     }
+
+    @Test
+    fun `buildSystemPrompt without overrides includes default densities`() {
+        val prompt = AnthropicService.buildSystemPrompt()
+        assertTrue(prompt.contains("all-purpose flour 0.51"))
+        assertTrue(prompt.contains("granulated sugar 0.84"))
+        assertTrue(prompt.contains("butter 0.96"))
+        assertFalse(prompt.contains("%DENSITY_TABLE%"))
+    }
+
+    @Test
+    fun `buildSystemPrompt with overrides includes merged densities`() {
+        val overrides = mapOf("custom ingredient" to 1.5)
+        val prompt = AnthropicService.buildSystemPrompt(overrides)
+        // Default densities still present
+        assertTrue(prompt.contains("all-purpose flour 0.51"))
+        // Custom density added
+        assertTrue(prompt.contains("custom ingredient 1.5"))
+    }
+
+    @Test
+    fun `buildSystemPrompt overrides take precedence over defaults`() {
+        val overrides = mapOf("butter" to 0.99)
+        val prompt = AnthropicService.buildSystemPrompt(overrides)
+        // Override value should be present
+        assertTrue(prompt.contains("butter 0.99"))
+        // Original value should NOT be present
+        assertFalse(prompt.contains("butter 0.96"))
+    }
 }

--- a/app/src/test/kotlin/com/lionotter/recipes/data/repository/RecipeRepositoryTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/data/repository/RecipeRepositoryTest.kt
@@ -354,6 +354,24 @@ class RecipeRepositoryTest {
     }
 
     @Test
+    fun `updateTitleAndUrl calls dao updateTitleAndUrl`() = runTest {
+        coEvery { recipeDao.updateTitleAndUrl("recipe-1", "New Title", "https://new.url", any()) } just runs
+
+        recipeRepository.updateTitleAndUrl("recipe-1", "New Title", "https://new.url")
+
+        coVerify { recipeDao.updateTitleAndUrl("recipe-1", "New Title", "https://new.url", any()) }
+    }
+
+    @Test
+    fun `updateTitleAndUrl handles null source url`() = runTest {
+        coEvery { recipeDao.updateTitleAndUrl("recipe-1", "New Title", null, any()) } just runs
+
+        recipeRepository.updateTitleAndUrl("recipe-1", "New Title", null)
+
+        coVerify { recipeDao.updateTitleAndUrl("recipe-1", "New Title", null, any()) }
+    }
+
+    @Test
     fun `entity to recipe mapping handles malformed instruction json`() = runTest {
         val entity = createTestEntity(instructionSectionsJson = "not valid json")
         every { recipeDao.getRecipeByIdFlow("recipe-1") } returns flowOf(entity)

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -65,7 +65,7 @@ app: {
       }
       edit: {
         label: EditRecipeScreen
-        tooltip: "Recipe edit screen with two sections: (1) Image section — pick from gallery or remove, saved directly without AI. (2) Recipe text markdown editor — when saved, AI cleans up formatting and regenerates structured data (densities, etc.). Title comes from the AI parsing of the markdown. Includes model selection and extended thinking toggle. Also supports regeneration from original source via refresh icon (when original HTML or source URL is available). Save as Copy creates a new recipe from the edited markdown instead of updating the existing one."
+        tooltip: "Recipe edit screen with three sections: (1) Image section — pick from gallery or remove, saved directly without AI. (2) Title and source URL fields — edited directly, saved without AI when recipe body is unchanged. (3) Recipe body markdown editor — when body changes are saved, AI cleans up formatting and regenerates structured data (densities, etc.) with existing ingredient densities passed as hints for cheaper AI models. Includes model selection and extended thinking toggle. Also supports regeneration from original source via refresh icon (when original HTML or source URL is available). Save as Copy creates a new recipe from the edited markdown instead of updating the existing one."
       }
       add: AddRecipeScreen
       settings: SettingsScreen
@@ -135,7 +135,7 @@ app: {
       detail_vm: RecipeDetailViewModel
       edit_vm: {
         label: EditRecipeViewModel
-        tooltip: "Manages edit recipe screen state. Supports direct image editing (saved immediately without AI). Loads recipe text as markdown, tracks model/thinking settings, and enqueues RecipeEditWorker for save (or save as copy) or RecipeRegenerateWorker for regeneration from original source. Uses ImageDownloadService to save picked images from gallery."
+        tooltip: "Manages edit recipe screen state. Supports direct image editing (saved immediately without AI). Separates title, source URL, and recipe body: title/URL changes are saved directly without AI, while body changes trigger AI re-parsing via RecipeEditWorker. Tracks model/thinking settings. Supports save as copy and regeneration from original source via RecipeRegenerateWorker. Uses ImageDownloadService to save picked images from gallery."
       }
       add_vm: AddRecipeViewModel
       settings_vm: SettingsViewModel
@@ -309,7 +309,7 @@ app: {
       }
       edit_recipe: {
         label: EditRecipeUseCase
-        tooltip: "Edits a recipe by sending user-modified markdown text through ParseHtmlUseCase.parseText() for AI re-parsing. Preserves recipe ID, createdAt, favorite status, image, source URL, and original HTML (for future regeneration). Supports saveAsCopy mode which generates a new UUID and fresh timestamps for the copied recipe."
+        tooltip: "Edits a recipe by sending user-modified markdown text through ParseHtmlUseCase.parseText() for AI re-parsing. Collects existing ingredient densities and passes them as hints to the AI, enabling cheaper models (like Haiku) to reuse known values. Preserves recipe ID, createdAt, favorite status, image, source URL, and original HTML (for future regeneration). Supports saveAsCopy mode which generates a new UUID and fresh timestamps for the copied recipe."
       }
       aggregate_grocery: {
         label: AggregateGroceryListUseCase
@@ -333,7 +333,7 @@ app: {
 
       markdown: {
         label: RecipeMarkdownFormatter
-        tooltip: "Converts Recipe to human-readable Markdown format for export"
+        tooltip: "Converts Recipe to human-readable Markdown format for export. Supports format() (full markdown with title/URL) and formatBody() (body only, for edit screen where title/URL are separate fields). Also provides collectDensities() and formatDensityHints() for extracting existing ingredient densities as AI hints."
       }
       serializer: {
         label: RecipeSerializer
@@ -711,9 +711,9 @@ legend: {
     }
   }
   edit1: "1. User taps edit (pencil icon) on recipe detail screen"
-  edit2: "2. EditRecipeScreen shows image picker and recipe text (markdown) as separate sections"
-  edit3: "3. Image changes are saved directly without AI re-parsing"
-  edit4: "4. Recipe text edits trigger AI cycle: RecipeEditWorker via EditRecipeUseCase"
+  edit2: "2. EditRecipeScreen shows image picker, title/URL fields, and recipe body (markdown) as separate sections"
+  edit3: "3. Image, title, and URL changes are saved directly without AI re-parsing"
+  edit4: "4. Recipe body edits trigger AI cycle: RecipeEditWorker via EditRecipeUseCase (with existing density hints)"
   edit5: "5. AI re-parses into structured recipe, preserving user's image (Save preserves ID/metadata; Save as Copy creates new recipe)"
 
   edit1 -> edit2 -> edit3 -> edit4 -> edit5


### PR DESCRIPTION
## Summary
- Separates title and source URL from the recipe body markdown editor, so changes to just the title or URL are saved directly without triggering expensive AI re-parsing
- Passes existing ingredient densities as hints in the AI system prompt when editing, enabling cheaper models like Haiku to reuse known values instead of re-deriving them
- Adds `RecipeDao.updateTitleAndUrl()` for direct title/URL updates without full recipe save

## Changes
- **RecipeMarkdownFormatter**: Added `formatBody()` (body only, excluding title/URL), `collectDensities()`, and `formatDensityHints()` helper methods
- **EditRecipeScreen**: Added separate title and source URL input fields above the recipe body editor
- **EditRecipeViewModel**: Tracks title, URL, and body independently; saves title/URL directly when body is unchanged; reconstructs full markdown when body changes
- **RecipeDao/RecipeRepository**: Added `updateTitleAndUrl()` for lightweight direct saves
- **EditRecipeUseCase**: Collects existing ingredient densities and passes them through to the AI
- **AnthropicService**: Accepts and appends density hints to the system prompt
- **ParseHtmlUseCase**: Passes through `densityHints` parameter
- Updated architecture docs and string resources
- Added unit tests for new formatter methods and repository method

## Test plan
- [x] All existing tests pass (`./ci-local.sh`)
- [x] New tests added for `formatBody()`, `collectDensities()`, `formatDensityHints()`, and `updateTitleAndUrl()`
- [ ] Manual: Edit only the title -> verify no AI call, title updates instantly
- [ ] Manual: Edit only the source URL -> verify no AI call, URL updates
- [ ] Manual: Edit the recipe body -> verify AI processes with density hints
- [ ] Manual: Save as copy with body changes -> verify full markdown reconstruction

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)