### PR TITLE
feat: use batch mode for Paprika imports

### DIFF
--- a/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/12.json
+++ b/app/schemas/com.lionotter.recipes.data.local.RecipeDatabase/12.json
@@ -1,0 +1,360 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "59213c686b0bdd66d5725887984b7dff",
+    "entities": [
+      {
+        "tableName": "recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sourceUrl` TEXT, `story` TEXT, `servings` INTEGER, `prepTime` TEXT, `cookTime` TEXT, `totalTime` TEXT, `ingredientSectionsJson` TEXT NOT NULL, `instructionSectionsJson` TEXT NOT NULL, `equipmentJson` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `imageUrl` TEXT, `sourceImageUrl` TEXT, `originalHtml` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, `userNotes` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "story",
+            "columnName": "story",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "prepTime",
+            "columnName": "prepTime",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cookTime",
+            "columnName": "cookTime",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalTime",
+            "columnName": "totalTime",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ingredientSectionsJson",
+            "columnName": "ingredientSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructionSectionsJson",
+            "columnName": "instructionSectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipmentJson",
+            "columnName": "equipmentJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userNotes",
+            "columnName": "userNotes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "import_debug",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceUrl` TEXT, `originalHtml` TEXT, `cleanedContent` TEXT, `aiOutputJson` TEXT, `originalLength` INTEGER NOT NULL, `cleanedLength` INTEGER NOT NULL, `inputTokens` INTEGER, `outputTokens` INTEGER, `aiModel` TEXT, `thinkingEnabled` INTEGER NOT NULL, `recipeId` TEXT, `recipeName` TEXT, `errorMessage` TEXT, `isError` INTEGER NOT NULL, `durationMs` INTEGER, `createdAt` INTEGER NOT NULL, `batchMode` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalHtml",
+            "columnName": "originalHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cleanedContent",
+            "columnName": "cleanedContent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aiOutputJson",
+            "columnName": "aiOutputJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLength",
+            "columnName": "originalLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanedLength",
+            "columnName": "cleanedLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "aiModel",
+            "columnName": "aiModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thinkingEnabled",
+            "columnName": "thinkingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recipeName",
+            "columnName": "recipeName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isError",
+            "columnName": "isError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchMode",
+            "columnName": "batchMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "pending_imports",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `name` TEXT, `imageUrl` TEXT, `status` TEXT NOT NULL, `workManagerId` TEXT, `errorMessage` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workManagerId",
+            "columnName": "workManagerId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "meal_plans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `recipeId` TEXT NOT NULL, `recipeName` TEXT NOT NULL, `recipeImageUrl` TEXT, `date` TEXT NOT NULL, `mealType` TEXT NOT NULL, `servings` REAL NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeName",
+            "columnName": "recipeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeImageUrl",
+            "columnName": "recipeImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealType",
+            "columnName": "mealType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '59213c686b0bdd66d5725887984b7dff')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/ImportDebugEntity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/ImportDebugEntity.kt
@@ -1,5 +1,6 @@
 package com.lionotter.recipes.data.local
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -22,5 +23,7 @@ data class ImportDebugEntity(
     val errorMessage: String?,
     val isError: Boolean,
     val durationMs: Long?,
-    val createdAt: Long
+    val createdAt: Long,
+    @ColumnInfo(defaultValue = "0")
+    val batchMode: Boolean = false
 )

--- a/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/local/RecipeDatabase.kt
@@ -8,7 +8,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [RecipeEntity::class, ImportDebugEntity::class, PendingImportEntity::class, MealPlanEntity::class],
-    version = 11,
+    version = 12,
     exportSchema = true
 )
 @TypeConverters(InstantConverter::class)
@@ -118,6 +118,12 @@ abstract class RecipeDatabase : RoomDatabase() {
         val MIGRATION_10_11 = object : Migration(10, 11) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE recipes ADD COLUMN userNotes TEXT")
+            }
+        }
+
+        val MIGRATION_11_12 = object : Migration(11, 12) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE import_debug ADD COLUMN batchMode INTEGER NOT NULL DEFAULT 0")
             }
         }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/di/DatabaseModule.kt
