### PR TITLE
Remove delete confirmation for meal plans

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
@@ -82,32 +82,6 @@ fun MealPlanScreen(
 
     val scope = rememberCoroutineScope()
 
-    // State for delete confirmation
-    var entryToDelete by remember { mutableStateOf<MealPlanEntry?>(null) }
-    var deleteSwipeState by remember { mutableStateOf<SwipeActionBoxState?>(null) }
-
-    // Delete confirmation dialog
-    entryToDelete?.let { entry ->
-        MealPlanDeleteDialog(
-            recipeName = entry.recipeName,
-            onConfirm = {
-                val swipe = deleteSwipeState
-                entryToDelete = null
-                deleteSwipeState = null
-                scope.launch {
-                    swipe?.confirm()
-                    viewModel.deleteMealPlan(entry.id)
-                }
-            },
-            onDismiss = {
-                val swipe = deleteSwipeState
-                entryToDelete = null
-                deleteSwipeState = null
-                scope.launch { swipe?.reset() }
-            }
-        )
-    }
-
     // Add meal plan dialog
     if (showAddDialog) {
         AddMealPlanDialog(
@@ -187,8 +161,8 @@ fun MealPlanScreen(
                                     scope.launch { swipeState.reset() }
                                 },
                                 onDeleteRequest = {
-                                    entryToDelete = entry
-                                    deleteSwipeState = swipeState
+                                    viewModel.deleteMealPlan(entry.id)
+                                    scope.launch { swipeState.confirm() }
                                 },
                                 swipeState = swipeState
                             )
@@ -428,29 +402,6 @@ private fun MealPlanCard(
             )
         }
     }
-}
-
-@Composable
-private fun MealPlanDeleteDialog(
-    recipeName: String,
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    androidx.compose.material3.AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.delete_meal_plan)) },
-        text = { Text(stringResource(R.string.delete_meal_plan_confirmation, recipeName)) },
-        confirmButton = {
-            androidx.compose.material3.TextButton(onClick = onConfirm) {
-                Text(stringResource(R.string.remove))
-            }
-        },
-        dismissButton = {
-            androidx.compose.material3.TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.cancel))
-            }
-        }
-    )
 }
 
 private fun formatServings(servings: Double): String {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,8 +241,6 @@
     <string name="today">Today</string>
     <string name="no_meals_planned">No meals planned</string>
     <string name="tap_plus_to_add_meal">Tap + to add a meal</string>
-    <string name="delete_meal_plan">Remove from Meal Plan</string>
-    <string name="delete_meal_plan_confirmation">Remove \"%1$s\" from the meal plan?</string>
     <string name="search_recipes_to_add">Search recipes to add\u2026</string>
     <string name="no_recipes_found">No recipes found</string>
     <string name="previous_week">Previous week</string>


### PR DESCRIPTION
## Summary
- Remove the confirmation dialog when swiping to delete meal plan entries
- Meal plans are easy to re-add, so the extra confirmation step is unnecessary friction
- Both swipe-to-delete and long-press context menu delete now act immediately

Fixes #291

## Test plan
- [ ] Swipe a meal plan entry left to delete — it should be removed immediately with no dialog
- [ ] Long-press a meal plan entry, tap "Remove" — it should be removed immediately with no dialog
- [ ] Swipe a meal plan entry right to edit — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)