### PR TITLE
fix: migrate guest recipes when signing into existing Google account

### DIFF
--- a/app/src/main/kotlin/com/lionotter/recipes/data/remote/AccountMigrationService.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/data/remote/AccountMigrationService.kt
@@ -1,0 +1,230 @@
+package com.lionotter.recipes.data.remote
+
+import android.content.Context
+import android.util.Log
+import com.google.firebase.Firebase
+import com.google.firebase.FirebaseApp
+import com.google.firebase.app
+import com.google.firebase.auth.AuthCredential
+import com.google.firebase.auth.auth
+import com.google.firebase.firestore.Source
+import com.google.firebase.firestore.firestore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Handles data migration when a guest (anonymous) user signs into an
+ * existing Google account (the "NeedsMerge" flow).
+ *
+ * Strategy: create an ephemeral secondary [FirebaseApp] pointing at the
+ * same project, sign the Google user in on that secondary instance, then
+ * copy documents from the default (anonymous) Firestore to the secondary
+ * (Google) Firestore. Once complete, sign the Google user in on the
+ * default app and tear down the secondary app.
+ *
+ * This avoids the need for intermediate staging (Room) because the
+ * anonymous user's data remains intact on the default app until the
+ * migration is fully committed on the server via the secondary app.
+ */
+@Singleton
+class AccountMigrationService @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val firestoreService: FirestoreService
+) {
+    companion object {
+        private const val TAG = "AccountMigrationService"
+        private const val MIGRATION_APP_NAME = "migration"
+    }
+
+    /**
+     * Migrates guest data to an existing Google account.
+     *
+     * 1. Creates a secondary FirebaseApp and signs in the Google user there
+     * 2. Reads all recipes + meal plans from the default (anonymous) Firestore cache
+     * 3. Writes them to the secondary (Google) Firestore, skipping existing IDs
+     * 4. Tears down the secondary app
+     * 5. Signs in the Google user on the default app
+     * 6. Clears the anonymous Firestore cache and enables network
+     *
+     * If this method throws, the default app is still signed in as anonymous
+     * with all guest data intact — safe to retry.
+     */
+    suspend fun migrateGuestData(credential: AuthCredential): Result<Unit> {
+        // 1. Create secondary app and sign in as Google user
+        val migrationApp = createMigrationApp()
+        try {
+            val migrationAuth = com.google.firebase.auth.FirebaseAuth.getInstance(migrationApp)
+            migrationAuth.signInWithCredential(credential).await()
+            val googleUid = migrationAuth.currentUser?.uid
+                ?: run {
+                    cleanupMigrationApp(migrationApp)
+                    return Result.failure(IllegalStateException("No user after sign-in on migration app"))
+                }
+
+            val migrationFirestore = com.google.firebase.firestore.FirebaseFirestore.getInstance(migrationApp)
+
+            // 2. Read guest data from default (anonymous) Firestore cache
+            val anonymousUid = Firebase.auth.currentUser?.uid
+                ?: run {
+                    cleanupMigrationApp(migrationApp)
+                    return Result.failure(IllegalStateException("No anonymous user"))
+                }
+
+            val defaultFirestore = Firebase.firestore
+
+            val guestRecipes = readDocuments(
+                defaultFirestore.collection(FirestoreService.USERS_COLLECTION)
+                    .document(anonymousUid).collection(FirestoreService.RECIPES_COLLECTION)
+            )
+            val guestMealPlans = readDocuments(
+                defaultFirestore.collection(FirestoreService.USERS_COLLECTION)
+                    .document(anonymousUid).collection(FirestoreService.MEAL_PLANS_COLLECTION)
+            )
+
+            Log.d(TAG, "Read ${guestRecipes.size} recipes and ${guestMealPlans.size} meal plans from guest account")
+
+            if (guestRecipes.isEmpty() && guestMealPlans.isEmpty()) {
+                // Nothing to migrate — skip straight to sign-in
+                cleanupMigrationApp(migrationApp)
+                return completeSignIn(credential)
+            }
+
+            // 3. Read existing IDs in Google account to avoid overwriting
+            val existingRecipeIds = readDocumentIds(
+                migrationFirestore.collection(FirestoreService.USERS_COLLECTION)
+                    .document(googleUid).collection(FirestoreService.RECIPES_COLLECTION)
+            )
+            val existingMealPlanIds = readDocumentIds(
+                migrationFirestore.collection(FirestoreService.USERS_COLLECTION)
+                    .document(googleUid).collection(FirestoreService.MEAL_PLANS_COLLECTION)
+            )
+
+            // 4. Write guest data to Google account, skipping existing IDs
+            val recipesToMigrate = guestRecipes.filter { it.first !in existingRecipeIds }
+            val mealPlansToMigrate = guestMealPlans.filter { it.first !in existingMealPlanIds }
+
+            Log.d(TAG, "Migrating ${recipesToMigrate.size} recipes (${guestRecipes.size - recipesToMigrate.size} skipped)")
+            Log.d(TAG, "Migrating ${mealPlansToMigrate.size} meal plans (${guestMealPlans.size - mealPlansToMigrate.size} skipped)")
+
+            writeDocuments(
+                migrationFirestore.collection(FirestoreService.USERS_COLLECTION)
+                    .document(googleUid).collection(FirestoreService.RECIPES_COLLECTION),
+                recipesToMigrate
+            )
+            writeDocuments(
+                migrationFirestore.collection(FirestoreService.USERS_COLLECTION)
+                    .document(googleUid).collection(FirestoreService.MEAL_PLANS_COLLECTION),
+                mealPlansToMigrate
+            )
+
+            // 5. Tear down secondary app
+            cleanupMigrationApp(migrationApp)
+
+            // 6. Switch default app to Google user
+            return completeSignIn(credential)
+        } catch (e: Exception) {
+            Log.e(TAG, "Migration failed", e)
+            cleanupMigrationApp(migrationApp)
+            return Result.failure(e)
+        }
+    }
+
+    /**
+     * Completes the sign-in on the default app: signs in as Google,
+     * clears the anonymous Firestore cache, and enables network.
+     *
+     * Sign-in happens first so that if it fails, the anonymous user's
+     * local cache is still intact and nothing has been lost.
+     */
+    private suspend fun completeSignIn(credential: AuthCredential): Result<Unit> {
+        // Sign in as Google first — if this fails, anonymous data is still intact
+        Firebase.auth.signInWithCredential(credential).await()
+        // Now clear the anonymous Firestore cache to prevent orphaned documents
+        // from syncing when network is re-enabled. The auth state listener is
+        // suppressed (Loading), so the UID change won't trigger repository
+        // re-subscriptions yet.
+        firestoreService.clearLocalData()
+        firestoreService.enableNetwork()
+        return Result.success(Unit)
+    }
+
+    private fun createMigrationApp(): FirebaseApp {
+        // Clean up any leftover migration app from a previous crash
+        try {
+            FirebaseApp.getInstance(MIGRATION_APP_NAME).delete()
+        } catch (_: IllegalStateException) {
+            // No existing migration app — expected
+        }
+
+        val defaultApp = Firebase.app
+        return FirebaseApp.initializeApp(
+            context,
+            defaultApp.options,
+            MIGRATION_APP_NAME
+        )
+    }
+
+    private suspend fun cleanupMigrationApp(app: FirebaseApp) {
+        try {
+            val firestore = com.google.firebase.firestore.FirebaseFirestore.getInstance(app)
+            firestore.terminate().await()
+            firestore.clearPersistence().await()
+        } catch (e: Exception) {
+            Log.w(TAG, "Error during Firestore cleanup for migration app", e)
+        } finally {
+            try {
+                app.delete()
+                Log.d(TAG, "Migration app cleaned up")
+            } catch (e: Exception) {
+                Log.w(TAG, "Error deleting migration app", e)
+            }
+        }
+    }
+
+    /**
+     * Reads all documents from a collection's local cache,
+     * returning pairs of (documentId, data).
+     * Uses [Source.CACHE] since guest data is strictly offline.
+     */
+    private suspend fun readDocuments(
+        collection: com.google.firebase.firestore.CollectionReference
+    ): List<Pair<String, Map<String, Any?>>> {
+        val snapshot = collection.get(Source.CACHE).await()
+        return snapshot.documents.mapNotNull { doc ->
+            val data = doc.data
+            if (data != null) doc.id to data else null
+        }
+    }
+
+    /**
+     * Reads all document IDs from a collection.
+     */
+    private suspend fun readDocumentIds(
+        collection: com.google.firebase.firestore.CollectionReference
+    ): Set<String> {
+        val snapshot = collection.get().await()
+        return snapshot.documents.map { it.id }.toSet()
+    }
+
+    /**
+     * Writes documents to a collection using batched writes.
+     * Firestore batches support up to 500 operations.
+     */
+    private suspend fun writeDocuments(
+        collection: com.google.firebase.firestore.CollectionReference,
+        documents: List<Pair<String, Map<String, Any?>>>
+    ) {
+        if (documents.isEmpty()) return
+
+        val firestore = collection.firestore
+        for (chunk in documents.chunked(500)) {
+            val batch = firestore.batch()
+            for ((id, data) in chunk) {
+                batch.set(collection.document(id), data)
+            }
+            batch.commit().await()
+        }
+    }
+}

