### PR TITLE
feat: store recipe images in Firebase Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,26 @@ Cloud sync is optional — the app works fully offline without it. To enable syn
      }
      ```
 
-Data is stored at `users/{userId}/recipes/{recipeId}` and `users/{userId}/mealPlans/{mealPlanId}`, so each user's data is fully isolated.
+6. Enable **Cloud Storage for Firebase**:
+   - Go to **Storage** and click "Get started"
+   - Use the existing bucket (e.g., `gs://lion-otter-recipes.firebasestorage.app`) or create one
+   - Set the security rules to restrict access per user and validate image uploads:
+     ```
+     rules_version = '2';
+     service firebase.storage {
+       match /b/{bucket}/o {
+         match /users/{userId}/images/{fileName} {
+           allow read: if request.auth != null && request.auth.uid == userId;
+           allow write: if request.auth != null
+             && request.auth.uid == userId
+             && request.resource.contentType.matches('image/.*')
+             && request.resource.size < 5 * 1024 * 1024;
+         }
+       }
+     }
+     ```
+
+Data is stored at `users/{userId}/recipes/{recipeId}` and `users/{userId}/mealPlans/{mealPlanId}`, so each user's data is fully isolated. Recipe images are stored in Firebase Storage at `users/{userId}/images/{filename}`.
 
 ## App Setup
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth)
     implementation(libs.firebase.firestore)
+    implementation(libs.firebase.storage)
 
     // Credentials (Google Sign-In)
     implementation(libs.credentials)

--- a/app/src/main/kotlin/com/lionotter/recipes/LionOtterApp.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/LionOtterApp.kt
@@ -3,12 +3,16 @@ package com.lionotter.recipes
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import com.lionotter.recipes.data.remote.FirebaseStorageCoilFetcher
+import com.lionotter.recipes.data.remote.FirebaseStorageKeyer
 import com.lionotter.recipes.notification.RecipeNotificationHelper
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
 @HiltAndroidApp
