### PR TITLE
feat: support anonymous guest mode

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AuthService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AuthService.kt
@@ -7,15 +7,42 @@ import androidx.credentials.GetCredentialRequest
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.firebase.Firebase
+import com.google.firebase.auth.AuthCredential
+import com.google.firebase.auth.FirebaseAuthUserCollisionException
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.auth
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
+
+/** Represents the current authentication state of the app. */
+sealed class AuthState {
+    /** App is initializing or transitioning between auth states. */
+    data object Loading : AuthState()
+
+    /** User is signed in anonymously (offline-only, no cloud sync). */
+    data object Anonymous : AuthState()
+
+    /** User is signed in with a Google account. */
+    data class Google(val email: String) : AuthState()
+}
+
+/** Result of attempting to link an anonymous account with Google. */
+sealed class LinkResult {
+    /** Successfully linked — anonymous UID is preserved, no data migration needed. */
+    data object Linked : LinkResult()
+
+    /** Google account already exists — need to migrate data from anonymous to Google. */
+    data class NeedsMerge(val anonymousUid: String, val credential: AuthCredential) : LinkResult()
+}
 
 @Singleton
 class AuthService @Inject constructor(
@@ -26,42 +53,95 @@ class AuthService @Inject constructor(
         private const val TAG = "AuthService"
     }
 
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     private val _isSignedIn = MutableStateFlow(Firebase.auth.currentUser != null)
     val isSignedIn: StateFlow<Boolean> = _isSignedIn.asStateFlow()
 
     private val _currentUserEmail = MutableStateFlow(Firebase.auth.currentUser?.email)
     val currentUserEmail: StateFlow<String?> = _currentUserEmail.asStateFlow()
 
+    private val _currentUserId = MutableStateFlow(Firebase.auth.currentUser?.uid)
+    /** Emits the current Firebase UID (or null). Repositories observe this to reset their listeners. */
+    val currentUserId: StateFlow<String?> = _currentUserId.asStateFlow()
+
+    private val _authState = MutableStateFlow<AuthState>(AuthState.Loading)
+    val authState: StateFlow<AuthState> = _authState.asStateFlow()
+
     init {
+        // Set initial auth state based on current user
+        updateAuthState(Firebase.auth.currentUser)
+
         Firebase.auth.addAuthStateListener { auth ->
             _isSignedIn.value = auth.currentUser != null
             _currentUserEmail.value = auth.currentUser?.email
+            _currentUserId.value = auth.currentUser?.uid
+            // Only update authState from listener when not in Loading (transition) state.
+            // During transitions (sign-out -> anonymous), we control authState manually.
+            if (_authState.value !is AuthState.Loading) {
+                if (auth.currentUser == null) {
+                    // User signed out unexpectedly (e.g., token revoked).
+                    // Re-establish an anonymous session to avoid a frozen UI.
+                    serviceScope.launch {
+                        ensureSignedIn()
+                    }
+                } else {
+                    updateAuthState(auth.currentUser)
+                }
+            }
+        }
+    }
+
+    private fun updateAuthState(user: com.google.firebase.auth.FirebaseUser?) {
+        _authState.value = when {
+            user == null -> AuthState.Loading
+            user.isAnonymous -> AuthState.Anonymous
+            else -> AuthState.Google(user.email ?: "")
+        }
+    }
+
+    /**
+     * Ensures the user is signed in (either Google or anonymously).
+     * Called during app startup. If no user exists, signs in anonymously
+     * with Firestore network disabled.
+     */
+    suspend fun ensureSignedIn() {
+        val currentUser = Firebase.auth.currentUser
+        if (currentUser != null) {
+            if (currentUser.isAnonymous) {
+                // Anonymous user from previous session — keep network disabled
+                firestoreService.disableNetwork()
+            }
+            updateAuthState(currentUser)
+            return
+        }
+        // No user — sign in anonymously with network off
+        _authState.value = AuthState.Loading
+        firestoreService.disableNetwork()
+        val result = signInAnonymously()
+        if (result.isFailure) {
+            // Stay in Loading state — caller should show error
+            Log.e(TAG, "Failed to sign in anonymously during startup")
+        }
+    }
+
+    /** Sign in anonymously. Returns Result for error handling. */
+    suspend fun signInAnonymously(): Result<Unit> {
+        return try {
+            Firebase.auth.signInAnonymously().await()
+            _authState.value = AuthState.Anonymous
+            _isSignedIn.value = true
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "Anonymous sign-in failed", e)
+            Result.failure(e)
         }
     }
 
     suspend fun signInWithGoogle(activityContext: Context): Result<Unit> {
         return try {
-            val credentialManager = CredentialManager.create(activityContext)
-            val webClientId = activityContext.getString(
-                activityContext.resources.getIdentifier(
-                    "default_web_client_id", "string", activityContext.packageName
-                )
-            )
-
-            val googleIdOption = GetGoogleIdOption.Builder()
-                .setFilterByAuthorizedAccounts(false)
-                .setServerClientId(webClientId)
-                .build()
-
-            val request = GetCredentialRequest.Builder()
-                .addCredentialOption(googleIdOption)
-                .build()
-
-            val result = credentialManager.getCredential(activityContext, request)
-            val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(result.credential.data)
-            val firebaseCredential = GoogleAuthProvider.getCredential(googleIdTokenCredential.idToken, null)
-
-            Firebase.auth.signInWithCredential(firebaseCredential).await()
+            val credential = getGoogleCredential(activityContext)
+            Firebase.auth.signInWithCredential(credential).await()
             Result.success(Unit)
         } catch (e: Exception) {
             Log.e(TAG, "Google sign-in failed", e)
@@ -69,8 +149,83 @@ class AuthService @Inject constructor(
         }
     }
 
+    /**
+     * Links the current anonymous account with a Google credential.
+     * If the Google account already exists, returns [LinkResult.NeedsMerge].
+     */
+    suspend fun linkWithGoogle(activityContext: Context): Result<LinkResult> {
+        val anonymousUser = Firebase.auth.currentUser
+            ?: return Result.failure(IllegalStateException("No current user"))
+        val anonymousUid = anonymousUser.uid
+
+        return try {
+            val credential = getGoogleCredential(activityContext)
+            try {
+                // Try linking — preserves UID, no data migration needed
+                anonymousUser.linkWithCredential(credential).await()
+                firestoreService.enableNetwork()
+                _authState.value = AuthState.Google(Firebase.auth.currentUser?.email ?: "")
+                Result.success(LinkResult.Linked)
+            } catch (e: FirebaseAuthUserCollisionException) {
+                // Google account already exists — need to migrate data
+                Result.success(LinkResult.NeedsMerge(anonymousUid, credential))
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to link Google account", e)
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Completes the merge flow: signs in with the Google credential,
+     * enables network. The caller is responsible for migrating data before calling this.
+     */
+    suspend fun completeMergeSignIn(credential: AuthCredential): Result<Unit> {
+        return try {
+            Firebase.auth.signInWithCredential(credential).await()
+            firestoreService.enableNetwork()
+            _authState.value = AuthState.Google(Firebase.auth.currentUser?.email ?: "")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to complete merge sign-in", e)
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Signs out the current user and transitions to anonymous mode.
+     * Clears Firestore persistence and re-signs-in anonymously.
+     */
     suspend fun signOut() {
-        firestoreService.signOut()
-        // AuthStateListener will update _isSignedIn to false
+        _authState.value = AuthState.Loading
+        firestoreService.clearLocalData()
+        Firebase.auth.signOut()
+        // Now sign in anonymously with network disabled
+        firestoreService.disableNetwork()
+        signInAnonymously()
+        // AuthState is updated inside signInAnonymously()
+    }
+
+    /** Extracts a Google [AuthCredential] using Credential Manager. */
+    private suspend fun getGoogleCredential(activityContext: Context): AuthCredential {
+        val credentialManager = CredentialManager.create(activityContext)
+        val webClientId = activityContext.getString(
+            activityContext.resources.getIdentifier(
+                "default_web_client_id", "string", activityContext.packageName
+            )
+        )
+
+        val googleIdOption = GetGoogleIdOption.Builder()
+            .setFilterByAuthorizedAccounts(false)
+            .setServerClientId(webClientId)
+            .build()
+
+        val request = GetCredentialRequest.Builder()
+            .addCredentialOption(googleIdOption)
+            .build()
+
+        val result = credentialManager.getCredential(activityContext, request)
+        val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(result.credential.data)
+        return GoogleAuthProvider.getCredential(googleIdTokenCredential.idToken, null)
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/ImageDownloadService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/ImageDownloadService.kt
@@ -12,6 +12,8 @@ import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.jvm.javaio.toInputStream
 import android.util.Base64
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 import java.io.File
 import java.io.InputStream
 import java.util.UUID
@@ -72,6 +74,9 @@ class ImageDownloadService @Inject constructor(
         if (previousImageUrl != null) {
             cleanupImage(previousImageUrl)
         }
+
+        // Skip upload for anonymous users — just use local file
+        if (Firebase.auth.currentUser?.isAnonymous == true) return localUri
 
         // Upload to Firebase Storage
         return imageSyncService.uploadImage(localUri) ?: localUri

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.lionotter.recipes.ui.screens.settings
 
 import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -59,10 +60,20 @@ fun SettingsScreen(
     val groceryWeightUnitSystem by viewModel.groceryWeightUnitSystem.collectAsStateWithLifecycle()
     val startOfWeek by viewModel.startOfWeek.collectAsStateWithLifecycle()
     val importDebuggingEnabled by viewModel.importDebuggingEnabled.collectAsStateWithLifecycle()
-    val currentUserEmail by viewModel.currentUserEmail.collectAsStateWithLifecycle()
+    val authState by viewModel.authState.collectAsStateWithLifecycle()
+    val isLinking by viewModel.isLinking.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
+
+    // Observe toast messages from SettingsViewModel (emitted as string resource IDs)
+    // Context is used for string resolution in a side-effect, not for rendering
+    @Suppress("LocalContextGetResourceValueCall")
+    LaunchedEffect(Unit) {
+        viewModel.toastMessage.collect { messageResId ->
+            Toast.makeText(context, context.getString(messageResId), Toast.LENGTH_SHORT).show()
+        }
+    }
 
     // Export file picker (create .lorecipes document)
     val exportLauncher = rememberLauncherForActivityResult(
@@ -139,8 +150,10 @@ fun SettingsScreen(
             HorizontalDivider()
 
             AccountSection(
-                userEmail = currentUserEmail,
-                onSignOut = { viewModel.signOut() }
+                authState = authState,
+                onSignInWithGoogle = { viewModel.linkWithGoogle(context) },
+                onSignOut = { viewModel.signOut() },
+                isLinking = isLinking
             )
 
             HorizontalDivider()

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/AccountSection.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/settings/components/AccountSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -17,12 +18,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.lionotter.recipes.R
+import com.lionotter.recipes.data.remote.AuthState
 
 @Composable
 fun AccountSection(
-    userEmail: String?,
-    onSignOut: () -> Unit
+    authState: AuthState,
+    onSignInWithGoogle: () -> Unit,
+    onSignOut: () -> Unit,
+    isLinking: Boolean = false
 ) {
     var showConfirmDialog by remember { mutableStateOf(false) }
 
@@ -32,38 +38,67 @@ fun AccountSection(
             .padding(horizontal = 16.dp)
     ) {
         Text(
-            text = "Account",
+            text = stringResource(R.string.account),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.primary
         )
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        if (userEmail != null) {
-            Text(
-                text = "Signed in as $userEmail",
-                style = MaterialTheme.typography.bodyMedium
-            )
-        }
+        when (authState) {
+            is AuthState.Anonymous -> {
+                Text(
+                    text = stringResource(R.string.guest_mode_description),
+                    style = MaterialTheme.typography.bodyMedium
+                )
 
-        Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(8.dp))
 
-        Button(
-            onClick = { showConfirmDialog = true },
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.error
-            )
-        ) {
-            Text("Sign Out")
+                if (isLinking) {
+                    CircularProgressIndicator()
+                } else {
+                    Button(onClick = onSignInWithGoogle) {
+                        Text(stringResource(R.string.sign_in_with_google))
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Text(
+                    text = stringResource(R.string.sign_in_sync_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            is AuthState.Google -> {
+                Text(
+                    text = stringResource(R.string.signed_in_as, authState.email),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Button(
+                    onClick = { showConfirmDialog = true },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text(stringResource(R.string.sign_out))
+                }
+            }
+            is AuthState.Loading -> {
+                CircularProgressIndicator()
+            }
         }
     }
 
     if (showConfirmDialog) {
         AlertDialog(
             onDismissRequest = { showConfirmDialog = false },
-            title = { Text("Sign Out") },
+            title = { Text(stringResource(R.string.sign_out)) },
             text = {
-                Text("Signing out will delete all locally cached data. Export your recipes first to keep a backup.")
+                Text(stringResource(R.string.sign_out_confirmation))
             },
             confirmButton = {
                 TextButton(
@@ -72,12 +107,12 @@ fun AccountSection(
                         onSignOut()
                     }
                 ) {
-                    Text("Sign Out", color = MaterialTheme.colorScheme.error)
+                    Text(stringResource(R.string.sign_out), color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showConfirmDialog = false }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.cancel))
                 }
             }
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,18 @@
     <string name="search">Search</string>
     <string name="or">or</string>
 
+    <!-- Account -->
+    <string name="account">Account</string>
+    <string name="guest_mode_description">Using guest mode (data stored on this device only)</string>
+    <string name="sign_in_with_google">Sign in with Google</string>
+    <string name="sign_in_sync_description">Sign in to sync recipes across devices</string>
+    <string name="signed_in_as">Signed in as %1$s</string>
+    <string name="sign_out">Sign Out</string>
+    <string name="sign_out_confirmation">Signing out will delete all locally cached data. You will continue in guest mode with an empty recipe list. Export your recipes first to keep a backup.</string>
+    <string name="signed_in_with_google">Signed in with Google</string>
+    <string name="sign_in_failed">Failed to sign in</string>
+    <string name="sign_in_migration_warning">Signed in with Google, but some data may not have been migrated</string>
+
     <!-- Delete Confirmation Dialog -->
     <string name="delete_recipe">Delete Recipe</string>
     <string name="delete_recipe_confirmation">Are you sure you want to delete \"%1$s\"? This action cannot be undone.</string>

--- a/app/src/test/kotlin/com/lionotter/recipes/integration/FirestoreIntegrationTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/integration/FirestoreIntegrationTest.kt
@@ -6,10 +6,14 @@ import com.google.firebase.FirebaseOptions
 import com.google.firebase.firestore.MemoryCacheSettings
 import com.google.firebase.firestore.firestore
 import com.google.firebase.firestore.firestoreSettings
+import com.lionotter.recipes.data.remote.AuthService
 import com.lionotter.recipes.data.remote.ImageDownloadService
 import com.lionotter.recipes.data.remote.ImageSyncService
 import com.lionotter.recipes.data.repository.MealPlanRepository
 import com.lionotter.recipes.data.repository.RecipeRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -78,7 +82,9 @@ abstract class FirestoreIntegrationTest {
             engine { addHandler { respond("", HttpStatusCode.NotFound) } }
         }
         val imageDownloadService = ImageDownloadService(context, httpClient, imageSyncService)
-        recipeRepository = RecipeRepository(firestoreService, imageDownloadService)
+        val authService: AuthService = mockk()
+        every { authService.currentUserId } returns MutableStateFlow("test-user")
+        recipeRepository = RecipeRepository(firestoreService, imageDownloadService, authService)
         mealPlanRepository = MealPlanRepository(firestoreService)
     }
 

--- a/app/src/test/kotlin/com/lionotter/recipes/spike/FirestoreListenerSpikeTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/spike/FirestoreListenerSpikeTest.kt
@@ -1,9 +1,13 @@
 package com.lionotter.recipes.spike
 
 import android.util.Log
+import com.lionotter.recipes.data.remote.AuthService
 import com.lionotter.recipes.data.remote.ImageDownloadService
 import com.lionotter.recipes.data.remote.ImageSyncService
 import com.lionotter.recipes.data.repository.RecipeRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import com.lionotter.recipes.testutil.TestFirestoreService
 import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
@@ -320,7 +324,9 @@ class FirestoreListenerSpikeTest {
             engine { addHandler { respond("", HttpStatusCode.NotFound) } }
         }
         val imageDownloadService = ImageDownloadService(context, httpClient, imageSyncService)
-        val recipeRepo = RecipeRepository(testFirestoreService, imageDownloadService)
+        val authService: AuthService = mockk()
+        every { authService.currentUserId } returns MutableStateFlow("test-user")
+        val recipeRepo = RecipeRepository(testFirestoreService, imageDownloadService, authService)
 
         val recipe = com.lionotter.recipes.domain.model.Recipe(
             id = "looper-test",

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -4,6 +4,9 @@ import app.cash.turbine.test
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.remote.AnthropicService
 import com.lionotter.recipes.data.remote.AuthService
+import com.lionotter.recipes.data.remote.AuthState
+import com.lionotter.recipes.data.remote.ImageSyncService
+import com.lionotter.recipes.data.repository.IRecipeRepository
 import com.lionotter.recipes.data.repository.ImportDebugRepository
 import com.lionotter.recipes.domain.model.StartOfWeek
 import com.lionotter.recipes.domain.model.ThemeMode
@@ -33,6 +36,8 @@ class SettingsViewModelTest {
     private lateinit var settingsDataStore: SettingsDataStore
     private lateinit var importDebugRepository: ImportDebugRepository
     private lateinit var authService: AuthService
+    private lateinit var recipeRepository: IRecipeRepository
+    private lateinit var imageSyncService: ImageSyncService
     private lateinit var viewModel: SettingsViewModel
     private val testDispatcher = StandardTestDispatcher()
 
@@ -55,6 +60,8 @@ class SettingsViewModelTest {
         settingsDataStore = mockk()
         importDebugRepository = mockk()
         authService = mockk()
+        recipeRepository = mockk()
+        imageSyncService = mockk()
         every { settingsDataStore.anthropicApiKey } returns apiKeyFlow
         every { settingsDataStore.aiModel } returns aiModelFlow
         every { settingsDataStore.editModel } returns editModelFlow
@@ -68,7 +75,8 @@ class SettingsViewModelTest {
         every { settingsDataStore.groceryWeightUnitSystem } returns groceryWeightUnitSystemFlow
         every { settingsDataStore.startOfWeek } returns startOfWeekFlow
         every { authService.currentUserEmail } returns MutableStateFlow(null)
-        viewModel = SettingsViewModel(settingsDataStore, importDebugRepository, authService)
+        every { authService.authState } returns MutableStateFlow<AuthState>(AuthState.Anonymous)
+        viewModel = SettingsViewModel(settingsDataStore, importDebugRepository, authService, recipeRepository, imageSyncService)
     }
 
     @After

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -39,7 +39,7 @@ external: {
     style: {
       fill: "#ffca28"
     }
-    tooltip: "Firebase Auth (Google Sign-In), Cloud Firestore (recipes + meal plans), and Cloud Storage (recipe images). Firestore uses unlimited persistent cache with auto index creation. Storage images are cached locally for offline access."
+    tooltip: "Firebase Auth (Anonymous + Google Sign-In), Cloud Firestore (recipes + meal plans), and Cloud Storage (recipe images). Firestore uses unlimited persistent cache with auto index creation. Anonymous users operate fully offline with Firestore network disabled. Storage images are cached locally for offline access; anonymous users use local file:// URIs only."
   }
 
 }
@@ -69,7 +69,7 @@ app: {
 
       login: {
         label: LoginScreen
-        tooltip: "Google Sign-In screen shown when user is not authenticated. Gates access to the main app."
+        tooltip: "Legacy screen (no longer shown). App now auto-signs-in anonymously. Google Sign-In moved to Settings AccountSection."
       }
       list: RecipeListScreen
       detail: {
@@ -136,7 +136,7 @@ app: {
       cancel_import_dialog: CancelImportConfirmationDialog
       account_section: {
         label: AccountSection
-        tooltip: "Settings component showing signed-in email and sign-out button with confirmation dialog warning about local cache deletion."
+        tooltip: "Settings component with two modes: Anonymous shows 'guest mode' message and 'Sign in with Google' button; Google shows signed-in email and sign-out button. Sign-out transitions to anonymous mode (not login screen). Linking with Google uploads local images to Firebase Storage."
       }
     }
 
@@ -150,7 +150,7 @@ app: {
 
       login_vm: {
         label: LoginViewModel
-        tooltip: "Manages Google Sign-In loading state. Delegates to AuthService."
+        tooltip: "Legacy ViewModel (no longer used). Anonymous auth is automatic at startup."
       }
       list_vm: RecipeListViewModel
       detail_vm: RecipeDetailViewModel
@@ -543,7 +543,7 @@ app: {
       }
       image_dl: {
         label: ImageDownloadService
-        tooltip: "Downloads recipe images from remote URLs and stores them locally in app internal storage. Automatically retries with HTTPS if an HTTP download fails (e.g., cleartext traffic not permitted). Also supports saving images from byte streams (ZIP import) and base64 data (Paprika photo_data). After saving locally, uploads images to Firebase Storage via ImageSyncService. Returns gs:// URIs for Firestore sync. Used during import, export, and ZIP restore."
+        tooltip: "Downloads recipe images from remote URLs and stores them locally in app internal storage. Automatically retries with HTTPS if an HTTP download fails (e.g., cleartext traffic not permitted). Also supports saving images from byte streams (ZIP import) and base64 data (Paprika photo_data). After saving locally, uploads images to Firebase Storage via ImageSyncService (skipped for anonymous users — returns local file:// URI instead). Returns gs:// URIs for Firestore sync when signed in with Google. Used during import, export, and ZIP restore."
       }
       image_sync: {
         label: ImageSyncService
@@ -555,11 +555,11 @@ app: {
       }
       firestore_svc: {
         label: FirestoreService
-        tooltip: "Singleton managing Firestore instance with unlimited persistent cache and auto index creation. Provides user-scoped collection references (recipes, mealPlans). Reports errors via SharedFlow for Toast display. Handles sign-out (terminate, clear persistence)."
+        tooltip: "Singleton managing Firestore instance with unlimited persistent cache and auto index creation. Provides user-scoped collection references (recipes, mealPlans). Reports errors via SharedFlow for Toast display. Handles sign-out (terminate, clear persistence). Supports network toggle (disableNetwork/enableNetwork) for anonymous offline mode."
       }
       auth_svc: {
         label: AuthService
-        tooltip: "Google Sign-In via Credential Manager API. Exposes isSignedIn StateFlow for auth gating in MainActivity. Manages sign-out flow including Firestore cache clearing."
+        tooltip: "Authentication service supporting both anonymous and Google Sign-In via Credential Manager API. Exposes AuthState sealed class (Loading, Anonymous, Google) for reactive UI. On startup, auto-signs-in anonymously with Firestore network disabled if no user exists. Supports account upgrade via linkWithGoogle() which links anonymous account to Google credential. Handles merge conflict when Google account already exists. Sign-out clears Firestore cache and transitions to anonymous mode."
       }
     }
 
@@ -786,7 +786,7 @@ legend: {
   share1 -> share2 -> share3 -> share4
 
   note: {
-    label: "All imports run in background via WorkManager (URL, Paprika, .lorecipes). Import queue is database-backed (PendingImportEntity in Room) and persists across app restarts. Recipes and meal plans are stored in Firestore with unlimited persistent cache and fire-and-forget writes. Google Sign-In is required before accessing any data. Sign-out clears local Firestore cache. Paprika import uses the Message Batches API for multiple recipes (50% cheaper), submitting all recipes as a single batch for parallel processing, with fallback to sequential for single recipes. Batch cancellation propagates to the server. Export uses .lorecipes format (ZIP with RecipeSerializer) for both single recipe share and bulk backup."
+    label: "All imports run in background via WorkManager (URL, Paprika, .lorecipes). Import queue is database-backed (PendingImportEntity in Room) and persists across app restarts. Recipes and meal plans are stored in Firestore with unlimited persistent cache and fire-and-forget writes. App starts in anonymous guest mode with Firestore network disabled (offline-only). Users can optionally sign in with Google via Settings to enable cloud sync. Anonymous users store images locally (file:// URIs); linking with Google uploads images to Firebase Storage. Sign-out clears Firestore cache and returns to anonymous mode. Paprika import uses the Message Batches API for multiple recipes (50% cheaper), submitting all recipes as a single batch for parallel processing, with fallback to sequential for single recipes. Batch cancellation propagates to the server. Export uses .lorecipes format (ZIP with RecipeSerializer) for both single recipe share and bulk backup."
     style: {
       font-size: 12
       italic: true


### PR DESCRIPTION
## Summary
- Users now start in anonymous guest mode with Firestore running offline-only (no backend calls)
- Google Sign-In moved from mandatory login screen to optional in Settings
- Sign-out transitions to anonymous mode instead of back to login screen
- Local images use file:// URIs for anonymous users; uploaded to Firebase Storage on Google sign-in
- Account linking handles both fresh link and merge (existing Google account) scenarios

## Changes
- **AuthService**: Added `AuthState` sealed class (Loading/Anonymous/Google), `ensureSignedIn()` for startup, `linkWithGoogle()` for account upgrade with merge handling, `signOut()` transitions to anonymous
- **FirestoreService**: Added `disableNetwork()`/`enableNetwork()` for toggling offline mode
- **MainActivity**: Replaced `LoginScreen` gate with `AuthState`-based UI showing app for all auth states
- **ImageDownloadService**: Skip Firebase Storage upload for anonymous users
- **AccountSection**: Shows guest mode + sign-in button (anonymous) or email + sign-out (Google)
- **SettingsViewModel**: Added `linkWithGoogle()` with merge handling and background image upload on account upgrade
- **SettingsScreen**: Wired up new AccountSection with auth state and linking
- Updated architecture.d2 and string resources
- Updated SettingsViewModelTest for new constructor

## Test plan
- [ ] Fresh install: app should auto-sign-in anonymously and show recipe list
- [ ] Import a recipe in guest mode: should work with local storage only
- [ ] Go to Settings → tap "Sign in with Google": should link account and enable sync
- [ ] After Google sign-in: local images should be uploaded to Firebase Storage
- [ ] Sign out from Google: should clear data and return to anonymous guest mode
- [ ] Existing Google users: app should continue working as before

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)