### PR TITLE
fix: use dedicated release keystore in CI for Google Play

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -174,14 +174,28 @@ jobs:
           GSEOF
           fi
 
-      - name: Setup keystore
+      - name: Setup debug keystore
         env:
           DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
         run: |
           if [ -n "$DEBUG_KEYSTORE_BASE64" ]; then
             echo "$DEBUG_KEYSTORE_BASE64" | base64 -d > ${{ runner.temp }}/debug.keystore
             echo "DEBUG_KEYSTORE_PATH=${{ runner.temp }}/debug.keystore" >> $GITHUB_ENV
-            echo "RELEASE_KEYSTORE_PATH=${{ runner.temp }}/debug.keystore" >> $GITHUB_ENV
+          fi
+
+      - name: Setup release keystore
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          if [ -n "$RELEASE_KEYSTORE_BASE64" ]; then
+            echo "$RELEASE_KEYSTORE_BASE64" | base64 -d > ${{ runner.temp }}/release.keystore
+            echo "RELEASE_KEYSTORE_PATH=${{ runner.temp }}/release.keystore" >> $GITHUB_ENV
+            echo "RELEASE_KEYSTORE_PASSWORD=$RELEASE_KEYSTORE_PASSWORD" >> $GITHUB_ENV
+            echo "RELEASE_KEY_ALIAS=$RELEASE_KEY_ALIAS" >> $GITHUB_ENV
+            echo "RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD" >> $GITHUB_ENV
           fi
 
       - name: Build release AAB

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
             storeFile = file(System.getenv("RELEASE_KEYSTORE_PATH") ?: System.getenv("DEBUG_KEYSTORE_PATH") ?: "${System.getProperty("user.home")}/.android/debug.keystore")
             storePassword = System.getenv("RELEASE_KEYSTORE_PASSWORD") ?: "android"
             keyAlias = System.getenv("RELEASE_KEY_ALIAS") ?: "androiddebugkey"
-            keyPassword = System.getenv("RELEASE_KEY_PASSWORD") ?: "android"
+            keyPassword = System.getenv("RELEASE_KEY_PASSWORD") ?: System.getenv("RELEASE_KEYSTORE_PASSWORD") ?: "android"
         }
     }
 


### PR DESCRIPTION
## Summary
- The previous CI config set `RELEASE_KEYSTORE_PATH` to the debug keystore, so `bundleRelease` was still signing with the debug key. Google Play detects and rejects debug-signed bundles regardless of which Gradle `signingConfig` block is used.
- Split the release build's keystore setup into its own step that decodes `RELEASE_KEYSTORE_BASE64` and passes `RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS`, and `RELEASE_KEY_PASSWORD` to the Gradle build.

## Required GitHub Actions secrets

Add these in Settings > Secrets and variables > Actions:

| Secret | Value |
|---|---|
| `RELEASE_KEYSTORE_BASE64` | `base64 -w 0 release.keystore` |
| `RELEASE_KEYSTORE_PASSWORD` | Store password from `keytool` |
| `RELEASE_KEY_ALIAS` | Key alias (check with `keytool -list -keystore release.keystore`) |
| `RELEASE_KEY_PASSWORD` | Key password from `keytool` |

## Test plan
- [ ] Add the four secrets to GitHub Actions
- [ ] Merge this PR and verify the `build-release` job produces a properly signed AAB
- [ ] Upload the AAB to Google Play and confirm it is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)