-class LionOtterApp : Application(), Configuration.Provider {
+class LionOtterApp : Application(), Configuration.Provider, SingletonImageLoader.Factory {
 
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
@@ -25,4 +29,13 @@ class LionOtterApp : Application(), Configuration.Provider {
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
             .build()
+
+    override fun newImageLoader(context: android.content.Context): ImageLoader {
+        return ImageLoader.Builder(context)
+            .components {
+                add(FirebaseStorageKeyer())
+                add(FirebaseStorageCoilFetcher.Factory(context))
+            }
+            .build()
+    }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/FirebaseStorageCoilFetcher.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/FirebaseStorageCoilFetcher.kt
@@ -1,0 +1,81 @@
+package com.lionotter.recipes.data.remote
+
+import android.content.Context
+import coil3.ImageLoader
+import coil3.decode.DataSource
+import coil3.decode.ImageSource
+import coil3.fetch.FetchResult
+import coil3.fetch.Fetcher
+import coil3.fetch.SourceFetchResult
+import coil3.key.Keyer
+import coil3.request.Options
+import okio.Path.Companion.toOkioPath
+import java.io.IOException
+
+/**
+ * Wrapper type so Coil dispatches to our [Fetcher.Factory] instead of the
+ * built-in Uri fetcher. Coil 3's service-loaded fetchers claim plain [Uri]
+ * and [String] before user-registered factories, so we need a distinct type.
+ *
+ * Pass this directly as the `model` in Coil `AsyncImage`/`SubcomposeAsyncImage`
+ * calls for `gs://` URIs. Use [imageModel] to convert a nullable image URL
+ * string to the correct Coil model type.
+ */
+data class FirebaseStorageUri(val uri: String)
+
+/**
+ * Converts an image URL string to the appropriate Coil model.
+ *
+ * - `gs://` URIs → [FirebaseStorageUri] (handled by [FirebaseStorageCoilFetcher])
+ * - Other URLs (http://, content://, file://) → passed through as-is for Coil's built-in fetchers
+ * - `null` → `null`
+ */
+fun imageModel(imageUrl: String?): Any? {
+    if (imageUrl == null) return null
+    return if (imageUrl.startsWith("gs://")) FirebaseStorageUri(imageUrl) else imageUrl
+}
+
+/**
+ * Coil [Keyer] that provides a stable memory cache key for [FirebaseStorageUri].
+ */
+class FirebaseStorageKeyer : Keyer<FirebaseStorageUri> {
+    override fun key(data: FirebaseStorageUri, options: Options): String {
+        return data.uri
+    }
+}
+
+/**
+ * Coil [Fetcher] that handles Firebase Storage images referenced by `gs://` URIs
+ * (e.g., `gs://bucket/users/{uid}/images/{filename}`).
+ *
+ * Downloads are delegated to [ImageCacheConfig.resolveToFile], which shares
+ * the same local cache used by [ImageSyncService] for export/import flows.
+ */
+class FirebaseStorageCoilFetcher(
+    private val storageUri: String,
+    private val context: Context
+) : Fetcher {
+
+    override suspend fun fetch(): FetchResult {
+        val cacheFile = ImageCacheConfig.resolveToFile(storageUri, context)
+            ?: throw IOException("Failed to download image: $storageUri")
+
+        return SourceFetchResult(
+            source = ImageSource(
+                file = cacheFile.toOkioPath(),
+                fileSystem = okio.FileSystem.SYSTEM
+            ),
+            mimeType = null,
+            dataSource = DataSource.DISK
+        )
+    }
+
+    /**
+     * Factory that creates [FirebaseStorageCoilFetcher] for [FirebaseStorageUri] data.
+     */
+    class Factory(private val context: Context) : Fetcher.Factory<FirebaseStorageUri> {
+        override fun create(data: FirebaseStorageUri, options: Options, imageLoader: ImageLoader): Fetcher {
+            return FirebaseStorageCoilFetcher(data.uri, context)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/ImageSyncService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/ImageSyncService.kt
@@ -1,0 +1,270 @@
+package com.lionotter.recipes.data.remote
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.core.graphics.scale
+import android.util.Log
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
+import com.google.firebase.storage.StorageException
+import com.google.firebase.storage.storage
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.tasks.await
+import java.io.ByteArrayOutputStream
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Shared constants and helpers for local image caching. */
+object ImageCacheConfig {
+    const val IMAGE_CACHE_DIR = "recipe_images"
+    const val MAX_IMAGE_BYTES = 5 * 1024 * 1024L // 5 MB
+    private const val TAG = "ImageCacheConfig"
+
+    fun getImageCacheDir(context: Context): File {
+        val dir = File(context.filesDir, IMAGE_CACHE_DIR)
+        if (!dir.exists()) {
+            dir.mkdirs()
+        }
+        return dir
+    }
+
+    /**
+     * Resolve a `gs://` URI to a local cache [File], downloading from Firebase Storage
+     * if not already cached. Returns `null` on failure.
+     */
+    suspend fun resolveToFile(gsUri: String, context: Context): File? {
+        val filename = gsUri.substringAfterLast("/")
+        val cacheFile = File(getImageCacheDir(context), filename)
+
+        if (cacheFile.exists() && cacheFile.length() > 0) {
+            return cacheFile
+        }
+
+        return try {
+            val ref = Firebase.storage.getReferenceFromUrl(gsUri)
+            val bytes = ref.getBytes(MAX_IMAGE_BYTES).await()
+            cacheFile.writeBytes(bytes)
+            Log.d(TAG, "Downloaded $gsUri to cache (${bytes.size} bytes)")
+            cacheFile
+        } catch (e: StorageException) {
+            if (e.errorCode == StorageException.ERROR_OBJECT_NOT_FOUND) {
+                Log.d(TAG, "Image not found in storage: $gsUri")
+            } else {
+                Log.w(TAG, "Failed to download image: $gsUri", e)
+            }
+            null
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to download image: $gsUri", e)
+            null
+        }
+    }
+}
+
+/**
+ * Syncs recipe images between local storage and Firebase Storage.
+ *
+ * Images are stored in Firebase Storage and referenced via `gs://` URIs
+ * (e.g., `gs://bucket/users/{uid}/images/{filename}`). This makes the bucket
+ * explicit and produces a well-formed URI with a scheme that Coil can match on.
+ *
+ * Strategy:
+ * - On save: upload local image to Firebase Storage, return a `gs://` URI
+ *   that gets stored in the recipe's `imageUrl` field in Firestore
+ * - On display: if imageUrl is a `gs://` URI, check local cache first;
+ *   if not cached, download from Firebase Storage to local cache
+ * - Images are resized before upload to keep retina quality but avoid
+ *   excessively large files (max 2048px on longest side)
+ * - Orphaned images in Storage are cleaned up when recipes are deleted
+ *
+ */
+@Singleton
+class ImageSyncService @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private const val TAG = "ImageSyncService"
+        private const val MAX_IMAGE_DIMENSION = 2048
+        private const val JPEG_QUALITY = 85
+    }
+
+    private val storage = Firebase.storage
+
+    private fun requireUid(): String {
+        return Firebase.auth.currentUser?.uid
+            ?: throw IllegalStateException("User not authenticated")
+    }
+
+    /**
+     * Upload a local image file to Firebase Storage.
+     * Resizes the image if it exceeds [MAX_IMAGE_DIMENSION] on its longest side.
+     *
+     * @param localUri A file:// URI pointing to the local image
+     * @return A gs:// URI (e.g., "gs://bucket/users/{uid}/images/{filename}")
+     *         or null if upload fails
+     */
+    suspend fun uploadImage(localUri: String): String? {
+        if (!localUri.startsWith("file://")) {
+            Log.w(TAG, "Not a local file URI: $localUri")
+            return null
+        }
+
+        val path = localUri.removePrefix("file://")
+        val file = File(path)
+        if (!file.exists()) {
+            Log.w(TAG, "Local file does not exist: $path")
+            return null
+        }
+
+        return try {
+            val uid = requireUid()
+            val imageBytes = resizeImageIfNeeded(file)
+            val storagePath = "users/$uid/images/${file.name}"
+            val ref = storage.reference.child(storagePath)
+
+            ref.putBytes(imageBytes).await()
+            val gsUri = "gs://${storage.reference.bucket}/$storagePath"
+            Log.d(TAG, "Uploaded image to $gsUri (${imageBytes.size} bytes)")
+            gsUri
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to upload image: $localUri", e)
+            null
+        }
+    }
+
+    /**
+     * Ensure a local cached copy of an image exists.
+     * If the imageUrl is a Firebase Storage URI, downloads it to local cache.
+     * If it's already a local file://, returns it as-is (if it exists).
+     *
+     * @param imageUrl A gs:// URI or local file:// URI
+     * @return A local file:// URI, or null if the image cannot be resolved
+     */
+    suspend fun ensureLocalImage(imageUrl: String?): String? {
+        if (imageUrl == null) return null
+
+        // Already a local file — check it exists
+        if (imageUrl.startsWith("file://")) {
+            val path = imageUrl.removePrefix("file://")
+            return if (File(path).exists()) imageUrl else null
+        }
+
+        // Firebase Storage URI
+        if (isStoragePath(imageUrl)) {
+            return downloadToCache(imageUrl)
+        }
+
+        // Remote URL — not handled here (ImageDownloadService handles these)
+        return null
+    }
+
+    /**
+     * Download an image from Firebase Storage to the local cache directory.
+     * Returns the local file:// URI, or null if download fails.
+     * If the file is already cached, returns the existing cache path.
+     *
+     * @param imageUrl A gs:// URI (e.g., "gs://bucket/users/{uid}/images/{file}")
+     */
+    private suspend fun downloadToCache(imageUrl: String): String? {
+        val cacheFile = ImageCacheConfig.resolveToFile(imageUrl, context) ?: return null
+        return "file://${cacheFile.absolutePath}"
+    }
+
+    /**
+     * Delete an image from Firebase Storage.
+     * Best-effort — logs but does not propagate failures.
+     *
+     * @param imageUrl A gs:// URI
+     */
+    suspend fun deleteRemoteImage(imageUrl: String) {
+        if (!isStoragePath(imageUrl)) return
+        try {
+            storage.getReferenceFromUrl(imageUrl).delete().await()
+            Log.d(TAG, "Deleted remote image: $imageUrl")
+        } catch (e: StorageException) {
+            if (e.errorCode == StorageException.ERROR_OBJECT_NOT_FOUND) {
+                Log.d(TAG, "Remote image already deleted: $imageUrl")
+            } else {
+                Log.w(TAG, "Failed to delete remote image: $imageUrl", e)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to delete remote image: $imageUrl", e)
+        }
+    }
+
+    /**
+     * Resize an image file if it exceeds [MAX_IMAGE_DIMENSION] on its longest side.
+     * Returns the (potentially resized) image bytes as JPEG.
+     */
+    private fun resizeImageIfNeeded(file: File): ByteArray {
+        // First, decode just the bounds to check dimensions
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(file.absolutePath, options)
+
+        val originalWidth = options.outWidth
+        val originalHeight = options.outHeight
+
+        if (originalWidth <= 0 || originalHeight <= 0) {
+            // Can't decode as bitmap — return raw bytes
+            return file.readBytes()
+        }
+
+        val longestSide = maxOf(originalWidth, originalHeight)
+        if (longestSide <= MAX_IMAGE_DIMENSION && file.length() <= ImageCacheConfig.MAX_IMAGE_BYTES) {
+            // No resize needed — return original bytes
+            return file.readBytes()
+        }
+
+        // Calculate sample size for efficient decoding
+        val sampleSize = calculateInSampleSize(originalWidth, originalHeight, MAX_IMAGE_DIMENSION)
+        val decodeOptions = BitmapFactory.Options().apply { inSampleSize = sampleSize }
+        val sampledBitmap = BitmapFactory.decodeFile(file.absolutePath, decodeOptions)
+            ?: return file.readBytes()
+
+        // Scale to exact target dimensions if still too large
+        val bitmap = if (maxOf(sampledBitmap.width, sampledBitmap.height) > MAX_IMAGE_DIMENSION) {
+            val scale = MAX_IMAGE_DIMENSION.toFloat() / maxOf(sampledBitmap.width, sampledBitmap.height)
+            val targetWidth = (sampledBitmap.width * scale).toInt()
+            val targetHeight = (sampledBitmap.height * scale).toInt()
+            val scaled = sampledBitmap.scale(targetWidth, targetHeight)
+            if (scaled !== sampledBitmap) sampledBitmap.recycle()
+            scaled
+        } else {
+            sampledBitmap
+        }
+
+        val baos = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, baos)
+        bitmap.recycle()
+
+        Log.d(
+            TAG, "Resized image: ${originalWidth}x${originalHeight} -> " +
+                "${bitmap.width}x${bitmap.height}, ${file.length()} -> ${baos.size()} bytes"
+        )
+        return baos.toByteArray()
+    }
+
+    /**
+     * Calculate the largest inSampleSize value that is a power of 2 and keeps both
+     * the width and height larger than [targetSize].
+     */
+    private fun calculateInSampleSize(width: Int, height: Int, targetSize: Int): Int {
+        var inSampleSize = 1
+        if (width > targetSize || height > targetSize) {
+            val halfWidth = width / 2
+            val halfHeight = height / 2
+            while ((halfWidth / inSampleSize) >= targetSize && (halfHeight / inSampleSize) >= targetSize) {
+                inSampleSize *= 2
+            }
+        }
+        return inSampleSize
+    }
+
+    /**
+     * Check if a URL is a Firebase Storage gs:// URI.
+     */
+    fun isStoragePath(url: String?): Boolean {
+        return url != null && url.startsWith("gs://")
+    }
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportToZipUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportToZipUseCase.kt
@@ -2,6 +2,7 @@ package com.lionotter.recipes.domain.usecase
 
 import android.util.Log
 import com.lionotter.recipes.data.remote.ImageDownloadService
+import com.lionotter.recipes.data.remote.ImageSyncService
 import com.lionotter.recipes.data.repository.IMealPlanRepository
 import com.lionotter.recipes.data.repository.IRecipeRepository
 import com.lionotter.recipes.domain.model.MealPlanEntry
@@ -27,6 +28,7 @@ class ExportToZipUseCase @Inject constructor(
     private val recipeSerializer: RecipeSerializer,
     private val mealPlanRepository: IMealPlanRepository,
     private val imageDownloadService: ImageDownloadService,
+    private val imageSyncService: ImageSyncService,
     private val json: Json
 ) {
     companion object {
@@ -101,7 +103,9 @@ class ExportToZipUseCase @Inject constructor(
 
                         // Write image file (if available)
                         if (recipe.imageUrl != null) {
-                            val imageFile = imageDownloadService.getLocalImageFile(recipe.imageUrl)
+                            // Resolve Firebase Storage paths to local cache first
+                            val localImageUri = imageSyncService.ensureLocalImage(recipe.imageUrl)
+                            val imageFile = localImageUri?.let { imageDownloadService.getLocalImageFile(it) }
                             if (imageFile != null) {
                                 val imageName = "${RecipeSerializer.IMAGE_FILENAME_PREFIX}${imageFile.extension.let { ".$it" }}"
                                 zipOut.putNextEntry(ZipEntry("$prefix/$imageName"))

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ParseHtmlUseCase.kt
@@ -170,8 +170,11 @@ class ParseHtmlUseCase @Inject constructor(
         // Notify that recipe name is available
         onProgress(ParseProgress.RecipeNameAvailable(parsed.name))
 
-        // Download image locally if available
+        // Download image locally if available, then upload to Firebase Storage
         val downloadResult = imageUrl?.let { imageDownloadService.downloadAndStoreWithResult(it) }
+        val storedImageUrl = downloadResult?.localUri?.let { localUri ->
+            imageDownloadService.storeImage(localUri)
+        }
 
         // Create Recipe
         val now = Clock.System.now()
@@ -187,7 +190,7 @@ class ParseHtmlUseCase @Inject constructor(
             instructionSections = parsed.instructionSections,
             equipment = parsed.equipment,
             tags = parsed.tags,
-            imageUrl = downloadResult?.localUri,
+            imageUrl = storedImageUrl,
             sourceImageUrl = downloadResult?.effectiveUrl ?: imageUrl,
             createdAt = now,
             updatedAt = now
@@ -252,8 +255,11 @@ class ParseHtmlUseCase @Inject constructor(
     ): Recipe? {
         val parsed = parsedWithUsage.result
 
-        // Download image locally if available
+        // Download image locally if available, then upload to Firebase Storage
         val downloadResult = imageUrl?.let { imageDownloadService.downloadAndStoreWithResult(it) }
+        val storedImageUrl = downloadResult?.localUri?.let { localUri ->
+            imageDownloadService.storeImage(localUri)
+        }
 
         // Create Recipe
         val now = Clock.System.now()
@@ -269,7 +275,7 @@ class ParseHtmlUseCase @Inject constructor(
             instructionSections = parsed.instructionSections,
             equipment = parsed.equipment,
             tags = parsed.tags,
-            imageUrl = downloadResult?.localUri,
+            imageUrl = storedImageUrl,
             sourceImageUrl = downloadResult?.effectiveUrl ?: imageUrl,
             createdAt = now,
             updatedAt = now

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/util/ZipImportHelper.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/util/ZipImportHelper.kt
@@ -123,10 +123,12 @@ class ZipImportHelper @Inject constructor(
 
             // Try to use bundled image from the ZIP first, then fall back to download
             val localImageUrl = importImageFromZipOrDownload(imageFiles, recipe.imageUrl, recipe.sourceImageUrl)
+            // Upload to Firebase Storage for cross-device sync
+            val storedImageUrl = localImageUrl?.let { imageDownloadService.storeImage(it) }
 
             val importedRecipe = recipe.copy(
                 updatedAt = Clock.System.now(),
-                imageUrl = localImageUrl
+                imageUrl = storedImageUrl
             )
             val originalHtml = files[RecipeSerializer.RECIPE_HTML_FILENAME]
             recipeRepository.saveRecipe(importedRecipe, originalHtml)

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/components/RecipeThumbnail.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/components/RecipeThumbnail.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
+import com.lionotter.recipes.data.remote.imageModel
 
 /**
  * A recipe thumbnail that always reserves space for consistent layout alignment.
@@ -45,7 +46,7 @@ fun RecipeThumbnail(
 
     if (imageUrl != null) {
         SubcomposeAsyncImage(
-            model = imageUrl,
+            model = imageModel(imageUrl),
             contentDescription = contentDescription,
             modifier = modifier
                 .size(size.dp)

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/editrecipe/EditRecipeScreen.kt
@@ -65,6 +65,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
 import com.lionotter.recipes.R
+import com.lionotter.recipes.data.remote.imageModel
 import com.lionotter.recipes.ui.components.RecipeTopAppBar
 import com.lionotter.recipes.ui.screens.settings.components.SingleModelSelectionSection
 
@@ -479,7 +480,7 @@ private fun ImageEditSection(
             var showImage by remember(imageUrl) { mutableStateOf(true) }
             if (showImage) {
                 SubcomposeAsyncImage(
-                    model = imageUrl,
+                    model = imageModel(imageUrl),
                     contentDescription = stringResource(R.string.recipe_image),
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipedetail/components/RecipeContent.kt
@@ -44,6 +44,7 @@ import androidx.core.net.toUri
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
 import com.lionotter.recipes.R
+import com.lionotter.recipes.data.remote.imageModel
 import com.lionotter.recipes.domain.model.IngredientUsageStatus
 import com.lionotter.recipes.ui.TestTags
 import com.lionotter.recipes.domain.model.InstructionIngredientKey
@@ -85,7 +86,7 @@ fun RecipeContent(
             var showImage by remember(imageUrl) { mutableStateOf(true) }
             if (showImage) {
                 SubcomposeAsyncImage(
-                    model = imageUrl,
+                    model = imageModel(imageUrl),
                     contentDescription = recipe.name,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/test/kotlin/com/lionotter/recipes/integration/FirestoreIntegrationTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/integration/FirestoreIntegrationTest.kt
@@ -6,8 +6,14 @@ import com.google.firebase.FirebaseOptions
 import com.google.firebase.firestore.MemoryCacheSettings
 import com.google.firebase.firestore.firestore
 import com.google.firebase.firestore.firestoreSettings
+import com.lionotter.recipes.data.remote.ImageDownloadService
+import com.lionotter.recipes.data.remote.ImageSyncService
 import com.lionotter.recipes.data.repository.MealPlanRepository
 import com.lionotter.recipes.data.repository.RecipeRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
 import com.lionotter.recipes.testutil.TestFirestoreService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -67,7 +73,12 @@ abstract class FirestoreIntegrationTest {
         db.disableNetwork()
 
         firestoreService = TestFirestoreService()
-        recipeRepository = RecipeRepository(firestoreService)
+        val imageSyncService = ImageSyncService(context)
+        val httpClient = HttpClient(MockEngine) {
+            engine { addHandler { respond("", HttpStatusCode.NotFound) } }
+        }
+        val imageDownloadService = ImageDownloadService(context, httpClient, imageSyncService)
+        recipeRepository = RecipeRepository(firestoreService, imageDownloadService)
         mealPlanRepository = MealPlanRepository(firestoreService)
     }
 

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -39,7 +39,7 @@ external: {
     style: {
       fill: "#ffca28"
     }
-    tooltip: "Firebase Auth (Google Sign-In) and Cloud Firestore (recipes + meal plans). Firestore uses unlimited persistent cache with auto index creation."
+    tooltip: "Firebase Auth (Google Sign-In), Cloud Firestore (recipes + meal plans), and Cloud Storage (recipe images). Firestore uses unlimited persistent cache with auto index creation. Storage images are cached locally for offline access."
   }
 
 }
@@ -377,7 +377,7 @@ app: {
 
       recipe: {
         label: Recipe
-        tooltip: "@Immutable. Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, equipment, tags, imageUrl (local file:// URI, directly editable via gallery picker), sourceImageUrl (original remote URL), timestamps, isFavorite, userNotes (free-form user notes, preserved across AI edits/regeneration, included in markdown sent to AI)"
+        tooltip: "@Immutable. Fields: id, name, sourceUrl, story, servings, times, ingredients, instructions, equipment, tags, imageUrl (gs:// URI pointing to Firebase Storage, synced across devices via Firestore; Coil fetcher resolves to local cache), sourceImageUrl (original remote URL), timestamps, isFavorite, userNotes (free-form user notes, preserved across AI edits/regeneration, included in markdown sent to AI)"
       }
       ingredient: {
         label: Ingredient
@@ -436,8 +436,10 @@ app: {
     usecases.parse_html -> data.repository.import_debug_repo: save debug data
     usecases.export_zip -> util.serializer: serialize
     usecases.export_zip -> data.remote.image_dl: read local images
+    usecases.export_zip -> data.remote.image_sync: resolve storage images
     usecases.export_single -> util.serializer: serialize
     usecases.export_single -> data.remote.image_dl: read local images
+    usecases.export_single -> data.remote.image_sync: resolve storage images
     usecases.import_paprika -> data.remote.image_dl: save base64 images
     usecases.import_zip -> util.zip_import_helper: import
   }
@@ -508,9 +510,9 @@ app: {
         tooltip: "Room entity storing import debug data: source URL, original/cleaned HTML, AI output JSON, token counts, model, error info, linked recipe ID"
       }
       image_storage: {
-        label: Local Image Storage
+        label: Local Image Cache
         shape: cylinder
-        tooltip: "Recipe images stored as files in app internal storage (filesDir/recipe_images/). Referenced by file:// URIs in Recipe.imageUrl."
+        tooltip: "Recipe images cached locally in app internal storage (filesDir/recipe_images/). Primary storage is Firebase Storage, referenced via gs:// URIs (e.g., gs://bucket/users/{uid}/images/{file}). Coil's FirebaseStorageCoilFetcher downloads and caches images on first display."
       }
       settings: {
         label: SettingsDataStore
@@ -541,7 +543,15 @@ app: {
       }
       image_dl: {
         label: ImageDownloadService
-        tooltip: "Downloads recipe images from remote URLs and stores them locally in app internal storage. Automatically retries with HTTPS if an HTTP download fails (e.g., cleartext traffic not permitted). Also supports saving images from byte streams (ZIP import) and base64 data (Paprika photo_data). Returns file:// URIs for local access. Used during import, export, and ZIP restore to ensure images are available offline."
+        tooltip: "Downloads recipe images from remote URLs and stores them locally in app internal storage. Automatically retries with HTTPS if an HTTP download fails (e.g., cleartext traffic not permitted). Also supports saving images from byte streams (ZIP import) and base64 data (Paprika photo_data). After saving locally, uploads images to Firebase Storage via ImageSyncService. Returns gs:// URIs for Firestore sync. Used during import, export, and ZIP restore."
+      }
+      image_sync: {
+        label: ImageSyncService
+        tooltip: "Syncs recipe images between local storage and Firebase Storage. Uploads resized images (max 2048px, JPEG 85%) to users/{uid}/images/. Downloads images to local cache for offline display. Handles orphan cleanup. Returns gs:// URIs stored in Recipe.imageUrl for cross-device sync."
+      }
+      storage_fetcher: {
+        label: FirebaseStorageCoilFetcher
+        tooltip: "Custom Coil Fetcher that intercepts Firebase Storage gs:// URIs and resolves them to local cache files. Downloads from Firebase Storage on first load, then serves from disk cache. Registered via LionOtterApp's SingletonImageLoader.Factory."
       }
       firestore_svc: {
         label: FirestoreService
@@ -589,7 +599,11 @@ app: {
     repository.import_debug_repo -> local.import_debug_dao
     repository.pending_import_repo -> local.pending_import_dao
     repository.meal_plan_repo -> remote.firestore_svc: Firestore CRUD
-    remote.image_dl -> local.image_storage: stores images
+    remote.image_dl -> local.image_storage: caches images
+    remote.image_dl -> remote.image_sync: upload to storage
+    remote.image_sync -> local.image_storage: download cache
+    remote.storage_fetcher -> remote.image_sync: resolve paths
+    remote.storage_fetcher -> local.image_storage: cache read/write
   }
 
   # Performance
@@ -639,6 +653,7 @@ app: {
   ui.viewmodels.edit_vm -> data.repository.repo: recipe, original HTML, image
   ui.viewmodels.edit_vm -> data.local.settings: edit model, thinking prefs
   ui.viewmodels.edit_vm -> data.remote.image_dl: save picked images
+  ui.viewmodels.edit_vm -> data.remote.image_sync: delete remote images
   ui.viewmodels.edit_vm -> background.worker.edit_worker: save edits
   ui.viewmodels.edit_vm -> background.worker.regenerate_worker: regenerate from original
   ui.viewmodels.edit_vm -> background.worker.work_ext: observe edit/regenerate
@@ -683,6 +698,7 @@ app: {
   ui.viewmodels.settings_vm -> data.remote.auth_svc: sign out, email
   data.remote.firestore_svc -> external.firebase: Firestore
   data.remote.auth_svc -> external.firebase: Auth
+  data.remote.image_sync -> external.firebase: Storage
   data.remote.scraper -> external.web: fetch HTML
   data.remote.image_dl -> external.web: download image
   data.remote.anthropic_svc -> external.anthropic: parse recipe

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,7 @@ tink-android = { group = "com.google.crypto.tink", name = "tink-android", versio
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore" }
+firebase-storage = { group = "com.google.firebase", name = "firebase-storage" }
 
 # Credentials
 credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }


### PR DESCRIPTION
## Summary
- Uploads recipe images to Firebase Storage (`users/{uid}/images/`) for cross-device sync
- Images are resized before upload (max 2048px, JPEG 85% quality, 5MB size limit)
- Custom Coil fetcher transparently resolves Firebase Storage paths to local cached files for offline display
- Recipe deletion cleans up corresponding Firebase Storage images
- ZIP export/import handles Firebase Storage paths by resolving to local cache
- Added Firebase Storage security rules documentation to README

## Details

### New files
- **`ImageSyncService`** - Core service for uploading/downloading images to/from Firebase Storage with local caching and automatic image resizing
- **`FirebaseStorageCoilFetcher`** - Custom Coil `Fetcher` that intercepts Firebase Storage paths (e.g., `users/{uid}/images/filename.jpg`) and downloads them to local cache on first load, serving from cache thereafter

### Modified files
- **`ImageDownloadService`** - Added `uploadToStorage()` method; handles Firebase Storage paths in `downloadImageIfNeeded()` and `downloadAndStoreWithResult()`
- **`ParseHtmlUseCase`** - After downloading images locally, uploads to Firebase Storage; stores storage path in recipe
- **`EditRecipeViewModel`** - Image selection uploads to Firebase Storage; image removal deletes from Firebase Storage
- **`RecipeRepository`** - Deletes Firebase Storage images when recipes are deleted
- **`ExportToZipUseCase` / `ExportSingleRecipeUseCase`** - Resolves Firebase Storage paths to local cache before writing to ZIP
- **`ZipImportHelper`** - Uploads imported images to Firebase Storage
- **`LionOtterApp`** - Registers `FirebaseStorageCoilFetcher` with Coil's `SingletonImageLoader`

### Backend setup
Firebase Storage security rules are documented in the README. The rules:
- Restrict read/write to authenticated users accessing their own `users/{uid}/images/` path
- Validate that uploads are images (`image/*` content type)
- Enforce a 5MB size limit

## Test plan
- [ ] Import a recipe from URL and verify the image uploads to Firebase Storage
- [ ] Sign in on another device and verify the recipe image syncs and displays
- [ ] Edit a recipe image (pick from gallery) and verify the new image uploads
- [ ] Remove a recipe image and verify it's deleted from Firebase Storage
- [ ] Delete a recipe and verify the image is cleaned up from Firebase Storage
- [ ] Export recipes to .lorecipes and verify images are included
- [ ] Import recipes from .lorecipes and verify images upload to Firebase Storage
- [ ] Test offline: view cached images without network connectivity
- [ ] Verify large images are resized (check Firebase Storage for image dimensions)
- [ ] Deploy the Firebase Storage security rules from the README

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)