### PR TITLE
feat: default thinking to off

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/SettingsDataStore.kt
@@ -110,7 +110,7 @@ class SettingsDataStore @Inject constructor(
     }
 
     val thinkingEnabled: Flow<Boolean> = context.dataStore.data.map { preferences ->
-        preferences[Keys.EXTENDED_THINKING_ENABLED] ?: true
+        preferences[Keys.EXTENDED_THINKING_ENABLED] ?: DEFAULT_THINKING_ENABLED
     }
 
     val keepScreenOn: Flow<Boolean> = context.dataStore.data.map { preferences ->
@@ -279,6 +279,7 @@ class SettingsDataStore @Inject constructor(
     }
 
     companion object {
+        const val DEFAULT_THINKING_ENABLED = false
         private const val TAG = "SettingsDataStore"
         private const val API_KEY_PREFS_FILE = "tink_encrypted_api_key"
         private const val API_KEY_PREF_KEY = "encrypted_api_key"

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AnthropicService.kt
@@ -6,6 +6,7 @@ import com.anthropic.models.messages.MessageCreateParams
 import com.anthropic.models.messages.TextBlockParam
 import com.anthropic.models.messages.ThinkingConfigAdaptive
 import com.anthropic.models.messages.ThinkingConfigEnabled
+import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.domain.util.RecipeMarkdownFormatter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -34,7 +35,7 @@ class AnthropicService @Inject constructor(
         html: String,
         apiKey: String,
         model: String = DEFAULT_MODEL,
-        thinkingEnabled: Boolean = true,
+        thinkingEnabled: Boolean = SettingsDataStore.DEFAULT_THINKING_ENABLED,
         densityOverrides: Map<String, Double>? = null
     ): Result<ParseResultWithUsage> {
         return try {

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeViewModel.kt
@@ -87,7 +87,7 @@ class EditRecipeViewModel @Inject constructor(
     private val _model = MutableStateFlow(AnthropicService.DEFAULT_EDIT_MODEL)
     val model: StateFlow<String> = _model.asStateFlow()
 
-    private val _thinkingEnabled = MutableStateFlow(true)
+    private val _thinkingEnabled = MutableStateFlow(SettingsDataStore.DEFAULT_THINKING_ENABLED)
     val thinkingEnabled: StateFlow<Boolean> = _thinkingEnabled.asStateFlow()
 
     private val _hasOriginalHtml = MutableStateFlow(false)

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -48,7 +48,7 @@ class SettingsViewModel @Inject constructor(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
-            initialValue = true
+            initialValue = SettingsDataStore.DEFAULT_THINKING_ENABLED
         )
 
     val keepScreenOn: StateFlow<Boolean> = settingsDataStore.keepScreenOn

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeEditWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeEditWorker.kt
@@ -5,6 +5,7 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.Data
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.domain.usecase.EditRecipeUseCase
 import com.lionotter.recipes.notification.RecipeNotificationHelper
 import dagger.assisted.Assisted
@@ -75,7 +76,7 @@ class RecipeEditWorker @AssistedInject constructor(
             )
         val model = inputData.getString(KEY_MODEL)
         val thinkingEnabled = if (inputData.keyValueMap.containsKey(KEY_EXTENDED_THINKING)) {
-            inputData.getBoolean(KEY_EXTENDED_THINKING, true)
+            inputData.getBoolean(KEY_EXTENDED_THINKING, SettingsDataStore.DEFAULT_THINKING_ENABLED)
         } else {
             null
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeRegenerateWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeRegenerateWorker.kt
@@ -5,6 +5,7 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.Data
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.domain.usecase.RegenerateRecipeUseCase
 import com.lionotter.recipes.notification.RecipeNotificationHelper
 import dagger.assisted.Assisted
@@ -63,7 +64,7 @@ class RecipeRegenerateWorker @AssistedInject constructor(
             )
         val model = inputData.getString(KEY_MODEL)
         val thinkingEnabled = if (inputData.keyValueMap.containsKey(KEY_EXTENDED_THINKING)) {
-            inputData.getBoolean(KEY_EXTENDED_THINKING, true)
+            inputData.getBoolean(KEY_EXTENDED_THINKING, SettingsDataStore.DEFAULT_THINKING_ENABLED)
         } else {
             null
         }

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -37,7 +37,7 @@ class SettingsViewModelTest {
     private val apiKeyFlow = MutableStateFlow<String?>(null)
     private val aiModelFlow = MutableStateFlow(AnthropicService.DEFAULT_MODEL)
     private val editModelFlow = MutableStateFlow(AnthropicService.DEFAULT_EDIT_MODEL)
-    private val thinkingEnabledFlow = MutableStateFlow(true)
+    private val thinkingEnabledFlow = MutableStateFlow(SettingsDataStore.DEFAULT_THINKING_ENABLED)
     private val keepScreenOnFlow = MutableStateFlow(true)
     private val themeModeFlow = MutableStateFlow(ThemeMode.AUTO)
     private val importDebuggingEnabledFlow = MutableStateFlow(false)
@@ -254,14 +254,14 @@ class SettingsViewModelTest {
     @Test
     fun `thinkingEnabled flow reflects datastore value`() = runTest {
         viewModel.thinkingEnabled.test {
-            // Initial value (default: true)
-            assertEquals(true, awaitItem())
+            // Initial value (default: false)
+            assertEquals(false, awaitItem())
 
             // Update the underlying flow
-            thinkingEnabledFlow.value = false
+            thinkingEnabledFlow.value = true
             testDispatcher.scheduler.advanceUntilIdle()
 
-            assertEquals(false, awaitItem())
+            assertEquals(true, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
## Summary
- Default the thinking/adaptive thinking setting to **off** instead of on
- Most recipes aren't complicated enough to need extended thinking, so this reduces unnecessary API usage by default
- Users can still enable thinking in Settings whenever needed
- Centralized the default to a single constant (`SettingsDataStore.DEFAULT_THINKING_ENABLED`) so it only needs to be changed in one place

Closes #285

## Changes
- `SettingsDataStore.kt`: Added `DEFAULT_THINKING_ENABLED = false` constant and use it for the preference default
- `SettingsViewModel.kt`: Use `SettingsDataStore.DEFAULT_THINKING_ENABLED` for StateFlow initial value
- `EditRecipeViewModel.kt`: Use `SettingsDataStore.DEFAULT_THINKING_ENABLED` for MutableStateFlow initial value
- `AnthropicService.kt`: Use `SettingsDataStore.DEFAULT_THINKING_ENABLED` for `parseRecipe()` parameter default
- `RecipeEditWorker.kt`: Use `SettingsDataStore.DEFAULT_THINKING_ENABLED` for `getBoolean` fallback (was hardcoded `true`)
- `RecipeRegenerateWorker.kt`: Use `SettingsDataStore.DEFAULT_THINKING_ENABLED` for `getBoolean` fallback (was hardcoded `true`)
- `SettingsViewModelTest.kt`: Updated test to use the centralized constant

## Test plan
- [x] All existing unit tests pass (updated `SettingsViewModelTest` to match new default)
- [x] CI checks pass locally (`./ci-local.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)