--- a/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/lionotter/recipes/ui/screens/settings/SettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package com.lionotter.recipes.ui.screens.settings
 import app.cash.turbine.test
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.data.remote.AnthropicService
+import com.lionotter.recipes.data.remote.AccountMigrationService
 import com.lionotter.recipes.data.remote.AuthService
 import com.lionotter.recipes.data.remote.AuthState
 import com.lionotter.recipes.data.remote.ImageSyncService
@@ -38,6 +39,7 @@ class SettingsViewModelTest {
     private lateinit var authService: AuthService
     private lateinit var recipeRepository: IRecipeRepository
     private lateinit var imageSyncService: ImageSyncService
+    private lateinit var accountMigrationService: AccountMigrationService
     private lateinit var viewModel: SettingsViewModel
     private val testDispatcher = StandardTestDispatcher()
 
@@ -62,6 +64,7 @@ class SettingsViewModelTest {
         authService = mockk()
         recipeRepository = mockk()
         imageSyncService = mockk()
+        accountMigrationService = mockk()
         every { settingsDataStore.anthropicApiKey } returns apiKeyFlow
         every { settingsDataStore.aiModel } returns aiModelFlow
         every { settingsDataStore.editModel } returns editModelFlow
@@ -76,7 +79,7 @@ class SettingsViewModelTest {
         every { settingsDataStore.startOfWeek } returns startOfWeekFlow
         every { authService.currentUserEmail } returns MutableStateFlow(null)
         every { authService.authState } returns MutableStateFlow<AuthState>(AuthState.Anonymous)
-        viewModel = SettingsViewModel(settingsDataStore, importDebugRepository, authService, recipeRepository, imageSyncService)
+        viewModel = SettingsViewModel(settingsDataStore, importDebugRepository, authService, recipeRepository, imageSyncService, accountMigrationService)
     }
 
     @After

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -559,7 +559,11 @@ app: {
       }
       auth_svc: {
         label: AuthService
-        tooltip: "Authentication service supporting both anonymous and Google Sign-In via Credential Manager API. Exposes AuthState sealed class (Loading, Anonymous, Google) for reactive UI. On startup, auto-signs-in anonymously with Firestore network disabled if no user exists. Supports account upgrade via linkWithGoogle() which links anonymous account to Google credential. Handles merge conflict when Google account already exists. Sign-out clears Firestore cache and transitions to anonymous mode."
+        tooltip: "Authentication service supporting both anonymous and Google Sign-In via Credential Manager API. Exposes AuthState sealed class (Loading, Anonymous, Google) for reactive UI. On startup, auto-signs-in anonymously with Firestore network disabled if no user exists. Supports account upgrade via linkWithGoogle() which links anonymous account to Google credential. Handles merge conflict when Google account already exists via AccountMigrationService (ephemeral secondary FirebaseApp migrates data before switching the default app). Sign-out clears Firestore cache and transitions to anonymous mode."
+      }
+      migration_svc: {
+        label: AccountMigrationService
+        tooltip: "Handles data migration when a guest signs into an existing Google account (NeedsMerge). Creates an ephemeral secondary FirebaseApp with the same project config, signs the Google user in on it, reads guest recipes/meal plans from the default (anonymous) Firestore cache, writes them to the Google account via the secondary Firestore (skipping existing IDs), then tears down the secondary app and switches the default app to Google."
       }
     }
 
@@ -786,7 +790,7 @@ legend: {
   share1 -> share2 -> share3 -> share4
 
   note: {
-    label: "All imports run in background via WorkManager (URL, Paprika, .lorecipes). Import queue is database-backed (PendingImportEntity in Room) and persists across app restarts. Recipes and meal plans are stored in Firestore with unlimited persistent cache and fire-and-forget writes. App starts in anonymous guest mode with Firestore network disabled (offline-only). Users can optionally sign in with Google via Settings to enable cloud sync. Anonymous users store images locally (file:// URIs); linking with Google uploads images to Firebase Storage. Sign-out clears Firestore cache and returns to anonymous mode. Paprika import uses the Message Batches API for multiple recipes (50% cheaper), submitting all recipes as a single batch for parallel processing, with fallback to sequential for single recipes. Batch cancellation propagates to the server. Export uses .lorecipes format (ZIP with RecipeSerializer) for both single recipe share and bulk backup."
+    label: "All imports run in background via WorkManager (URL, Paprika, .lorecipes). Import queue is database-backed (PendingImportEntity in Room) and persists across app restarts. Recipes and meal plans are stored in Firestore with unlimited persistent cache and fire-and-forget writes. App starts in anonymous guest mode with Firestore network disabled (offline-only). Users can optionally sign in with Google via Settings to enable cloud sync. Anonymous users store images locally (file:// URIs); linking with Google uploads images to Firebase Storage. When linking to an existing Google account (NeedsMerge), AccountMigrationService creates an ephemeral secondary FirebaseApp, signs in as Google on it, copies guest recipes/meal plans from the anonymous Firestore cache to the Google account via the secondary instance, then tears it down and switches the default app to Google. Sign-out clears Firestore cache and returns to anonymous mode. Paprika import uses the Message Batches API for multiple recipes (50% cheaper), submitting all recipes as a single batch for parallel processing, with fallback to sequential for single recipes. Batch cancellation propagates to the server. Export uses .lorecipes format (ZIP with RecipeSerializer) for both single recipe share and bulk backup."
     style: {
       font-size: 12
       italic: true


### PR DESCRIPTION
## Summary

- Guest recipes (and meal plans) were disappearing when signing into an existing Google account because the UID changed without migrating data
- Add `AccountMigrationService` that uses an ephemeral secondary `FirebaseApp` to safely migrate data: signs in as Google on the secondary instance, reads guest data from the default (anonymous) Firestore cache, writes it to the Google account via the secondary Firestore (skipping existing IDs to avoid overwriting), then tears down the secondary app and switches the default app to Google
- The anonymous user's data remains intact on the default app until migration is fully committed on the server, so if anything fails the guest data is not lost
- Refactor `AuthService` to support merge transition state management (`beginMergeTransition`/`endMergeTransition`/`completeMergeSignIn`) to suppress premature UI updates during the Firestore terminate/re-init cycle

## Test plan

- [ ] As a guest, add a recipe, then sign into an **existing** Google account — verify the guest recipe appears in the signed-in account
- [ ] As a guest, add a recipe, then sign into a **new** Google account (link flow) — verify it still works as before
- [ ] If the Google account already has recipes, verify they are preserved (not overwritten) after merge
- [ ] Verify meal plans are also migrated
- [ ] If migration fails (e.g., network error during write to secondary), verify the guest account still has all data

🤖 Generated with [Claude Code](https://claude.com/claude-code)