### PR TITLE
feat: add per-user resource limits and remove originalHtml storage

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -40,7 +40,6 @@ data class RecipeEntity(
     val ingredientSectionsJson: String,  // Serialized List<IngredientSection>
     val instructionSectionsJson: String, // Serialized List<InstructionSection>
     val tagsJson: String,                // Serialized List<String>
-    val originalHtml: String?,           // Preserved for re-parsing
     // ... other fields
 )
 ```
@@ -49,7 +48,6 @@ data class RecipeEntity(
 1. Recipe structure is always loaded as a unit
 2. Avoids complex JOIN queries
 3. Simplifies schema migrations
-4. Original HTML preserved for potential AI re-processing
 
 #### DataStore (`SettingsDataStore`)
 
@@ -105,7 +103,7 @@ class RecipeRepository(
 ) {
     fun getAllRecipes(): Flow<List<Recipe>>
     fun getRecipeById(id: String): Flow<Recipe?>
-    suspend fun saveRecipe(recipe: Recipe, originalHtml: String?)
+    fun saveRecipe(recipe: Recipe)
     suspend fun deleteRecipe(id: String)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -93,13 +93,23 @@ Cloud sync is optional — the app works fully offline without it. To enable syn
    - Verify that the `oauth_client` array is **not empty** — it should contain an entry with `"client_type": 3` (web client). This is required for Google Sign-In.
 5. Enable **Cloud Firestore**:
    - Go to **Firestore Database** and create a database
-   - Set the security rules to restrict access per user:
+   - Set the security rules to restrict access per user with per-document size limits:
      ```
      rules_version = '2';
      service cloud.firestore {
        match /databases/{database}/documents {
-         match /users/{userId}/{document=**} {
-           allow read, write: if request.auth != null && request.auth.uid == userId;
+         match /users/{userId}/recipes/{recipeId} {
+           allow read: if request.auth != null && request.auth.uid == userId;
+           allow write: if request.auth != null
+             && request.auth.uid == userId
+             && request.resource.data.keys().size() > 0
+             && request.resource.size < 50 * 1024;  // 50 KB per recipe
+         }
+         match /users/{userId}/mealPlans/{mealPlanId} {
+           allow read: if request.auth != null && request.auth.uid == userId;
+           allow write: if request.auth != null
+             && request.auth.uid == userId
+             && request.resource.size < 10 * 1024;  // 10 KB per meal plan
          }
        }
      }
@@ -118,13 +128,26 @@ Cloud sync is optional — the app works fully offline without it. To enable syn
            allow write: if request.auth != null
              && request.auth.uid == userId
              && request.resource.contentType.matches('image/.*')
-             && request.resource.size < 5 * 1024 * 1024;
+             && request.resource.size < 5 * 1024 * 1024;  // 5 MB per image
          }
        }
      }
      ```
 
 Data is stored at `users/{userId}/recipes/{recipeId}` and `users/{userId}/mealPlans/{mealPlanId}`, so each user's data is fully isolated. Recipe images are stored in Firebase Storage at `users/{userId}/images/{filename}`.
+
+**Per-user resource limits** are enforced both server-side (via Firebase security rules above) and client-side:
+
+| Resource | Limit | Enforced by |
+|----------|-------|-------------|
+| Recipe document size | 50 KB | Firestore rules + client |
+| Meal plan document size | 10 KB | Firestore rules + client |
+| Image file size | 5 MB | Storage rules + client |
+| Total recipes per user | 1,000 | Client |
+| Total meal plans per user | 5,000 | Client |
+| Total images per user | 1,000 | Client |
+
+Client-side limits are defined in `ResourceLimits.kt`. Exceeding a limit shows an error message in the UI.
 
 ## App Setup
 

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/FirestoreService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/FirestoreService.kt
@@ -58,12 +58,6 @@ open class FirestoreService @Inject constructor() {
         return Firebase.firestore.collection("users").document(uid).collection("mealPlans")
     }
 
-    open fun recipeContentCollection(recipeId: String): CollectionReference {
-        val uid = requireUid()
-        return Firebase.firestore.collection("users").document(uid)
-            .collection("recipes").document(recipeId).collection("content")
-    }
-
     fun reportError(message: String) {
         Log.e(TAG, message)
         _errors.tryEmit(message)

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/IMealPlanRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/IMealPlanRepository.kt
@@ -12,4 +12,5 @@ interface IMealPlanRepository {
     suspend fun deleteMealPlansByRecipeId(recipeId: String)
     suspend fun countMealPlansByRecipeId(recipeId: String): Int
     suspend fun getAllMealPlansOnce(): List<MealPlanEntry>
+    suspend fun getMealPlanCount(): Int
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/IRecipeRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/IRecipeRepository.kt
@@ -8,12 +8,12 @@ interface IRecipeRepository {
     fun getAllRecipes(): Flow<List<Recipe>>
     fun getRecipeById(id: String): Flow<Recipe?>
     suspend fun getRecipeByIdOnce(id: String): Recipe?
-    suspend fun getOriginalHtml(recipeId: String): String?
-    fun saveRecipe(recipe: Recipe, originalHtml: String? = null)
+    fun saveRecipe(recipe: Recipe)
     fun deleteRecipe(id: String)
     fun setFavorite(id: String, isFavorite: Boolean)
     fun setUserNotes(id: String, userNotes: String?)
     fun setImageUrl(id: String, imageUrl: String?)
     fun updateTitleAndUrl(id: String, name: String, sourceUrl: String?)
     suspend fun getAllRecipeIdsAndNames(): List<RecipeIdAndName>
+    suspend fun getRecipeCount(): Int
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/MealPlanRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/MealPlanRepository.kt
@@ -118,6 +118,16 @@ class MealPlanRepository @Inject constructor(
         }
     }
 
+    override suspend fun getMealPlanCount(): Int {
+        return try {
+            val snapshot = firestoreService.mealPlansCollection().get().await()
+            snapshot.size()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error fetching meal plan count", e)
+            0
+        }
+    }
+
     override suspend fun getAllMealPlansOnce(): List<MealPlanEntry> {
         return try {
             val snapshot = firestoreService.mealPlansCollection().get().await()

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/ResourceLimits.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/ResourceLimits.kt
@@ -1,0 +1,27 @@
+package com.lionotter.recipes.domain
+
+/**
+ * Per-user resource limits enforced client-side.
+ *
+ * These limits prevent excessive Firebase usage. Size limits are also enforced
+ * server-side via Firebase security rules (see README.md for rule configuration).
+ */
+object ResourceLimits {
+    /** Maximum number of recipes a user can store. */
+    const val MAX_RECIPES = 1_000
+
+    /** Maximum number of meal plan entries a user can store. */
+    const val MAX_MEAL_PLANS = 5_000
+
+    /** Maximum number of images a user can store in Firebase Storage. */
+    const val MAX_IMAGES = 1_000
+
+    /** Maximum size of a single recipe document in bytes (50 KB). */
+    const val MAX_RECIPE_SIZE_BYTES = 50 * 1024L
+
+    /** Maximum size of a single meal plan document in bytes (10 KB). */
+    const val MAX_MEAL_PLAN_SIZE_BYTES = 10 * 1024L
+
+    /** Maximum size of a single image file in bytes (5 MB). */
+    const val MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024L
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/EditRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/EditRecipeUseCase.kt
@@ -57,9 +57,6 @@ class EditRecipeUseCase @Inject constructor(
         val existingRecipe = recipeRepository.getRecipeByIdOnce(recipeId)
             ?: return EditResult.Error("Recipe not found")
 
-        // Preserve original HTML for future regeneration
-        val originalHtml = recipeRepository.getOriginalHtml(recipeId)
-
         // Collect existing densities to merge with defaults for the AI
         val densityOverrides = RecipeMarkdownFormatter.collectDensities(existingRecipe)
             .ifEmpty { null }
@@ -70,7 +67,6 @@ class EditRecipeUseCase @Inject constructor(
             sourceUrl = existingRecipe.sourceUrl,
             imageUrl = existingRecipe.sourceImageUrl ?: existingRecipe.imageUrl,
             saveRecipe = false,
-            originalHtml = originalHtml,
             model = model,
             thinkingEnabled = thinkingEnabled,
             densityOverrides = densityOverrides,
@@ -123,7 +119,7 @@ class EditRecipeUseCase @Inject constructor(
                 }
 
                 onProgress(EditProgress.SavingRecipe)
-                recipeRepository.saveRecipe(editedRecipe, originalHtml = originalHtml)
+                recipeRepository.saveRecipe(editedRecipe)
 
                 val result = EditResult.Success(editedRecipe)
                 onProgress(EditProgress.Complete(result))

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportSingleRecipeUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportSingleRecipeUseCase.kt
@@ -15,7 +15,6 @@ import javax.inject.Inject
  * Use case for exporting a single recipe to a .lorecipes file.
  * The format is a ZIP file containing the same folder structure as the bulk export:
  * - recipe-name/recipe.json
- * - recipe-name/original.html (if available)
  * - recipe-name/recipe.md
  * - recipe-name/image.* (recipe image, if available)
  *
@@ -44,8 +43,7 @@ class ExportSingleRecipeUseCase @Inject constructor(
         outputStream: OutputStream
     ): ExportResult {
         return try {
-            val originalHtml = recipeRepository.getOriginalHtml(recipe.id)
-            val files = recipeSerializer.serializeRecipe(recipe, originalHtml)
+            val files = recipeSerializer.serializeRecipe(recipe)
             val prefix = files.folderName
 
             ZipOutputStream(outputStream).use { zipOut ->
@@ -53,13 +51,6 @@ class ExportSingleRecipeUseCase @Inject constructor(
                 zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_JSON_FILENAME}"))
                 zipOut.write(files.recipeJson.toByteArray(Charsets.UTF_8))
                 zipOut.closeEntry()
-
-                // Write original.html (if available)
-                if (files.originalHtml != null) {
-                    zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_HTML_FILENAME}"))
-                    zipOut.write(files.originalHtml.toByteArray(Charsets.UTF_8))
-                    zipOut.closeEntry()
-                }
 
                 // Write recipe.md
                 zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_MARKDOWN_FILENAME}"))

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportToZipUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ExportToZipUseCase.kt
@@ -19,7 +19,6 @@ import javax.inject.Inject
  * Use case for exporting recipes to a ZIP file.
  * Uses a standard folder structure:
  * - recipe-name/recipe.json
- * - recipe-name/original.html (if available)
  * - recipe-name/recipe.md
  * - recipe-name/image.* (recipe image, if available)
  */
@@ -80,21 +79,13 @@ class ExportToZipUseCase @Inject constructor(
                     )
 
                     try {
-                        val originalHtml = recipeRepository.getOriginalHtml(recipe.id)
-                        val files = recipeSerializer.serializeRecipe(recipe, originalHtml)
+                        val files = recipeSerializer.serializeRecipe(recipe)
                         val prefix = files.folderName
 
                         // Write recipe.json
                         zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_JSON_FILENAME}"))
                         zipOut.write(files.recipeJson.toByteArray(Charsets.UTF_8))
                         zipOut.closeEntry()
-
-                        // Write original.html (if available)
-                        if (files.originalHtml != null) {
-                            zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_HTML_FILENAME}"))
-                            zipOut.write(files.originalHtml.toByteArray(Charsets.UTF_8))
-                            zipOut.closeEntry()
-                        }
 
                         // Write recipe.md
                         zipOut.putNextEntry(ZipEntry("$prefix/${RecipeSerializer.RECIPE_MARKDOWN_FILENAME}"))

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportFromZipUseCase.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/usecase/ImportFromZipUseCase.kt
@@ -12,7 +12,6 @@ import kotlin.coroutines.coroutineContext
  * Use case for importing recipes from a ZIP file.
  * Expects the same folder structure as the export:
  * - recipe-name/recipe.json
- * - recipe-name/original.html (optional)
  * - recipe-name/recipe.md (ignored on import, regenerated from data)
  * - recipe-name/image.* (recipe image, used if present)
  *
@@ -102,6 +101,7 @@ class ImportFromZipUseCase @Inject constructor(
                 is ZipImportHelper.SingleRecipeResult.Imported -> importedCount++
                 is ZipImportHelper.SingleRecipeResult.Skipped -> skippedCount++
                 is ZipImportHelper.SingleRecipeResult.NoJson -> failedCount++
+                is ZipImportHelper.SingleRecipeResult.LimitReached -> failedCount++
                 is ZipImportHelper.SingleRecipeResult.Failed -> failedCount++
             }
         }

--- a/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeSerializer.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/domain/util/RecipeSerializer.kt
@@ -9,7 +9,6 @@ import javax.inject.Inject
  * Shared logic for serializing and deserializing recipes in the standard
  * folder export format. Each recipe is represented as a folder containing:
  * - recipe.json: The structured recipe data
- * - original.html: The original HTML page (if available)
  * - recipe.md: A human-readable Markdown version
  * - image.* (jpg/png/webp/gif): The recipe image (if available)
  *
@@ -20,7 +19,6 @@ class RecipeSerializer @Inject constructor(
 ) {
     companion object {
         const val RECIPE_JSON_FILENAME = "recipe.json"
-        const val RECIPE_HTML_FILENAME = "original.html"
         const val RECIPE_MARKDOWN_FILENAME = "recipe.md"
         const val IMAGE_FILENAME_PREFIX = "image"
         val IMAGE_EXTENSIONS = setOf(".jpg", ".jpeg", ".png", ".webp", ".gif")
@@ -32,18 +30,16 @@ class RecipeSerializer @Inject constructor(
     data class RecipeFiles(
         val folderName: String,
         val recipeJson: String,
-        val originalHtml: String?,
         val recipeMarkdown: String
     )
 
     /**
      * Serialize a recipe into the standard export files.
      */
-    fun serializeRecipe(recipe: Recipe, originalHtml: String?): RecipeFiles {
+    fun serializeRecipe(recipe: Recipe): RecipeFiles {
         return RecipeFiles(
             folderName = sanitizeFolderName(recipe.name),
             recipeJson = json.encodeToString(recipe),
-            originalHtml = originalHtml,
             recipeMarkdown = RecipeMarkdownFormatter.format(recipe)
         )
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/mealplan/MealPlanScreen.kt
@@ -79,8 +79,18 @@ fun MealPlanScreen(
     val weekStart by viewModel.currentWeekStart.collectAsStateWithLifecycle()
     val weekMealPlans by viewModel.weekMealPlans.collectAsStateWithLifecycle()
     val showAddDialog by viewModel.showAddDialog.collectAsStateWithLifecycle()
+    val errorMessage by viewModel.errorMessage.collectAsStateWithLifecycle()
 
     val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { androidx.compose.material3.SnackbarHostState() }
+
+    // Show error in snackbar
+    androidx.compose.runtime.LaunchedEffect(errorMessage) {
+        errorMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
 
     // Add meal plan dialog
     if (showAddDialog) {
@@ -91,6 +101,7 @@ fun MealPlanScreen(
     }
 
     Scaffold(
+        snackbarHost = { androidx.compose.material3.SnackbarHost(snackbarHostState) },
         topBar = {
             RecipeTopAppBar(
                 title = stringResource(R.string.meal_planner),

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeRegenerateWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/RecipeRegenerateWorker.kt
@@ -35,7 +35,7 @@ class RecipeRegenerateWorker @AssistedInject constructor(
         const val RESULT_SUCCESS = "success"
         const val RESULT_ERROR = "error"
         const val RESULT_NO_API_KEY = "no_api_key"
-        const val RESULT_NO_ORIGINAL_HTML = "no_original_html"
+        const val RESULT_NO_SOURCE_URL = "no_source_url"
 
         const val PROGRESS_FETCHING = "fetching"
         const val PROGRESS_PARSING = "parsing"
@@ -141,12 +141,12 @@ class RecipeRegenerateWorker @AssistedInject constructor(
                 errorMessage = "API key not configured",
                 KEY_RECIPE_ID to recipeId
             )
-            RegenerateRecipeUseCase.RegenerateResult.NoOriginalHtml -> errorResult(
+            RegenerateRecipeUseCase.RegenerateResult.NoSourceUrl -> errorResult(
                 errorNotificationTitle = "Regeneration Failed",
                 resultTypeKey = KEY_RESULT_TYPE,
                 errorMessageKey = KEY_ERROR_MESSAGE,
-                errorType = RESULT_NO_ORIGINAL_HTML,
-                errorMessage = "Original HTML not available for this recipe",
+                errorType = RESULT_NO_SOURCE_URL,
+                errorMessage = "No source URL available for this recipe",
                 KEY_RECIPE_ID to recipeId
             )
         }

--- a/app/src/test/kotlin/com/lionotter/recipes/integration/ErrorPropagationIntegrationTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/integration/ErrorPropagationIntegrationTest.kt
@@ -1,7 +1,6 @@
 package com.lionotter.recipes.integration
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
@@ -24,9 +23,4 @@ class ErrorPropagationIntegrationTest : FirestoreIntegrationTest() {
         assertEquals(null, result)
     }
 
-    @Test
-    fun `get original HTML for non-existent recipe returns null`() {
-        val result = runSuspending { recipeRepository.getOriginalHtml("non-existent-id") }
-        assertNull(result)
-    }
 }

--- a/app/src/test/kotlin/com/lionotter/recipes/integration/FirestoreIntegrationTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/integration/FirestoreIntegrationTest.kt
@@ -41,7 +41,7 @@ import java.util.concurrent.CountDownLatch
  * - [runSuspending]: runs a suspend block on [Dispatchers.Default] while the main
  *   thread continuously pumps the looper. This allows Firestore's `.get().await()`
  *   (which reads from the local cache) to complete. Use for one-shot suspend reads
- *   like `getRecipeByIdOnce()`, `getOriginalHtml()`, etc.
+ *   like `getRecipeByIdOnce()`, etc.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])

--- a/app/src/test/kotlin/com/lionotter/recipes/integration/RecipeCrudIntegrationTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/integration/RecipeCrudIntegrationTest.kt
@@ -239,31 +239,6 @@ class RecipeCrudIntegrationTest : FirestoreIntegrationTest() {
     }
 
     // -----------------------------------------------------------------------
-    // Original HTML
-    // -----------------------------------------------------------------------
-
-    @Test
-    fun `save recipe with original HTML and retrieve it`() {
-        val recipe = createTestRecipe()
-        val html = "<html><body><h1>Cookies</h1></body></html>"
-        recipeRepository.saveRecipe(recipe, originalHtml = html)
-        pumpLooper()
-
-        val retrieved = runSuspending { recipeRepository.getOriginalHtml(recipe.id) }
-        assertEquals(html, retrieved)
-    }
-
-    @Test
-    fun `recipe without original HTML returns null`() {
-        val recipe = createTestRecipe()
-        recipeRepository.saveRecipe(recipe)
-        pumpLooper()
-
-        val retrieved = runSuspending { recipeRepository.getOriginalHtml(recipe.id) }
-        assertNull(retrieved)
-    }
-
-    // -----------------------------------------------------------------------
     // IDs and names
     // -----------------------------------------------------------------------
 

--- a/app/src/test/kotlin/com/lionotter/recipes/testutil/TestFirestoreService.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/testutil/TestFirestoreService.kt
@@ -23,9 +23,4 @@ class TestFirestoreService : FirestoreService() {
     override fun mealPlansCollection(): CollectionReference {
         return Firebase.firestore.collection("users").document(TEST_USER_ID).collection("mealPlans")
     }
-
-    override fun recipeContentCollection(recipeId: String): CollectionReference {
-        return Firebase.firestore.collection("users").document(TEST_USER_ID)
-            .collection("recipes").document(recipeId).collection("content")
-    }
 }

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -78,7 +78,7 @@ app: {
       }
       edit: {
         label: EditRecipeScreen
-        tooltip: "Recipe edit screen with four sections: (1) Image section — pick from gallery or remove, saved directly without AI. (2) Title and source URL fields — edited directly, saved without AI when recipe body is unchanged. (3) AI instructions — optional text field for user instructions to the AI (e.g. 'Make this recipe vegan'), included in the AI prompt when non-empty. (4) Recipe body markdown editor — when body changes or AI instructions are provided, AI cleans up formatting and regenerates structured data (densities, etc.) with existing ingredient densities passed as hints for cheaper AI models. Includes model selection and extended thinking toggle. Also supports regeneration from original source via refresh icon (when original HTML or source URL is available). Save as Copy creates a new recipe from the edited markdown instead of updating the existing one."
+        tooltip: "Recipe edit screen with four sections: (1) Image section — pick from gallery or remove, saved directly without AI. (2) Title and source URL fields — edited directly, saved without AI when recipe body is unchanged. (3) AI instructions — optional text field for user instructions to the AI (e.g. 'Make this recipe vegan'), included in the AI prompt when non-empty. (4) Recipe body markdown editor — when body changes or AI instructions are provided, AI cleans up formatting and regenerates structured data (densities, etc.) with existing ingredient densities passed as hints for cheaper AI models. Includes model selection and extended thinking toggle. Also supports regeneration from source URL via refresh icon (when source URL is available). Save as Copy creates a new recipe from the edited markdown instead of updating the existing one."
       }
       add: AddRecipeScreen
       settings: SettingsScreen
@@ -156,7 +156,7 @@ app: {
       detail_vm: RecipeDetailViewModel
       edit_vm: {
         label: EditRecipeViewModel
-        tooltip: "Manages edit recipe screen state. Supports direct image editing (saved immediately without AI). Separates title, source URL, AI instructions, and recipe body: title/URL changes are saved directly without AI, while body changes or non-empty AI instructions trigger AI re-parsing via RecipeEditWorker. AI instructions are optional free-text (e.g. 'Make this recipe vegan') passed through the worker to the AI prompt. Defaults to the separate edit model setting (default: Sonnet) rather than the import model. Tracks model/thinking settings. Supports save as copy and regeneration from original source via RecipeRegenerateWorker. Uses ImageDownloadService to save picked images from gallery."
+        tooltip: "Manages edit recipe screen state. Supports direct image editing (saved immediately without AI). Separates title, source URL, AI instructions, and recipe body: title/URL changes are saved directly without AI, while body changes or non-empty AI instructions trigger AI re-parsing via RecipeEditWorker. AI instructions are optional free-text (e.g. 'Make this recipe vegan') passed through the worker to the AI prompt. Defaults to the separate edit model setting (default: Sonnet) rather than the import model. Tracks model/thinking settings. Supports save as copy and regeneration from source URL via RecipeRegenerateWorker. Uses ImageDownloadService to save picked images from gallery."
       }
       add_vm: AddRecipeViewModel
       settings_vm: SettingsViewModel
@@ -240,11 +240,11 @@ app: {
       }
       regenerate_worker: {
         label: RecipeRegenerateWorker
-        tooltip: "CoroutineWorker that re-parses a recipe from its stored original HTML using the AI. Supports selecting a different model and thinking mode. Overwrites the existing recipe, preserving ID, favorite status, and creation timestamp."
+        tooltip: "CoroutineWorker that re-parses a recipe by fetching fresh HTML from the source URL. Supports selecting a different model and thinking mode. Overwrites the existing recipe, preserving ID, favorite status, and creation timestamp."
       }
       edit_worker: {
         label: RecipeEditWorker
-        tooltip: "CoroutineWorker that processes user-edited recipe markdown through AI re-parsing via EditRecipeUseCase. Preserves recipe metadata (ID, favorite, image, source URL, original HTML). Supports save-as-copy mode which creates a new recipe with a fresh ID."
+        tooltip: "CoroutineWorker that processes user-edited recipe markdown through AI re-parsing via EditRecipeUseCase. Preserves recipe metadata (ID, favorite, image, source URL). Supports save-as-copy mode which creates a new recipe with a fresh ID."
       }
       paprika_import_worker: {
         label: PaprikaImportWorker
@@ -252,11 +252,11 @@ app: {
       }
       zip_export_worker: {
         label: ZipExportWorker
-        tooltip: "Exports all recipes to a ZIP file using RecipeSerializer (recipe.json + original.html + recipe.md per recipe)."
+        tooltip: "Exports all recipes to a ZIP file using RecipeSerializer (recipe.json + recipe.md per recipe)."
       }
       zip_import_worker: {
         label: ZipImportWorker
-        tooltip: "Imports recipes from a ZIP file. Reads recipe.json from each folder, skips duplicates, optionally restores original HTML."
+        tooltip: "Imports recipes from a ZIP file. Reads recipe.json from each folder, skips duplicates."
       }
       import_worker -> base_worker: extends
       regenerate_worker -> base_worker: extends
@@ -323,15 +323,15 @@ app: {
       }
       import_zip: {
         label: ImportFromZipUseCase
-        tooltip: "Imports recipes from a ZIP file. Reads recipe.json from each folder, skips duplicates by ID, optionally restores original HTML."
+        tooltip: "Imports recipes from a ZIP file. Reads recipe.json from each folder, skips duplicates by ID."
       }
       regenerate: {
         label: RegenerateRecipeUseCase
-        tooltip: "Re-parses a recipe from its stored original HTML via ParseHtmlUseCase.parseHtml(). If no cached HTML exists, fetches fresh HTML from the recipe's source URL via WebScraperService. Passes model/thinking overrides as parameters, preserves recipe ID, favorite status, and creation timestamp."
+        tooltip: "Re-parses a recipe by fetching fresh HTML from the recipe's source URL via WebScraperService and parsing via ParseHtmlUseCase.parseHtml(). Requires the recipe to have a source URL. Passes model/thinking overrides as parameters, preserves recipe ID, favorite status, and creation timestamp."
       }
       edit_recipe: {
         label: EditRecipeUseCase
-        tooltip: "Edits a recipe by sending user-modified markdown text through ParseHtmlUseCase.parseText() for AI re-parsing. Supports optional AI instructions (e.g. 'Make this recipe vegan') appended to the user message. Collects existing ingredient densities and passes them as hints to the AI, enabling cheaper models (like Haiku) to reuse known values. Preserves recipe ID, createdAt, favorite status, image, source URL, and original HTML (for future regeneration). Supports saveAsCopy mode which generates a new UUID and fresh timestamps for the copied recipe."
+        tooltip: "Edits a recipe by sending user-modified markdown text through ParseHtmlUseCase.parseText() for AI re-parsing. Supports optional AI instructions (e.g. 'Make this recipe vegan') appended to the user message. Collects existing ingredient densities and passes them as hints to the AI, enabling cheaper models (like Haiku) to reuse known values. Preserves recipe ID, createdAt, favorite status, image, and source URL. Supports saveAsCopy mode which generates a new UUID and fresh timestamps for the copied recipe."
       }
       aggregate_grocery: {
         label: AggregateGroceryListUseCase
@@ -359,7 +359,7 @@ app: {
       }
       serializer: {
         label: RecipeSerializer
-        tooltip: "Shared logic for serializing/deserializing recipes in the standard folder export format (recipe.json + original.html + recipe.md + image.*). Used by ZIP export/import."
+        tooltip: "Shared logic for serializing/deserializing recipes in the standard folder export format (recipe.json + recipe.md + image.*). Used by ZIP export/import."
       }
       zip_import_helper: {
         label: ZipImportHelper
@@ -460,7 +460,7 @@ app: {
 
       repo: {
         label: RecipeRepository
-        tooltip: "CRUD operations for recipes via Firestore. Uses snapshot listeners (callbackFlow) for reactive reads. Fire-and-forget writes. Original HTML stored in subcollection."
+        tooltip: "CRUD operations for recipes via Firestore. Uses snapshot listeners (callbackFlow) for reactive reads. Fire-and-forget writes."
       }
       import_debug_repo: {
         label: ImportDebugRepository
@@ -555,7 +555,7 @@ app: {
       }
       firestore_svc: {
         label: FirestoreService
-        tooltip: "Singleton managing Firestore instance with unlimited persistent cache and auto index creation. Provides user-scoped collection references (recipes, mealPlans, content subcollection). Reports errors via SharedFlow for Toast display. Handles sign-out (terminate, clear persistence)."
+        tooltip: "Singleton managing Firestore instance with unlimited persistent cache and auto index creation. Provides user-scoped collection references (recipes, mealPlans). Reports errors via SharedFlow for Toast display. Handles sign-out (terminate, clear persistence)."
       }
       auth_svc: {
         label: AuthService
@@ -650,7 +650,7 @@ app: {
   ui.viewmodels.detail_vm -> domain.usecases.calc_usage: ingredient usage
   ui.viewmodels.detail_vm -> domain.usecases.export_single: export .lorecipes
   ui.viewmodels.detail_vm -> data.local.settings: keep screen on, unit prefs
-  ui.viewmodels.edit_vm -> data.repository.repo: recipe, original HTML, image
+  ui.viewmodels.edit_vm -> data.repository.repo: recipe, image
   ui.viewmodels.edit_vm -> data.local.settings: edit model, thinking prefs
   ui.viewmodels.edit_vm -> data.remote.image_dl: save picked images
   ui.viewmodels.edit_vm -> data.remote.image_sync: delete remote images


### PR DESCRIPTION
## Summary
- Remove `originalHtml` storage from Firestore (content subcollection). Recipes no longer store cached HTML — regeneration now always fetches fresh HTML from the source URL, saving storage costs.
- Add per-user resource limits enforced both client-side (in use cases/ViewModels) and server-side (via Firebase security rules documented in README):
  - Recipes: 1,000 max count, 50 KB per document
  - Meal plans: 5,000 max count, 10 KB per document
  - Images: 1,000 max count, 5 MB per file
- Client-side checks show user-facing error messages when limits are exceeded, preventing wasted AI credits and failed writes.
- New `ResourceLimits.kt` centralizes all limit constants.

Closes #297

## Changes

### originalHtml removal
- `IRecipeRepository`: removed `getOriginalHtml()` and `originalHtml` parameter from `saveRecipe()`
- `RecipeRepository`: removed content subcollection operations and `HTML_DOC_ID`/`HTML_FIELD` constants
- `FirestoreService`: removed `recipeContentCollection()` method
- `RegenerateRecipeUseCase`: always fetches fresh HTML from source URL (renamed `NoOriginalHtml` to `NoSourceUrl`)
- `EditRecipeUseCase`: no longer preserves originalHtml across edits
- `ParseHtmlUseCase`: no longer passes originalHtml to `saveRecipe()`
- `RecipeSerializer`: removed `originalHtml` field and `RECIPE_HTML_FILENAME` constant
- Export use cases: no longer export `original.html` files
- `ZipImportHelper`: no longer imports `original.html` files
- `EditRecipeViewModel`: `canRegenerate` now based solely on source URL availability

### Resource limits
- New `ResourceLimits.kt` with centralized constants
- `ParseHtmlUseCase`: checks recipe count before AI call and before batch save
- `ZipImportHelper`: checks recipe count before importing each recipe
- `MealPlanViewModel`: checks meal plan count before creating new entries, with error display via Snackbar
- `RecipeRepository`/`MealPlanRepository`: added `getRecipeCount()`/`getMealPlanCount()` methods
- README: updated Firebase security rules with per-document size limits and documented all resource limits

## Test plan
- [x] CI passes (assembleDebug, testDebugUnitTest, lintDebug)
- [ ] Verify recipe import still works end-to-end
- [ ] Verify recipe regeneration works (fetches from source URL)
- [ ] Verify recipe editing preserves all metadata
- [ ] Verify ZIP export/import works without original.html
- [ ] Verify meal plan limit error shows in UI
- [ ] Deploy updated Firebase security rules to Firebase Console

Generated with [Claude Code](https://claude.com/claude-code)