### PR TITLE
build: bump versionCode to 2 for Google Play

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
         applicationId = "com.lionotter.recipes"
         minSdk = 26
         targetSdk = 36
-        versionCode = 1
+        versionCode = 2
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Summary
- Increments `versionCode` from 1 to 2 in `app/build.gradle.kts`
- Google Play requires a unique versionCode for each uploaded AAB, and version 1 was already used

## Test plan
- [x] CI passes (`./ci-local.sh`)
- [ ] Build release AAB and verify it uploads to Google Play successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)