### PR TITLE
fix: wrap all mutation coroutines with NonCancellable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 - Never silently discard exceptions. Always log exceptions with `Log.w`/`Log.e` at minimum.
   In user-facing operations, propagate errors so the UI can inform the user the action failed.
   It is better to tell the user something went wrong than to silently pretend everything is fine.
+- Wrap all mutation coroutines (writes, deletes, uploads, etc.) in `withContext(NonCancellable)` so they finish even if `viewModelScope` is cancelled. Keep UI state updates outside the `NonCancellable` block.
 - Commit after finishing fixes or features
 - Prefer to amend if fixing the current commit
 - ALWAYS check the current commit before amending

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanViewModel.kt
@@ -19,7 +19,9 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.time.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
@@ -201,30 +203,32 @@ class MealPlanViewModel @Inject constructor(
         viewModelScope.launch {
             val now = Clock.System.now()
             val existing = _editingEntry.value
-            if (existing != null) {
-                val updated = existing.copy(
-                    recipeId = recipe.id,
-                    recipeName = recipe.name,
-                    recipeImageUrl = recipe.imageUrl,
-                    date = _selectedDate.value,
-                    mealType = _selectedMealType.value,
-                    servings = _selectedServings.value,
-                    updatedAt = now
-                )
-                mealPlanRepository.updateMealPlan(updated)
-            } else {
-                val entry = MealPlanEntry(
-                    id = UUID.randomUUID().toString(),
-                    recipeId = recipe.id,
-                    recipeName = recipe.name,
-                    recipeImageUrl = recipe.imageUrl,
-                    date = _selectedDate.value,
-                    mealType = _selectedMealType.value,
-                    servings = _selectedServings.value,
-                    createdAt = now,
-                    updatedAt = now
-                )
-                mealPlanRepository.saveMealPlan(entry)
+            withContext(NonCancellable) {
+                if (existing != null) {
+                    val updated = existing.copy(
+                        recipeId = recipe.id,
+                        recipeName = recipe.name,
+                        recipeImageUrl = recipe.imageUrl,
+                        date = _selectedDate.value,
+                        mealType = _selectedMealType.value,
+                        servings = _selectedServings.value,
+                        updatedAt = now
+                    )
+                    mealPlanRepository.updateMealPlan(updated)
+                } else {
+                    val entry = MealPlanEntry(
+                        id = UUID.randomUUID().toString(),
+                        recipeId = recipe.id,
+                        recipeName = recipe.name,
+                        recipeImageUrl = recipe.imageUrl,
+                        date = _selectedDate.value,
+                        mealType = _selectedMealType.value,
+                        servings = _selectedServings.value,
+                        createdAt = now,
+                        updatedAt = now
+                    )
+                    mealPlanRepository.saveMealPlan(entry)
+                }
             }
             _showAddDialog.value = false
             _editingEntry.value = null
@@ -244,7 +248,9 @@ class MealPlanViewModel @Inject constructor(
                 servings = _selectedServings.value,
                 updatedAt = now
             )
-            mealPlanRepository.updateMealPlan(updated)
+            withContext(NonCancellable) {
+                mealPlanRepository.updateMealPlan(updated)
+            }
             _showAddDialog.value = false
             _editingEntry.value = null
         }
@@ -252,7 +258,9 @@ class MealPlanViewModel @Inject constructor(
 
     fun deleteMealPlan(entryId: String) {
         viewModelScope.launch {
-            mealPlanRepository.deleteMealPlan(entryId)
+            withContext(NonCancellable) {
+                mealPlanRepository.deleteMealPlan(entryId)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/RecipeListViewModel.kt
@@ -18,7 +18,9 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -135,7 +137,9 @@ class RecipeListViewModel @Inject constructor(
             val item = recipes.value.find { it.id == recipeId }
             if (item is RecipeListItem.Saved) {
                 val newFavorite = !item.recipe.isFavorite
-                recipeRepository.setFavorite(recipeId, newFavorite)
+                withContext(NonCancellable) {
+                    recipeRepository.setFavorite(recipeId, newFavorite)
+                }
             }
         }
     }
@@ -152,8 +156,10 @@ class RecipeListViewModel @Inject constructor(
             // Only delete if it's a saved recipe (not in-progress)
             val item = recipes.value.find { it.id == recipeId }
             if (item is RecipeListItem.Saved) {
-                mealPlanRepository.deleteMealPlansByRecipeId(recipeId)
-                recipeRepository.deleteRecipe(recipeId)
+                withContext(NonCancellable) {
+                    mealPlanRepository.deleteMealPlansByRecipeId(recipeId)
+                    recipeRepository.deleteRecipe(recipeId)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModel.kt
@@ -15,7 +15,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -132,7 +134,9 @@ class SettingsViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                settingsDataStore.setAnthropicApiKey(key)
+                withContext(NonCancellable) {
+                    settingsDataStore.setAnthropicApiKey(key)
+                }
                 _apiKeyInput.value = ""
                 _saveState.value = SaveState.Success
             } catch (e: Exception) {
@@ -143,83 +147,87 @@ class SettingsViewModel @Inject constructor(
 
     fun clearApiKey() {
         viewModelScope.launch {
-            settingsDataStore.clearAnthropicApiKey()
+            withContext(NonCancellable) {
+                settingsDataStore.clearAnthropicApiKey()
+            }
             _saveState.value = SaveState.Idle
         }
     }
 
     fun setAiModel(model: String) {
         viewModelScope.launch {
-            settingsDataStore.setAiModel(model)
+            withContext(NonCancellable) { settingsDataStore.setAiModel(model) }
         }
     }
 
     fun setEditModel(model: String) {
         viewModelScope.launch {
-            settingsDataStore.setEditModel(model)
+            withContext(NonCancellable) { settingsDataStore.setEditModel(model) }
         }
     }
 
     fun setThinkingEnabled(enabled: Boolean) {
         viewModelScope.launch {
-            settingsDataStore.setThinkingEnabled(enabled)
+            withContext(NonCancellable) { settingsDataStore.setThinkingEnabled(enabled) }
         }
     }
 
     fun setKeepScreenOn(enabled: Boolean) {
         viewModelScope.launch {
-            settingsDataStore.setKeepScreenOn(enabled)
+            withContext(NonCancellable) { settingsDataStore.setKeepScreenOn(enabled) }
         }
     }
 
     fun setThemeMode(mode: ThemeMode) {
         viewModelScope.launch {
-            settingsDataStore.setThemeMode(mode)
+            withContext(NonCancellable) { settingsDataStore.setThemeMode(mode) }
         }
     }
 
     fun setVolumeUnitSystem(system: UnitSystem) {
         viewModelScope.launch {
-            settingsDataStore.setVolumeUnitSystem(system)
+            withContext(NonCancellable) { settingsDataStore.setVolumeUnitSystem(system) }
         }
     }
 
     fun setWeightUnitSystem(system: UnitSystem) {
         viewModelScope.launch {
-            settingsDataStore.setWeightUnitSystem(system)
+            withContext(NonCancellable) { settingsDataStore.setWeightUnitSystem(system) }
         }
     }
 
     fun setGroceryVolumeUnitSystem(system: UnitSystem) {
         viewModelScope.launch {
-            settingsDataStore.setGroceryVolumeUnitSystem(system)
+            withContext(NonCancellable) { settingsDataStore.setGroceryVolumeUnitSystem(system) }
         }
     }
 
     fun setGroceryWeightUnitSystem(system: UnitSystem) {
         viewModelScope.launch {
-            settingsDataStore.setGroceryWeightUnitSystem(system)
+            withContext(NonCancellable) { settingsDataStore.setGroceryWeightUnitSystem(system) }
         }
     }
 
     fun setStartOfWeek(startOfWeek: StartOfWeek) {
         viewModelScope.launch {
-            settingsDataStore.setStartOfWeek(startOfWeek)
+            withContext(NonCancellable) { settingsDataStore.setStartOfWeek(startOfWeek) }
         }
     }
 
     fun setImportDebuggingEnabled(enabled: Boolean) {
         viewModelScope.launch {
-            settingsDataStore.setImportDebuggingEnabled(enabled)
-            if (!enabled) {
-                importDebugRepository.deleteAllDebugEntries()
+            withContext(NonCancellable) {
+                settingsDataStore.setImportDebuggingEnabled(enabled)
+                if (!enabled) {
+                    importDebugRepository.deleteAllDebugEntries()
+                }
             }
         }
     }
 
     fun signOut() {
         viewModelScope.launch {
-            authService.signOut()
+            withContext(NonCancellable) { authService.signOut() }
         }
     }
 


### PR DESCRIPTION
## Summary
- Wraps all mutation coroutines across ViewModels with `withContext(NonCancellable)` so that writes (favorites, deletes, saves, image uploads, settings changes, sign-out, etc.) complete even if the user navigates away and the ViewModel scope is cancelled
- Audited all ViewModels: `RecipeDetailViewModel`, `RecipeListViewModel`, `EditRecipeViewModel`, `MealPlanViewModel`, and `SettingsViewModel`
- ViewModels that already used proper patterns (WorkManager for long-running tasks, or already had `NonCancellable`) were left unchanged

## Details

The issue: `viewModelScope` is cancelled when a ViewModel is cleared (e.g., user navigates away). Any in-flight coroutines that perform mutations (Firestore writes, DataStore writes, image uploads, file I/O) would be cancelled mid-operation, potentially leaving data in an inconsistent state.

The fix: Wrap the mutation portions of each coroutine with `withContext(NonCancellable)` so the write completes regardless of scope cancellation. UI state updates (like `_recipeDeleted.emit(Unit)` or dialog dismissals) remain outside `NonCancellable` since they're only relevant if the scope is still active.

**ViewModels already correct (no changes needed):**
- `AddRecipeViewModel` - delegates to WorkManager
- `ZipExportImportViewModel` - delegates to WorkManager
- `ImportSelectionViewModel` - `parseFile()` is read-only; `importSelected()` uses WorkManager synchronously
- `GroceryListViewModel` - `generateGroceryList()` is read-only computation
- `EditRecipeViewModel.saveEdits()` (markdown path) - delegates to WorkManager
- `EditRecipeViewModel.saveEdits()` (title/URL path) - already had `NonCancellable`

## Test plan
- [x] CI passes (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Manual: Toggle favorite on a recipe and quickly navigate back - favorite should persist
- [ ] Manual: Delete a recipe and quickly navigate away - recipe should be deleted
- [ ] Manual: Change a setting and quickly navigate away - setting should persist
- [ ] Manual: Upload an image in edit mode and quickly navigate away - image should upload

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)