### PR TITLE
fix: use release signing config for Google Play uploads

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -174,13 +174,14 @@ jobs:
           GSEOF
           fi
 
-      - name: Setup debug keystore
+      - name: Setup keystore
         env:
           DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
         run: |
           if [ -n "$DEBUG_KEYSTORE_BASE64" ]; then
             echo "$DEBUG_KEYSTORE_BASE64" | base64 -d > ${{ runner.temp }}/debug.keystore
             echo "DEBUG_KEYSTORE_PATH=${{ runner.temp }}/debug.keystore" >> $GITHUB_ENV
+            echo "RELEASE_KEYSTORE_PATH=${{ runner.temp }}/debug.keystore" >> $GITHUB_ENV
           fi
 
       - name: Build release AAB

--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ The debug APK will be at `app/build/outputs/apk/debug/app-debug.apk`.
 
 ### Release Builds
 
-Release builds use the same debug keystore as an upload key for Google Play App Signing. Google re-signs the final app with their own managed key before distributing to users, so the upload key credentials don't need to be secret — they just need to be consistent.
+Release builds use a `release` signing config as an upload key for Google Play App Signing. Google re-signs the final app with their own managed key before distributing to users, so the upload key credentials don't need to be secret — they just need to be consistent.
+
+By default, the release signing config falls back to the standard Android debug keystore (same key, but properly configured as a release signing config so Google Play accepts the upload).
+
+You can override the release keystore via environment variables:
+- `RELEASE_KEYSTORE_PATH` — path to the keystore file
+- `RELEASE_KEYSTORE_PASSWORD` — keystore password (default: `android`)
+- `RELEASE_KEY_ALIAS` — key alias (default: `androiddebugkey`)
+- `RELEASE_KEY_PASSWORD` — key password (default: `android`)
 
 ```bash
 # Build a release AAB locally
@@ -59,7 +67,7 @@ Release builds use the same debug keystore as an upload key for Google Play App 
 
 The AAB will be at `app/build/outputs/bundle/release/app-release.aab`.
 
-CI automatically builds a signed release AAB on pushes to `main` (after lint, tests, and debug build pass). If you have `DEBUG_KEYSTORE_BASE64` set as a GitHub secret, CI will use it for both debug and release builds. Otherwise it falls back to the default Android debug keystore.
+CI automatically builds a signed release AAB on pushes to `main` (after lint, tests, and debug build pass). If you have `DEBUG_KEYSTORE_BASE64` set as a GitHub secret, CI will use it for both debug and release builds (setting both `DEBUG_KEYSTORE_PATH` and `RELEASE_KEYSTORE_PATH`). Otherwise it falls back to the default Android debug keystore.
 
 ### Build from Android Studio
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,14 @@ android {
             keyAlias = "androiddebugkey"
             keyPassword = "android"
         }
+        create("release") {
+            // Upload key for Google Play App Signing. Google re-signs with their own key
+            // before distribution, so this just needs to be consistent.
+            storeFile = file(System.getenv("RELEASE_KEYSTORE_PATH") ?: System.getenv("DEBUG_KEYSTORE_PATH") ?: "${System.getProperty("user.home")}/.android/debug.keystore")
+            storePassword = System.getenv("RELEASE_KEYSTORE_PASSWORD") ?: "android"
+            keyAlias = System.getenv("RELEASE_KEY_ALIAS") ?: "androiddebugkey"
+            keyPassword = System.getenv("RELEASE_KEY_PASSWORD") ?: "android"
+        }
     }
 
     defaultConfig {
@@ -33,7 +41,7 @@ android {
 
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -42,7 +50,7 @@ android {
         }
         create("benchmark") {
             initWith(buildTypes.getByName("release"))
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             matchingFallbacks += listOf("release")
             isDebuggable = false
         }


### PR DESCRIPTION
## Summary
- Google Play was rejecting the AAB upload because the release build type was using `signingConfigs.getByName("debug")`, which causes the bundle to be marked as debug-signed
- Added a proper `release` signing config that uses the same keystore but is recognized by Gradle as a release config
- The release signing config supports env var overrides (`RELEASE_KEYSTORE_PATH`, `RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`) for flexibility, falling back to the debug keystore defaults
- Updated CI workflow to set `RELEASE_KEYSTORE_PATH` alongside `DEBUG_KEYSTORE_PATH`
- Updated README documentation to reflect the new configuration

## Test plan
- [x] `./ci-local.sh` passes (assembleDebug, testDebugUnitTest, lintDebug)
- [x] `./gradlew bundleRelease` builds successfully
- [x] `jarsigner -verify` confirms the AAB is properly signed
- [ ] Re-upload the AAB to Google Play Console and verify it's accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)