@@ -38,7 +38,8 @@ object DatabaseModule {
                 RecipeDatabase.MIGRATION_7_8,
                 RecipeDatabase.MIGRATION_8_9,
                 RecipeDatabase.MIGRATION_9_10,
-                RecipeDatabase.MIGRATION_10_11
+                RecipeDatabase.MIGRATION_10_11,
+                RecipeDatabase.MIGRATION_11_12
             )
             .build()
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportPaprikaUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportPaprikaUseCase.kt
@@ -1,12 +1,21 @@
 package com.lionotter.recipes.domain.usecase
 
 import android.util.Log
+import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.paprika.PaprikaParser
 import com.lionotter.recipes.data.paprika.PaprikaRecipe
+import com.anthropic.models.messages.batches.MessageBatch
+import com.lionotter.recipes.data.remote.AnthropicService
 import com.lionotter.recipes.data.remote.ImageDownloadService
+import com.lionotter.recipes.data.remote.RecipeParseException
 import com.lionotter.recipes.data.remote.WebScraperService
 import com.lionotter.recipes.domain.model.Recipe
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.first
 import java.io.InputStream
 import javax.inject.Inject
 import kotlin.coroutines.coroutineContext
@@ -14,20 +23,25 @@ import kotlin.coroutines.coroutineContext
 /**
  * Use case for importing recipes from a Paprika export file (.paprikarecipes).
  *
- * For each recipe in the export:
- * 1. Parse the Paprika recipe data
- * 2. Send the ingredients and directions (not the source URL) to the AI for structured parsing
- * 3. Use the Paprika image if available (base64-decoded photo_data), otherwise try to fetch from source URL
- * 4. Save the resulting recipe to the database
+ * Uses the Anthropic Message Batches API when importing multiple recipes:
+ * 1. Parse all Paprika recipe data from the export file
+ * 2. Submit all recipes as a single batch for parallel AI processing (50% cheaper)
+ * 3. Poll for batch completion
+ * 4. Process results and save each recipe to the database
+ *
+ * Falls back to sequential processing for single-recipe imports.
  */
 class ImportPaprikaUseCase @Inject constructor(
     private val paprikaParser: PaprikaParser,
     private val parseHtmlUseCase: ParseHtmlUseCase,
+    private val anthropicService: AnthropicService,
+    private val settingsDataStore: SettingsDataStore,
     private val webScraperService: WebScraperService,
     private val imageDownloadService: ImageDownloadService
 ) {
     companion object {
         private const val TAG = "ImportPaprikaUseCase"
+        private const val BATCH_POLL_INTERVAL_MS = 10_000L
     }
     sealed class ImportResult {
         data class Success(
@@ -47,6 +61,12 @@ class ImportPaprikaUseCase @Inject constructor(
 
     sealed class ImportProgress {
         object Parsing : ImportProgress()
+        data class SubmittingBatch(val total: Int) : ImportProgress()
+        data class WaitingForBatch(
+            val total: Int,
+            val succeeded: Int = 0,
+            val processing: Int = 0
+        ) : ImportProgress()
         data class ImportingRecipe(
             val recipeName: String,
             val current: Int,
@@ -59,7 +79,20 @@ class ImportPaprikaUseCase @Inject constructor(
     }
 
     /**
+     * Holds prepared data for a single recipe in the batch.
+     */
+    private data class PreparedRecipe(
+        val paprikaRecipe: PaprikaRecipe,
+        val contentForAi: String,
+        val imageUrl: String?,
+        val sourceUrl: String?
+    )
+
+    /**
      * Import recipes from a Paprika export file.
+     *
+     * Uses batch processing for multiple recipes (50% cheaper) and falls back
+     * to sequential processing for single recipes.
      *
      * @param inputStream InputStream of the .paprikarecipes file
      * @param selectedRecipeNames If non-null, only import recipes whose names are in this set
@@ -89,6 +122,239 @@ class ImportPaprikaUseCase @Inject constructor(
             return ImportResult.Error("No recipes found in export file")
         }
 
+        // For a single recipe, use sequential processing (no batch overhead)
+        if (paprikaRecipes.size == 1) {
+            return executeSequential(paprikaRecipes, onProgress)
+        }
+
+        // For multiple recipes, use batch processing
+        return executeBatch(paprikaRecipes, onProgress)
+    }
+
+    /**
+     * Import recipes using the Anthropic Message Batches API.
+     * Sends all recipes in a single batch for parallel processing at 50% cost.
+     */
+    private suspend fun executeBatch(
+        paprikaRecipes: List<PaprikaRecipe>,
+        onProgress: suspend (ImportProgress) -> Unit
+    ): ImportResult {
+        // Check for API key
+        val apiKey = settingsDataStore.anthropicApiKey.first()
+        if (apiKey.isNullOrBlank()) {
+            return ImportResult.NoApiKey
+        }
+
+        val model = settingsDataStore.aiModel.first()
+        val thinkingEnabled = settingsDataStore.thinkingEnabled.first()
+
+        // Prepare all recipes: format text, resolve images in parallel
+        onProgress(ImportProgress.SubmittingBatch(paprikaRecipes.size))
+        val preparedRecipes = coroutineScope {
+            paprikaRecipes.mapIndexed { index, paprikaRecipe ->
+                async {
+                    val contentForAi = paprikaParser.formatForAi(paprikaRecipe)
+                    val imageUrl = resolveImageUrl(paprikaRecipe)
+                    val sourceUrl = paprikaRecipe.sourceUrl?.takeIf { it.isNotBlank() }
+                    val customId = "recipe-$index"
+                    customId to PreparedRecipe(
+                        paprikaRecipe = paprikaRecipe,
+                        contentForAi = contentForAi,
+                        imageUrl = imageUrl,
+                        sourceUrl = sourceUrl
+                    )
+                }
+            }.awaitAll().toMap()
+        }
+
+        // Create batch requests
+        val batchRequests = preparedRecipes.map { (customId, prepared) ->
+            AnthropicService.BatchRequest(
+                customId = customId,
+                text = prepared.contentForAi
+            )
+        }
+
+        // Submit the batch
+        val startTime = System.currentTimeMillis()
+        val batchIdResult = anthropicService.createRecipeBatch(
+            requests = batchRequests,
+            apiKey = apiKey,
+            model = model,
+            thinkingEnabled = thinkingEnabled
+        )
+
+        if (batchIdResult.isFailure) {
+            val error = batchIdResult.exceptionOrNull()
+            Log.e(TAG, "Failed to create batch, falling back to sequential import", error)
+            // Fall back to sequential import
+            return executeSequential(paprikaRecipes, onProgress)
+        }
+
+        val batchId = batchIdResult.getOrThrow()
+        Log.i(TAG, "Created batch $batchId with ${paprikaRecipes.size} recipes")
+
+        // Poll for batch completion
+        try {
+            while (true) {
+                coroutineContext.ensureActive()
+
+                val batchResult = anthropicService.retrieveBatch(batchId, apiKey)
+                if (batchResult.isFailure) {
+                    Log.e(TAG, "Failed to retrieve batch status", batchResult.exceptionOrNull())
+                    delay(BATCH_POLL_INTERVAL_MS)
+                    continue
+                }
+
+                val batch = batchResult.getOrThrow()
+                val counts = batch.requestCounts()
+
+                onProgress(ImportProgress.WaitingForBatch(
+                    total = paprikaRecipes.size,
+                    succeeded = counts.succeeded().toInt(),
+                    processing = counts.processing().toInt()
+                ))
+
+                if (batch.processingStatus() == MessageBatch.ProcessingStatus.ENDED) {
+                    break
+                }
+
+                delay(BATCH_POLL_INTERVAL_MS)
+            }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // Try to cancel the batch on the server
+            try {
+                anthropicService.cancelBatch(batchId, apiKey)
+            } catch (cancelError: Exception) {
+                Log.w(TAG, "Failed to cancel batch $batchId on server", cancelError)
+            }
+            val result = ImportResult.Cancelled(importedCount = 0, failedCount = 0)
+            onProgress(ImportProgress.Complete(result))
+            throw e
+        }
+
+        val durationMs = System.currentTimeMillis() - startTime
+
+        // Retrieve and process results
+        val resultsResult = anthropicService.getBatchResults(batchId, apiKey)
+        if (resultsResult.isFailure) {
+            return ImportResult.Error("Failed to retrieve batch results: ${resultsResult.exceptionOrNull()?.message}")
+        }
+
+        val results = resultsResult.getOrThrow()
+        var importedCount = 0
+        var failedCount = 0
+        val failedRecipeNames = mutableListOf<String>()
+
+        try {
+            results.forEachIndexed { resultIndex, response ->
+                coroutineContext.ensureActive()
+
+                val customId = response.customId()
+                val prepared = preparedRecipes[customId]
+                if (prepared == null) {
+                    Log.w(TAG, "Unknown custom_id in batch results: $customId")
+                    return@forEachIndexed
+                }
+
+                onProgress(ImportProgress.ImportingRecipe(
+                    recipeName = prepared.paprikaRecipe.name,
+                    current = resultIndex + 1,
+                    total = results.size,
+                    importedSoFar = importedCount,
+                    failedSoFar = failedCount
+                ))
+
+                val batchResult = response.result()
+                if (batchResult.isSucceeded()) {
+                    val message = batchResult.asSucceeded().message()
+                    val parseResult = anthropicService.parseMessageResult(message)
+
+                    if (parseResult.isSuccess) {
+                        try {
+                            val recipe = parseHtmlUseCase.saveBatchResult(
+                                parsedWithUsage = parseResult.getOrThrow(),
+                                sourceUrl = prepared.sourceUrl,
+                                imageUrl = prepared.imageUrl,
+                                cleanedContent = prepared.contentForAi,
+                                model = model,
+                                thinkingEnabled = thinkingEnabled,
+                                durationMs = durationMs
+                            )
+                            if (recipe != null) {
+                                importedCount++
+                            } else {
+                                failedCount++
+                                failedRecipeNames.add(prepared.paprikaRecipe.name)
+                            }
+                        } catch (e: kotlinx.coroutines.CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Failed to save batch result for: ${prepared.paprikaRecipe.name}", e)
+                            failedCount++
+                            failedRecipeNames.add(prepared.paprikaRecipe.name)
+                        }
+                    } else {
+                        val error = parseResult.exceptionOrNull()
+                        val errorMsg = if (error is RecipeParseException) error.message else error?.message
+                        Log.e(TAG, "Failed to parse batch result for: ${prepared.paprikaRecipe.name}", error)
+                        parseHtmlUseCase.saveBatchErrorDebugEntry(
+                            sourceUrl = prepared.sourceUrl,
+                            cleanedContent = prepared.contentForAi,
+                            errorMessage = errorMsg,
+                            model = model,
+                            thinkingEnabled = thinkingEnabled,
+                            durationMs = durationMs
+                        )
+                        failedCount++
+                        failedRecipeNames.add(prepared.paprikaRecipe.name)
+                    }
+                } else {
+                    val errorType = when {
+                        batchResult.isErrored() -> "errored"
+                        batchResult.isCanceled() -> "canceled"
+                        batchResult.isExpired() -> "expired"
+                        else -> "unknown"
+                    }
+                    Log.e(TAG, "Batch result $errorType for: ${prepared.paprikaRecipe.name}")
+                    parseHtmlUseCase.saveBatchErrorDebugEntry(
+                        sourceUrl = prepared.sourceUrl,
+                        cleanedContent = prepared.contentForAi,
+                        errorMessage = "Batch request $errorType",
+                        model = model,
+                        thinkingEnabled = thinkingEnabled,
+                        durationMs = durationMs
+                    )
+                    failedCount++
+                    failedRecipeNames.add(prepared.paprikaRecipe.name)
+                }
+            }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            val result = ImportResult.Cancelled(
+                importedCount = importedCount,
+                failedCount = failedCount
+            )
+            onProgress(ImportProgress.Complete(result))
+            throw e
+        }
+
+        val result = ImportResult.Success(
+            importedCount = importedCount,
+            failedCount = failedCount,
+            failedRecipes = failedRecipeNames
+        )
+        onProgress(ImportProgress.Complete(result))
+        return result
+    }
+
+    /**
+     * Import recipes sequentially (one API call per recipe).
+     * Used as fallback for single-recipe imports or when batch creation fails.
+     */
+    private suspend fun executeSequential(
+        paprikaRecipes: List<PaprikaRecipe>,
+        onProgress: suspend (ImportProgress) -> Unit
+    ): ImportResult {
         var importedCount = 0
         var failedCount = 0
         val failedRecipes = mutableListOf<String>()

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/PaprikaImportWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/PaprikaImportWorker.kt
@@ -44,6 +44,8 @@ class PaprikaImportWorker @AssistedInject constructor(
         const val RESULT_NO_API_KEY = "no_api_key"
 
         const val PROGRESS_PARSING = "parsing"
+        const val PROGRESS_SUBMITTING_BATCH = "submitting_batch"
+        const val PROGRESS_WAITING_FOR_BATCH = "waiting_for_batch"
         const val PROGRESS_IMPORTING = "importing"
 
         fun createInputData(
@@ -103,6 +105,23 @@ class PaprikaImportWorker @AssistedInject constructor(
                             ))
                             "Reading Paprika export..."
                         }
+                        is ImportPaprikaUseCase.ImportProgress.SubmittingBatch -> {
+                            setProgress(workDataOf(
+                                KEY_PROGRESS to PROGRESS_SUBMITTING_BATCH,
+                                KEY_IMPORT_ID to importId,
+                                KEY_TOTAL to progress.total
+                            ))
+                            "Submitting ${progress.total} recipes for batch processing..."
+                        }
+                        is ImportPaprikaUseCase.ImportProgress.WaitingForBatch -> {
+                            setProgress(workDataOf(
+                                KEY_PROGRESS to PROGRESS_WAITING_FOR_BATCH,
+                                KEY_IMPORT_ID to importId,
+                                KEY_TOTAL to progress.total,
+                                KEY_PROGRESS_IMPORTED_COUNT to progress.succeeded
+                            ))
+                            "AI processing: ${progress.succeeded}/${progress.total} complete..."
+                        }
                         is ImportPaprikaUseCase.ImportProgress.ImportingRecipe -> {
                             setProgress(
                                 workDataOf(
@@ -115,7 +134,7 @@ class PaprikaImportWorker @AssistedInject constructor(
                                     KEY_PROGRESS_FAILED_COUNT to progress.failedSoFar
                                 )
                             )
-                            "Importing ${progress.current}/${progress.total}: ${progress.recipeName}"
+                            "Saving ${progress.current}/${progress.total}: ${progress.recipeName}"
                         }
                         is ImportPaprikaUseCase.ImportProgress.Complete -> "Complete!"
                     }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -289,7 +289,7 @@ app: {
       }
       import_paprika: {
         label: ImportPaprikaUseCase
-        tooltip: "Imports recipes from Paprika export (.paprikarecipes). Parses export, sends recipe content through ParseHtmlUseCase.parseText(). Resolves images by priority: base64 photo_data (saved directly to local storage), image_url, or og:image from source page. Supports cooperative cancellation — checks coroutine state between recipes and preserves already-imported recipes on cancel."
+        tooltip: "Imports recipes from Paprika export (.paprikarecipes). Uses Message Batches API for multiple recipes (50% cheaper): prepares all recipes, submits as a single batch, polls for completion, processes results. Falls back to sequential processing for single recipes or when batch creation fails. Resolves images by priority: base64 photo_data (saved directly to local storage), image_url, or og:image from source page. Supports cooperative cancellation — cancels batch on server and preserves already-imported recipes."
       }
       export_zip: {
         label: ExportToZipUseCase
@@ -524,7 +524,7 @@ app: {
 
       anthropic_svc: {
         label: AnthropicService
-        tooltip: "Uses the Anthropic Java SDK (OkHttp) to parse recipes with volume/weight conversions, step-level ingredient extraction, and optional field detection. Thinking is configurable via settings: uses adaptive thinking for Opus 4.6 and Sonnet 4.6, extended thinking with budget for older models. Supports Opus 4.6, Opus 4.5, Sonnet 4.5, and Haiku 4.5"
+        tooltip: "Uses the Anthropic Java SDK (OkHttp) to parse recipes with volume/weight conversions, step-level ingredient extraction, and optional field detection. Thinking is configurable via settings: uses adaptive thinking for Opus 4.6 and Sonnet 4.6, extended thinking with budget for older models. Supports Opus 4.6, Opus 4.5, Sonnet 4.5, and Haiku 4.5. Supports Message Batches API for bulk imports (Paprika): creates batch, polls for completion, streams results. Batch mode is 50% cheaper than synchronous calls."
       }
       scraper: {
         label: WebScraperService
@@ -642,7 +642,8 @@ app: {
   domain.util.zip_import_helper -> data.repository.meal_plan_repo: import meal plans
   domain.util.zip_import_helper -> data.remote.image_dl: download image
   domain.usecases.import_paprika -> data.paprika.parser: parse export
-  domain.usecases.import_paprika -> domain.usecases.parse_html: parseText
+  domain.usecases.import_paprika -> domain.usecases.parse_html: parseText, saveBatchResult
+  domain.usecases.import_paprika -> data.remote.anthropic_svc: batch API
   domain.usecases.regenerate -> data.remote.scraper: fetch HTML if not cached
   domain.usecases.import_paprika -> data.remote.scraper: fetch source image
   domain.usecases.parse_html -> data.remote.image_dl: download image
@@ -697,9 +698,9 @@ legend: {
   }
   pap1: "1. User picks .paprikarecipes file, selects recipes to import"
   pap2: "2. PaprikaImportWorker parses ZIP of gzip-compressed JSON (filtered to selected)"
-  pap3: "3. Each recipe's content (not source URL) sent to AI"
-  pap4: "4. Image resolved from Paprika data or source page"
-  pap5: "5. Repository saves each parsed recipe to Room"
+  pap3: "3. For multiple recipes: submit all as a batch via Message Batches API (50% cheaper, parallel)"
+  pap4: "4. Poll for batch completion, then stream results and save each recipe"
+  pap5: "5. Images resolved from Paprika data or source page; single recipes use sequential API"
 
   pap1 -> pap2 -> pap3 -> pap4 -> pap5
 
@@ -733,7 +734,7 @@ legend: {
   share1 -> share2 -> share3 -> share4
 
   note: {
-    label: "All imports run in background via WorkManager (URL, Paprika, .lorecipes). Import queue is database-backed (PendingImportEntity) and persists across app restarts. Supports multiple concurrent imports with individual cancellation from the recipe list via swipe-to-dismiss. Page metadata (title, image) is fetched cheaply before AI parsing begins. Paprika import runs in background with progress notifications and can be cancelled mid-way, keeping already-imported recipes. Export uses .lorecipes format (ZIP with RecipeSerializer) for both single recipe share and bulk backup."
+    label: "All imports run in background via WorkManager (URL, Paprika, .lorecipes). Import queue is database-backed (PendingImportEntity) and persists across app restarts. Supports multiple concurrent imports with individual cancellation from the recipe list via swipe-to-dismiss. Page metadata (title, image) is fetched cheaply before AI parsing begins. Paprika import uses the Message Batches API for multiple recipes (50% cheaper), submitting all recipes as a single batch for parallel processing, with fallback to sequential for single recipes. Batch cancellation propagates to the server. Export uses .lorecipes format (ZIP with RecipeSerializer) for both single recipe share and bulk backup."
     style: {
       font-size: 12
       italic: true


### PR DESCRIPTION
## Summary
- Switch Paprika multi-recipe imports to use the Anthropic Message Batches API, which processes all recipes in parallel at 50% of the standard API cost
- Add batch API methods to `AnthropicService` (`createRecipeBatch`, `retrieveBatch`, `cancelBatch`, `getBatchResults`, `parseMessageResult`)
- Refactor `ImportPaprikaUseCase` to submit all recipes as a single batch, poll for completion, and process results; falls back to sequential processing for single recipes or when batch creation fails
- Add `saveBatchResult` and `saveBatchErrorDebugEntry` methods to `ParseHtmlUseCase` for handling batch results
- Add `batchMode` column to `ImportDebugEntity` with Room migration v11→v12
- Update cost estimation in `ImportDebugDetailScreen` to use batch pricing (50% cheaper) when `batchMode` is true
- Update `PaprikaImportWorker` to handle new `SubmittingBatch` and `WaitingForBatch` progress states
- Update architecture diagram to document batch processing flow

## Test plan
- [ ] Import a single recipe from Paprika (should use sequential mode, not batch)
- [ ] Import multiple recipes from Paprika (should use batch mode)
- [ ] Verify batch progress states show in notifications (submitting, waiting, saving)
- [ ] Cancel a batch import mid-processing and verify server-side cancellation
- [ ] Check import debug screen shows "(batch)" suffix on cost estimates for batch imports
- [ ] Verify Room migration from v11→v12 succeeds on existing database
- [ ] Test batch fallback: if batch creation fails, sequential import should work

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)