### PR TITLE
feat: add AI instructions input to the edit pane

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/EditRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/EditRecipeUseCase.kt
@@ -41,6 +41,7 @@ class EditRecipeUseCase @Inject constructor(
      * @param saveAsCopy If true, saves as a new recipe instead of updating the existing one
      * @param model The AI model to use (null = use current setting)
      * @param thinkingEnabled Whether to use extended thinking (null = use current setting)
+     * @param aiInstructions Optional user instructions for the AI (e.g. "Make this recipe vegan")
      * @param onProgress Callback for progress updates
      */
     suspend fun execute(
@@ -49,6 +50,7 @@ class EditRecipeUseCase @Inject constructor(
         saveAsCopy: Boolean = false,
         model: String? = null,
         thinkingEnabled: Boolean? = null,
+        aiInstructions: String? = null,
         onProgress: suspend (EditProgress) -> Unit = {}
     ): EditResult {
         // Load existing recipe to preserve metadata
@@ -72,6 +74,7 @@ class EditRecipeUseCase @Inject constructor(
             model = model,
             thinkingEnabled = thinkingEnabled,
             densityOverrides = densityOverrides,
+            aiInstructions = aiInstructions,
             onProgress = { progress ->
                 when (progress) {
                     is ParseHtmlUseCase.ParseProgress.ExtractingContent -> {}

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -101,6 +101,7 @@ class ParseHtmlUseCase @Inject constructor(
      * @param model AI model override (null = use current setting)
      * @param thinkingEnabled Extended thinking override (null = use current setting)
      * @param densityOverrides Optional density overrides from existing recipe (merged with defaults for cheaper editing)
+     * @param aiInstructions Optional user instructions for the AI (e.g. "Make this recipe vegan")
      * @param onProgress Callback for progress updates
      * @return The parsed recipe or error
      */
@@ -113,6 +114,7 @@ class ParseHtmlUseCase @Inject constructor(
         model: String? = null,
         thinkingEnabled: Boolean? = null,
         densityOverrides: Map<String, Double>? = null,
+        aiInstructions: String? = null,
         onProgress: suspend (ParseProgress) -> Unit = {}
     ): ParseResult {
         // Check for API key
@@ -128,7 +130,7 @@ class ParseHtmlUseCase @Inject constructor(
         // Parse with AI
         onProgress(ParseProgress.ParsingRecipe)
         val startTime = System.currentTimeMillis()
-        val parseResult = anthropicService.parseRecipe(text, apiKey, model, thinkingEnabled, densityOverrides)
+        val parseResult = anthropicService.parseRecipe(text, apiKey, model, thinkingEnabled, densityOverrides, aiInstructions)
         val durationMs = System.currentTimeMillis() - startTime
         if (parseResult.isFailure) {
             val errorMessage = "Failed to parse recipe: ${parseResult.exceptionOrNull()?.message}"

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
@@ -80,6 +80,7 @@ fun EditRecipeScreen(
     val title by viewModel.title.collectAsStateWithLifecycle()
     val sourceUrl by viewModel.sourceUrl.collectAsStateWithLifecycle()
     val markdownText by viewModel.markdownText.collectAsStateWithLifecycle()
+    val aiInstructions by viewModel.aiInstructions.collectAsStateWithLifecycle()
     val editState by viewModel.editState.collectAsStateWithLifecycle()
     val model by viewModel.model.collectAsStateWithLifecycle()
     val thinkingEnabled by viewModel.thinkingEnabled.collectAsStateWithLifecycle()
@@ -196,6 +197,8 @@ fun EditRecipeScreen(
                     onTitleChange = viewModel::setTitle,
                     sourceUrl = sourceUrl,
                     onSourceUrlChange = viewModel::setSourceUrl,
+                    aiInstructions = aiInstructions,
+                    onAiInstructionsChange = viewModel::setAiInstructions,
                     markdownText = markdownText,
                     onMarkdownChange = viewModel::setMarkdownText,
                     model = model,
@@ -285,6 +288,8 @@ private fun EditContent(
     onTitleChange: (String) -> Unit,
     sourceUrl: String?,
     onSourceUrlChange: (String?) -> Unit,
+    aiInstructions: String,
+    onAiInstructionsChange: (String) -> Unit,
     markdownText: String,
     onMarkdownChange: (String) -> Unit,
     model: String,
@@ -347,6 +352,29 @@ private fun EditContent(
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text(stringResource(R.string.source_url_field)) },
                 singleLine = true
+            )
+
+            HorizontalDivider()
+
+            // AI instructions section
+            Text(
+                text = stringResource(R.string.ai_instructions),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = stringResource(R.string.ai_instructions_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            OutlinedTextField(
+                value = aiInstructions,
+                onValueChange = onAiInstructionsChange,
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text(stringResource(R.string.ai_instructions_placeholder)) },
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Sentences
+                )
             )
 
             HorizontalDivider()

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeEditWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeEditWorker.kt
@@ -29,6 +29,7 @@ class RecipeEditWorker @AssistedInject constructor(
         const val KEY_MODEL = "model"
         const val KEY_EXTENDED_THINKING = "extended_thinking"
         const val KEY_SAVE_AS_COPY = "save_as_copy"
+        const val KEY_AI_INSTRUCTIONS = "ai_instructions"
         const val KEY_ERROR_MESSAGE = "error_message"
         const val KEY_PROGRESS = "progress"
         const val KEY_RESULT_TYPE = "result_type"
@@ -47,14 +48,16 @@ class RecipeEditWorker @AssistedInject constructor(
             markdownText: String,
             model: String?,
             thinkingEnabled: Boolean?,
-            saveAsCopy: Boolean = false
+            saveAsCopy: Boolean = false,
+            aiInstructions: String? = null
         ): Data {
             return workDataOf(
                 KEY_RECIPE_ID to recipeId,
                 KEY_MARKDOWN_TEXT to markdownText,
                 KEY_MODEL to model,
                 KEY_EXTENDED_THINKING to thinkingEnabled,
-                KEY_SAVE_AS_COPY to saveAsCopy
+                KEY_SAVE_AS_COPY to saveAsCopy,
+                KEY_AI_INSTRUCTIONS to aiInstructions
             )
         }
     }
@@ -81,6 +84,7 @@ class RecipeEditWorker @AssistedInject constructor(
             null
         }
         val saveAsCopy = inputData.getBoolean(KEY_SAVE_AS_COPY, false)
+        val aiInstructions = inputData.getString(KEY_AI_INSTRUCTIONS)
 
         setForegroundProgress(if (saveAsCopy) "Saving copy..." else "Updating recipe...")
 
@@ -90,6 +94,7 @@ class RecipeEditWorker @AssistedInject constructor(
             saveAsCopy = saveAsCopy,
             model = model,
             thinkingEnabled = thinkingEnabled,
+            aiInstructions = aiInstructions,
             onProgress = { progress ->
                 val progressMessage = when (progress) {
                     is EditRecipeUseCase.EditProgress.ParsingRecipe -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,9 @@
     <string name="recipe_title">Title</string>
     <string name="source_url_field">Source URL</string>
     <string name="recipe_text">Recipe Text</string>
+    <string name="ai_instructions">AI Instructions</string>
+    <string name="ai_instructions_placeholder">Parse this recipe</string>
+    <string name="ai_instructions_description">Optionally provide instructions for the AI, e.g. \"Make this recipe vegan\" or \"Convert to metric units\".</string>
 
     <!-- Regenerate Recipe -->
     <string name="regenerate">Regenerate</string>

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -65,7 +65,7 @@ app: {
       }
       edit: {
         label: EditRecipeScreen
-        tooltip: "Recipe edit screen with three sections: (1) Image section — pick from gallery or remove, saved directly without AI. (2) Title and source URL fields — edited directly, saved without AI when recipe body is unchanged. (3) Recipe body markdown editor — when body changes are saved, AI cleans up formatting and regenerates structured data (densities, etc.) with existing ingredient densities passed as hints for cheaper AI models. Includes model selection and extended thinking toggle. Also supports regeneration from original source via refresh icon (when original HTML or source URL is available). Save as Copy creates a new recipe from the edited markdown instead of updating the existing one."
+        tooltip: "Recipe edit screen with four sections: (1) Image section — pick from gallery or remove, saved directly without AI. (2) Title and source URL fields — edited directly, saved without AI when recipe body is unchanged. (3) AI instructions — optional text field for user instructions to the AI (e.g. 'Make this recipe vegan'), included in the AI prompt when non-empty. (4) Recipe body markdown editor — when body changes or AI instructions are provided, AI cleans up formatting and regenerates structured data (densities, etc.) with existing ingredient densities passed as hints for cheaper AI models. Includes model selection and extended thinking toggle. Also supports regeneration from original source via refresh icon (when original HTML or source URL is available). Save as Copy creates a new recipe from the edited markdown instead of updating the existing one."
       }
       add: AddRecipeScreen
       settings: SettingsScreen
@@ -135,7 +135,7 @@ app: {
       detail_vm: RecipeDetailViewModel
       edit_vm: {
         label: EditRecipeViewModel
-        tooltip: "Manages edit recipe screen state. Supports direct image editing (saved immediately without AI). Separates title, source URL, and recipe body: title/URL changes are saved directly without AI, while body changes trigger AI re-parsing via RecipeEditWorker. Defaults to the separate edit model setting (default: Sonnet) rather than the import model. Tracks model/thinking settings. Supports save as copy and regeneration from original source via RecipeRegenerateWorker. Uses ImageDownloadService to save picked images from gallery."
+        tooltip: "Manages edit recipe screen state. Supports direct image editing (saved immediately without AI). Separates title, source URL, AI instructions, and recipe body: title/URL changes are saved directly without AI, while body changes or non-empty AI instructions trigger AI re-parsing via RecipeEditWorker. AI instructions are optional free-text (e.g. 'Make this recipe vegan') passed through the worker to the AI prompt. Defaults to the separate edit model setting (default: Sonnet) rather than the import model. Tracks model/thinking settings. Supports save as copy and regeneration from original source via RecipeRegenerateWorker. Uses ImageDownloadService to save picked images from gallery."
       }
       add_vm: AddRecipeViewModel
       settings_vm: SettingsViewModel
@@ -309,7 +309,7 @@ app: {
       }
       edit_recipe: {
         label: EditRecipeUseCase
-        tooltip: "Edits a recipe by sending user-modified markdown text through ParseHtmlUseCase.parseText() for AI re-parsing. Collects existing ingredient densities and passes them as hints to the AI, enabling cheaper models (like Haiku) to reuse known values. Preserves recipe ID, createdAt, favorite status, image, source URL, and original HTML (for future regeneration). Supports saveAsCopy mode which generates a new UUID and fresh timestamps for the copied recipe."
+        tooltip: "Edits a recipe by sending user-modified markdown text through ParseHtmlUseCase.parseText() for AI re-parsing. Supports optional AI instructions (e.g. 'Make this recipe vegan') appended to the user message. Collects existing ingredient densities and passes them as hints to the AI, enabling cheaper models (like Haiku) to reuse known values. Preserves recipe ID, createdAt, favorite status, image, source URL, and original HTML (for future regeneration). Supports saveAsCopy mode which generates a new UUID and fresh timestamps for the copied recipe."
       }
       aggregate_grocery: {
         label: AggregateGroceryListUseCase
@@ -712,9 +712,9 @@ legend: {
     }
   }
   edit1: "1. User taps edit (pencil icon) on recipe detail screen"
-  edit2: "2. EditRecipeScreen shows image picker, title/URL fields, and recipe body (markdown) as separate sections"
+  edit2: "2. EditRecipeScreen shows image picker, title/URL fields, optional AI instructions, and recipe body (markdown) as separate sections"
   edit3: "3. Image, title, and URL changes are saved directly without AI re-parsing"
-  edit4: "4. Recipe body edits trigger AI cycle: RecipeEditWorker via EditRecipeUseCase (with existing density hints)"
+  edit4: "4. Recipe body edits or non-empty AI instructions trigger AI cycle: RecipeEditWorker via EditRecipeUseCase (with existing density hints and user instructions)"
   edit5: "5. AI re-parses into structured recipe, preserving user's image (Save preserves ID/metadata; Save as Copy creates new recipe)"
 
   edit1 -> edit2 -> edit3 -> edit4 -> edit5


### PR DESCRIPTION
## Summary
- Adds an optional "AI Instructions" text input to the recipe edit screen, placed between the title/URL section and the recipe body markdown editor
- When non-empty, instructions are appended to the AI prompt as "The user also provided these instructions: [text]"
- If AI instructions are provided (even without body changes), the AI re-parsing cycle is triggered, enabling use cases like "Make this recipe vegan"
- Field defaults to empty with placeholder text "Parse this recipe" and description explaining usage

## Test plan
- [ ] Open edit screen for a recipe, verify the new "AI Instructions" field appears between title/URL and recipe body sections
- [ ] Save without changing anything (instructions empty) — should behave as before (no AI cycle)
- [ ] Type instructions like "Make this vegan" without changing recipe body, save — should trigger AI cycle
- [ ] Change recipe body with instructions — should include instructions in AI prompt
- [ ] Save as Copy with instructions — should include instructions
- [ ] Verify placeholder text says "Parse this recipe" and description mentions example uses

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)