### PR TITLE
feat(recipes): add multi-select to delete multiple recipes

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/repository/IMealPlanRepository.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/repository/IMealPlanRepository.kt
@@ -11,6 +11,7 @@ interface IMealPlanRepository {
     fun deleteMealPlan(id: String)
     suspend fun deleteMealPlansByRecipeId(recipeId: String)
     suspend fun countMealPlansByRecipeId(recipeId: String): Int
+    suspend fun countMealPlansByRecipeIds(recipeIds: List<String>): Int
     suspend fun getAllMealPlansOnce(): List<MealPlanEntry>
     suspend fun getMealPlanCount(): Int
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/components/DeleteConfirmationDialog.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/components/DeleteConfirmationDialog.kt
@@ -44,3 +44,54 @@ fun DeleteConfirmationDialog(
         }
     )
 }
+
+@Composable
+fun BulkDeleteConfirmationDialog(
+    recipeCount: Int,
+    affectedMealPlanCount: Int = 0,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val message = buildString {
+        append(
+            pluralStringResource(
+                R.plurals.delete_recipes_confirmation,
+                recipeCount,
+                recipeCount
+            )
+        )
+        if (affectedMealPlanCount > 0) {
+            append("\n\n")
+            append(
+                pluralStringResource(
+                    R.plurals.delete_recipe_meal_plan_warning,
+                    affectedMealPlanCount,
+                    affectedMealPlanCount
+                )
+            )
+        }
+    }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                pluralStringResource(
+                    R.plurals.delete_recipes,
+                    recipeCount,
+                    recipeCount
+                )
+            )
+        },
+        text = { Text(message) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.delete))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/RecipeCard.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/RecipeCard.kt
@@ -3,7 +3,6 @@ package com.lionotter.recipes.ui.screens.recipelist.components
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -14,13 +13,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.Circle
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -43,91 +41,105 @@ internal fun RecipeCard(
     recipe: Recipe,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
-    showMenu: Boolean,
-    onDismissMenu: () -> Unit,
-    onDeleteRequest: () -> Unit,
-    onFavoriteClick: () -> Unit
+    onFavoriteClick: () -> Unit,
+    isSelected: Boolean = false,
+    isMultiSelectActive: Boolean = false
 ) {
-    Box {
-        Card(
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(TestTags.recipeCard(recipe.id))
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick
+            ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        colors = if (isSelected) {
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer
+            )
+        } else {
+            CardDefaults.cardColors()
+        }
+    ) {
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .testTag(TestTags.recipeCard(recipe.id))
-                .combinedClickable(
-                    onClick = onClick,
-                    onLongClick = onLongClick
-                ),
-            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                .padding(12.dp)
         ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(12.dp)
-            ) {
-                // Recipe image (always reserve space for consistent alignment)
-                RecipeThumbnail(
-                    imageUrl = recipe.imageUrl,
-                    contentDescription = recipe.name,
-                    size = 80
+            // Recipe image (always reserve space for consistent alignment)
+            RecipeThumbnail(
+                imageUrl = recipe.imageUrl,
+                contentDescription = recipe.name,
+                size = 80
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = recipe.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
                 )
-                Spacer(modifier = Modifier.width(12.dp))
 
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = recipe.name,
-                        style = MaterialTheme.typography.titleMedium,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-
-                    if (recipe.totalTime != null || recipe.servings != null) {
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Row {
-                            recipe.totalTime?.let {
-                                Text(
-                                    text = it,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                            if (recipe.totalTime != null && recipe.servings != null) {
-                                Text(
-                                    text = " \u2022 ",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                            recipe.servings?.let {
-                                Text(
-                                    text = stringResource(R.string.servings_count, it.toString()),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
+                if (recipe.totalTime != null || recipe.servings != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row {
+                        recipe.totalTime?.let {
+                            Text(
+                                text = it,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
-                    }
-
-                    if (recipe.tags.isNotEmpty()) {
-                        Spacer(modifier = Modifier.height(8.dp))
-                        FlowRow(
-                            horizontalArrangement = Arrangement.spacedBy(4.dp),
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            recipe.tags.take(3).forEach { tag ->
-                                TagChip(tag = tag)
-                            }
-                            if (recipe.tags.size > 3) {
-                                Text(
-                                    text = "+${recipe.tags.size - 3}",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(horizontal = 4.dp)
-                                )
-                            }
+                        if (recipe.totalTime != null && recipe.servings != null) {
+                            Text(
+                                text = " \u2022 ",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        recipe.servings?.let {
+                            Text(
+                                text = stringResource(R.string.servings_count, it.toString()),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
                     }
                 }
 
+                if (recipe.tags.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        recipe.tags.take(3).forEach { tag ->
+                            TagChip(tag = tag)
+                        }
+                        if (recipe.tags.size > 3) {
+                            Text(
+                                text = "+${recipe.tags.size - 3}",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 4.dp)
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (isMultiSelectActive) {
+                // Selection indicator
+                Icon(
+                    imageVector = if (isSelected) Icons.Filled.CheckCircle else Icons.Outlined.Circle,
+                    contentDescription = null,
+                    tint = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.align(Alignment.CenterVertically)
+                )
+            } else {
                 // Favorite button
                 IconButton(
                     onClick = onFavoriteClick,
@@ -142,27 +154,6 @@ internal fun RecipeCard(
                     )
                 }
             }
-        }
-
-        // Long-press context menu
-        DropdownMenu(
-            expanded = showMenu,
-            onDismissRequest = onDismissMenu
-        ) {
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.delete)) },
-                onClick = {
-                    onDismissMenu()
-                    onDeleteRequest()
-                },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.Delete,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.error
-                    )
-                }
-            )
         }
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/SwipeableRecipeCard.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/recipelist/components/SwipeableRecipeCard.kt
@@ -10,10 +10,6 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -31,15 +27,16 @@ fun SwipeableRecipeCard(
     onClick: () -> Unit,
     onDeleteRequest: () -> Unit,
     onFavoriteClick: () -> Unit,
-    swipeState: SwipeActionBoxState = rememberSwipeActionBoxState()
+    swipeState: SwipeActionBoxState = rememberSwipeActionBoxState(),
+    isSelected: Boolean = false,
+    isMultiSelectActive: Boolean = false,
+    onLongClick: () -> Unit = {}
 ) {
-    var showMenu by remember { mutableStateOf(false) }
-
     SwipeActionBox(
         state = swipeState,
         onEndToStartAction = onDeleteRequest,
         enableStartToEnd = false,
-        enableEndToStart = true,
+        enableEndToStart = !isMultiSelectActive,
         backgroundContent = {
             Box(
                 modifier = Modifier
@@ -58,11 +55,10 @@ fun SwipeableRecipeCard(
         RecipeCard(
             recipe = recipe,
             onClick = onClick,
-            onLongClick = { showMenu = true },
-            showMenu = showMenu,
-            onDismissMenu = { showMenu = false },
-            onDeleteRequest = onDeleteRequest,
-            onFavoriteClick = onFavoriteClick
+            onLongClick = onLongClick,
+            onFavoriteClick = onFavoriteClick,
+            isSelected = isSelected,
+            isMultiSelectActive = isMultiSelectActive
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,14 @@
     <!-- Delete Confirmation Dialog -->
     <string name="delete_recipe">Delete Recipe</string>
     <string name="delete_recipe_confirmation">Are you sure you want to delete \"%1$s\"? This action cannot be undone.</string>
+    <plurals name="delete_recipes">
+        <item quantity="one">Delete %1$d Recipe</item>
+        <item quantity="other">Delete %1$d Recipes</item>
+    </plurals>
+    <plurals name="delete_recipes_confirmation">
+        <item quantity="one">Are you sure you want to delete %1$d recipe? This action cannot be undone.</item>
+        <item quantity="other">Are you sure you want to delete %1$d recipes? This action cannot be undone.</item>
+    </plurals>
     <plurals name="delete_recipe_meal_plan_warning">
         <item quantity="one">This will also remove %1$d meal plan entry using this recipe.</item>
         <item quantity="other">This will also remove %1$d meal plan entries using this recipe.</item>
@@ -29,6 +37,10 @@
     <string name="import_failed">Import failed</string>
     <string name="cancel_import_confirmation">Cancel this import?</string>
     <string name="servings_count">%1$s servings</string>
+    <plurals name="selected_count">
+        <item quantity="one">%1$d selected</item>
+        <item quantity="other">%1$d selected</item>
+    </plurals>
 
     <!-- Recipe Detail Screen -->
     <string name="recipe">Recipe</string>


### PR DESCRIPTION
## Summary
- Long-pressing a recipe card enters multi-select mode where users can tap to select/deselect multiple recipes
- Top bar switches to show selection count (with back arrow to cancel) and a delete button for bulk deletion
- Bulk delete confirmation dialog shows how many recipes and affected meal plan entries will be removed
- Swipe-to-delete still works for individual recipes as before; swiping and context menus are disabled during multi-select

## Changes
- **RecipeListScreen**: Added multi-select state management, `BackHandler` to exit selection, conditional top bar with selection count and delete action, hidden search/filter during selection
- **RecipeListViewModel**: Added `selectedRecipeIds` state, `isMultiSelectActive` derived state, `startSelection`/`toggleRecipeSelection`/`clearSelection`/`deleteSelectedRecipes` methods
- **RecipeCard**: Added `isSelected`/`isMultiSelectActive` params; shows check circle instead of favorite button when selecting; highlights selected cards with `primaryContainer` color
- **SwipeableRecipeCard**: Added selection params; disables swipe during multi-select; redirects long-press to start selection
- **DeleteConfirmationDialog**: Added `BulkDeleteConfirmationDialog` for multi-recipe deletion with proper pluralization
- **IMealPlanRepository / MealPlanRepository**: Added `countMealPlansByRecipeIds` for efficient bulk meal plan counting (uses Firestore `whereIn` with chunking for >30 IDs)
- **strings.xml**: Added plural strings for selected count, bulk delete title, and bulk delete confirmation

## Test plan
- [ ] Long-press a recipe card to enter multi-select mode
- [ ] Verify the top bar changes to show "N selected" with back arrow and delete icon
- [ ] Tap additional recipe cards to select/deselect them
- [ ] Verify selected cards are highlighted and show check circles
- [ ] Press the back arrow or system back to exit multi-select mode
- [ ] Tap delete, verify confirmation dialog shows recipe count and affected meal plan count
- [ ] Confirm deletion and verify all selected recipes are removed
- [ ] Verify swipe-to-delete still works for single recipes when not in multi-select mode
- [ ] Verify swiping is disabled during multi-select mode
- [ ] Verify search bar and tag filters are hidden during multi-select
- [ ] Verify FAB is hidden during multi-select

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)