### PR TITLE
feat: separate default model for imports and editing

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -31,6 +31,7 @@ class SettingsDataStore @Inject constructor(
 ) {
     private object Keys {
         val AI_MODEL = stringPreferencesKey("ai_model")
+        val EDIT_MODEL = stringPreferencesKey("edit_model")
         val EXTENDED_THINKING_ENABLED = booleanPreferencesKey("extended_thinking_enabled")
         val KEEP_SCREEN_ON = booleanPreferencesKey("keep_screen_on")
         val THEME_MODE = stringPreferencesKey("theme_mode")
@@ -102,6 +103,10 @@ class SettingsDataStore @Inject constructor(
 
     val aiModel: Flow<String> = context.dataStore.data.map { preferences ->
         preferences[Keys.AI_MODEL] ?: AnthropicService.DEFAULT_MODEL
+    }
+
+    val editModel: Flow<String> = context.dataStore.data.map { preferences ->
+        preferences[Keys.EDIT_MODEL] ?: AnthropicService.DEFAULT_EDIT_MODEL
     }
 
     val extendedThinkingEnabled: Flow<Boolean> = context.dataStore.data.map { preferences ->
@@ -210,6 +215,12 @@ class SettingsDataStore @Inject constructor(
     suspend fun setAiModel(model: String) {
         context.dataStore.edit { preferences ->
             preferences[Keys.AI_MODEL] = model
+        }
+    }
+
+    suspend fun setEditModel(model: String) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.EDIT_MODEL] = model
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -133,6 +133,7 @@ class AnthropicService @Inject constructor(
 
     companion object {
         const val DEFAULT_MODEL = "claude-opus-4-6"
+        const val DEFAULT_EDIT_MODEL = "claude-sonnet-4-6"
         private const val API_KEY_PREFIX = "sk-ant-"
 
         /**

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
@@ -66,7 +66,7 @@ import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
 import com.lionotter.recipes.R
 import com.lionotter.recipes.ui.components.RecipeTopAppBar
-import com.lionotter.recipes.ui.screens.settings.components.ModelSelectionSection
+import com.lionotter.recipes.ui.screens.settings.components.SingleModelSelectionSection
 
 @Composable
 fun EditRecipeScreen(
@@ -377,7 +377,7 @@ private fun EditContent(
                 )
             )
 
-            ModelSelectionSection(
+            SingleModelSelectionSection(
                 currentModel = model,
                 onModelChange = onModelChange,
                 extendedThinkingEnabled = extendedThinking,

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeViewModel.kt
@@ -84,7 +84,7 @@ class EditRecipeViewModel @Inject constructor(
     private val _editState = MutableStateFlow<EditUiState>(EditUiState.Idle)
     val editState: StateFlow<EditUiState> = _editState.asStateFlow()
 
-    private val _model = MutableStateFlow(AnthropicService.DEFAULT_MODEL)
+    private val _model = MutableStateFlow(AnthropicService.DEFAULT_EDIT_MODEL)
     val model: StateFlow<String> = _model.asStateFlow()
 
     private val _extendedThinking = MutableStateFlow(true)
@@ -306,7 +306,7 @@ class EditRecipeViewModel @Inject constructor(
     private fun loadInitialData() {
         viewModelScope.launch {
             // Load settings defaults
-            _model.value = settingsDataStore.aiModel.first()
+            _model.value = settingsDataStore.editModel.first()
             _extendedThinking.value = settingsDataStore.extendedThinkingEnabled.first()
 
             // Check for original HTML

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -46,6 +46,7 @@ fun SettingsScreen(
     val apiKey by viewModel.apiKey.collectAsStateWithLifecycle()
     val apiKeyInput by viewModel.apiKeyInput.collectAsStateWithLifecycle()
     val aiModel by viewModel.aiModel.collectAsStateWithLifecycle()
+    val editModel by viewModel.editModel.collectAsStateWithLifecycle()
     val extendedThinkingEnabled by viewModel.extendedThinkingEnabled.collectAsStateWithLifecycle()
     val keepScreenOn by viewModel.keepScreenOn.collectAsStateWithLifecycle()
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
@@ -139,6 +140,8 @@ fun SettingsScreen(
             ModelSelectionSection(
                 currentModel = aiModel,
                 onModelChange = viewModel::setAiModel,
+                currentEditModel = editModel,
+                onEditModelChange = viewModel::setEditModel,
                 extendedThinkingEnabled = extendedThinkingEnabled,
                 onExtendedThinkingChange = viewModel::setExtendedThinkingEnabled
             )

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -37,6 +37,13 @@ class SettingsViewModel @Inject constructor(
             initialValue = AnthropicService.DEFAULT_MODEL
         )
 
+    val editModel: StateFlow<String> = settingsDataStore.editModel
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = AnthropicService.DEFAULT_EDIT_MODEL
+        )
+
     val extendedThinkingEnabled: StateFlow<Boolean> = settingsDataStore.extendedThinkingEnabled
         .stateIn(
             scope = viewModelScope,
@@ -140,6 +147,12 @@ class SettingsViewModel @Inject constructor(
     fun setAiModel(model: String) {
         viewModelScope.launch {
             settingsDataStore.setAiModel(model)
+        }
+    }
+
+    fun setEditModel(model: String) {
+        viewModelScope.launch {
+            settingsDataStore.setEditModel(model)
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ModelSelectionSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/ModelSelectionSection.kt
@@ -24,26 +24,32 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.lionotter.recipes.R
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun ModelSelectionSection(
-    currentModel: String,
-    onModelChange: (String) -> Unit,
-    extendedThinkingEnabled: Boolean,
-    onExtendedThinkingChange: (Boolean) -> Unit
-) {
-    var expanded by remember { mutableStateOf(false) }
-
-    val models = listOf(
+private val MODELS
+    @Composable get() = listOf(
         "claude-opus-4-6" to stringResource(R.string.model_opus_4_6),
         "claude-opus-4-5" to stringResource(R.string.model_opus),
+        "claude-sonnet-4-6" to stringResource(R.string.model_sonnet_4_6),
         "claude-sonnet-4-5" to stringResource(R.string.model_sonnet),
         "claude-haiku-4-5" to stringResource(R.string.model_haiku)
     )
 
+/**
+ * Model selection section for the settings screen, with separate import and edit model dropdowns.
+ */
+@Composable
+fun ModelSelectionSection(
+    currentModel: String,
+    onModelChange: (String) -> Unit,
+    currentEditModel: String,
+    onEditModelChange: (String) -> Unit,
+    extendedThinkingEnabled: Boolean,
+    onExtendedThinkingChange: (Boolean) -> Unit
+) {
+    val models = MODELS
+
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
-            text = stringResource(R.string.ai_model),
+            text = stringResource(R.string.ai_models),
             style = MaterialTheme.typography.titleMedium
         )
 
@@ -52,6 +58,86 @@ fun ModelSelectionSection(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+
+        ModelDropdown(
+            label = stringResource(R.string.import_model),
+            description = stringResource(R.string.import_model_description),
+            currentModel = currentModel,
+            models = models,
+            onModelChange = onModelChange
+        )
+
+        ModelDropdown(
+            label = stringResource(R.string.edit_model),
+            description = stringResource(R.string.edit_model_description),
+            currentModel = currentEditModel,
+            models = models,
+            onModelChange = onEditModelChange
+        )
+
+        ExtendedThinkingToggle(
+            enabled = extendedThinkingEnabled,
+            onEnabledChange = onExtendedThinkingChange
+        )
+    }
+}
+
+/**
+ * Single model selection section used on the edit recipe screen.
+ */
+@Composable
+fun SingleModelSelectionSection(
+    currentModel: String,
+    onModelChange: (String) -> Unit,
+    extendedThinkingEnabled: Boolean,
+    onExtendedThinkingChange: (Boolean) -> Unit
+) {
+    val models = MODELS
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = stringResource(R.string.ai_model),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        ModelDropdown(
+            currentModel = currentModel,
+            models = models,
+            onModelChange = onModelChange
+        )
+
+        ExtendedThinkingToggle(
+            enabled = extendedThinkingEnabled,
+            onEnabledChange = onExtendedThinkingChange
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ModelDropdown(
+    currentModel: String,
+    models: List<Pair<String, String>>,
+    onModelChange: (String) -> Unit,
+    label: String? = null,
+    description: String? = null
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        if (label != null) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+        if (description != null) {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
 
         ExposedDropdownMenuBox(
             expanded = expanded,
@@ -82,27 +168,33 @@ fun ModelSelectionSection(
                 }
             }
         }
+    }
+}
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.extended_thinking),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-                Text(
-                    text = stringResource(R.string.extended_thinking_description),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            Switch(
-                checked = extendedThinkingEnabled,
-                onCheckedChange = onExtendedThinkingChange
+@Composable
+private fun ExtendedThinkingToggle(
+    enabled: Boolean,
+    onEnabledChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.extended_thinking),
+                style = MaterialTheme.typography.bodyLarge
+            )
+            Text(
+                text = stringResource(R.string.extended_thinking_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
+        Switch(
+            checked = enabled,
+            onCheckedChange = onEnabledChange
+        )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,8 +111,13 @@
     <string name="save_api_key">Save API Key</string>
     <string name="remove_api_key">Remove API key</string>
     <string name="get_api_key">Get an API Key from Anthropic</string>
+    <string name="ai_models">AI Models</string>
     <string name="ai_model">AI Model</string>
-    <string name="ai_model_description">Choose the Claude model to use for parsing recipes. Better models may provide more accurate results but cost more.</string>
+    <string name="ai_model_description">Choose the Claude models to use for recipe operations. Better models may provide more accurate results but cost more.</string>
+    <string name="import_model">Import model</string>
+    <string name="import_model_description">Used when importing new recipes from URLs.</string>
+    <string name="edit_model">Edit model</string>
+    <string name="edit_model_description">Used when editing or regenerating existing recipes. Editing is simpler than importing, so a cheaper model often works well.</string>
     <string name="extended_thinking">Extended thinking</string>
     <string name="extended_thinking_description">Allow the AI to think through complex recipes before responding. Improves accuracy but increases cost and import time.</string>
     <string name="theme">Theme</string>
@@ -139,7 +144,8 @@
     <!-- Model names -->
     <string name="model_opus_4_6">Claude Opus 4.6 (Best quality)</string>
     <string name="model_opus">Claude Opus 4.5</string>
-    <string name="model_sonnet">Claude Sonnet 4.5 (Balanced)</string>
+    <string name="model_sonnet_4_6">Claude Sonnet 4.6 (Balanced)</string>
+    <string name="model_sonnet">Claude Sonnet 4.5</string>
     <string name="model_haiku">Claude Haiku 4.5 (Fastest)</string>
 
     <!-- Common count strings -->

--- a/app/src/test/kotlin/com/lionotter/recipes/integration/HiltIntegrationTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/integration/HiltIntegrationTest.kt
@@ -62,6 +62,7 @@ abstract class HiltIntegrationTest {
     val settingsDataStore: SettingsDataStore = mockk(relaxed = true) {
         every { anthropicApiKey } returns MutableStateFlow(null)
         every { aiModel } returns MutableStateFlow("claude-sonnet-4-20250514")
+        every { editModel } returns MutableStateFlow("claude-sonnet-4-6")
         every { extendedThinkingEnabled } returns MutableStateFlow(true)
         every { keepScreenOn } returns MutableStateFlow(true)
         every { themeMode } returns MutableStateFlow(ThemeMode.AUTO)

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -36,6 +36,7 @@ class SettingsViewModelTest {
 
     private val apiKeyFlow = MutableStateFlow<String?>(null)
     private val aiModelFlow = MutableStateFlow(AnthropicService.DEFAULT_MODEL)
+    private val editModelFlow = MutableStateFlow(AnthropicService.DEFAULT_EDIT_MODEL)
     private val extendedThinkingFlow = MutableStateFlow(true)
     private val keepScreenOnFlow = MutableStateFlow(true)
     private val themeModeFlow = MutableStateFlow(ThemeMode.AUTO)
@@ -53,6 +54,7 @@ class SettingsViewModelTest {
         importDebugRepository = mockk()
         every { settingsDataStore.anthropicApiKey } returns apiKeyFlow
         every { settingsDataStore.aiModel } returns aiModelFlow
+        every { settingsDataStore.editModel } returns editModelFlow
         every { settingsDataStore.extendedThinkingEnabled } returns extendedThinkingFlow
         every { settingsDataStore.keepScreenOn } returns keepScreenOnFlow
         every { settingsDataStore.themeMode } returns themeModeFlow

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -135,7 +135,7 @@ app: {
       detail_vm: RecipeDetailViewModel
       edit_vm: {
         label: EditRecipeViewModel
-        tooltip: "Manages edit recipe screen state. Supports direct image editing (saved immediately without AI). Separates title, source URL, and recipe body: title/URL changes are saved directly without AI, while body changes trigger AI re-parsing via RecipeEditWorker. Tracks model/thinking settings. Supports save as copy and regeneration from original source via RecipeRegenerateWorker. Uses ImageDownloadService to save picked images from gallery."
+        tooltip: "Manages edit recipe screen state. Supports direct image editing (saved immediately without AI). Separates title, source URL, and recipe body: title/URL changes are saved directly without AI, while body changes trigger AI re-parsing via RecipeEditWorker. Defaults to the separate edit model setting (default: Sonnet) rather than the import model. Tracks model/thinking settings. Supports save as copy and regeneration from original source via RecipeRegenerateWorker. Uses ImageDownloadService to save picked images from gallery."
       }
       add_vm: AddRecipeViewModel
       settings_vm: SettingsViewModel
@@ -501,7 +501,7 @@ app: {
       }
       settings: {
         label: SettingsDataStore
-        tooltip: "Uses Tink AEAD encryption for API key, DataStore for non-sensitive settings (AI model, extended thinking enabled, keep screen on, theme mode, volume/weight unit system preferences, grocery list volume/weight unit system preferences, start of week, import debugging enabled)"
+        tooltip: "Uses Tink AEAD encryption for API key, DataStore for non-sensitive settings (AI model, edit model, extended thinking enabled, keep screen on, theme mode, volume/weight unit system preferences, grocery list volume/weight unit system preferences, start of week, import debugging enabled)"
       }
 
       dao -> room
@@ -605,7 +605,7 @@ app: {
   ui.viewmodels.detail_vm -> domain.usecases.export_single: export .lorecipes
   ui.viewmodels.detail_vm -> data.local.settings: keep screen on, unit prefs
   ui.viewmodels.edit_vm -> data.repository.repo: recipe, original HTML, image
-  ui.viewmodels.edit_vm -> data.local.settings: model, thinking prefs
+  ui.viewmodels.edit_vm -> data.local.settings: edit model, thinking prefs
   ui.viewmodels.edit_vm -> data.remote.image_dl: save picked images
   ui.viewmodels.edit_vm -> background.worker.edit_worker: save edits
   ui.viewmodels.edit_vm -> background.worker.regenerate_worker: regenerate from original


### PR DESCRIPTION
## Summary
- Adds a separate **edit model** setting (defaults to Claude Sonnet 4.6) used when editing or regenerating existing recipes
- The existing **import model** setting (defaults to Claude Opus 4.6) continues to be used for new recipe imports from URLs
- Adds Claude Sonnet 4.6 to the available model list
- Settings screen now shows two model dropdowns: "Import model" and "Edit model" with descriptions

## Motivation
Editing a recipe is much simpler than the original import (the AI already has density hints and structured data to work with), so a cheaper/faster model like Sonnet works well for edits while Opus remains the default for imports.

## Changes
- **AnthropicService**: Added `DEFAULT_EDIT_MODEL` constant (`claude-sonnet-4-6`)
- **SettingsDataStore**: Added `editModel` preference with getter/setter
- **SettingsViewModel**: Added `editModel` state flow and `setEditModel()` 
- **ModelSelectionSection**: Split into `ModelSelectionSection` (settings, with import + edit dropdowns) and `SingleModelSelectionSection` (edit screen, single dropdown)
- **EditRecipeViewModel**: Now defaults to `editModel` setting instead of `aiModel`
- **strings.xml**: Added string resources for import/edit model labels and Claude Sonnet 4.6

## Test plan
- [x] CI passes (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Verify settings screen shows two separate model dropdowns
- [ ] Verify edit model defaults to Claude Sonnet 4.6
- [ ] Verify import model defaults to Claude Opus 4.6
- [ ] Verify editing a recipe uses the edit model setting
- [ ] Verify importing a recipe uses the import model setting

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)