### PR TITLE
docs: add privacy policy

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -49,21 +49,20 @@ your recipes and meal plans are available across devices. When you sign in:
 - Recipe images (stored in Firebase Storage under your user ID)
 
 All cloud data is isolated to your account via Firebase security rules. No
-other user or administrator can access your data through the app.
+other user can access your data through the app.
 
 ## External Services
 
 ### Anthropic API (Claude AI)
 
 When you import a recipe, the app sends the **recipe web page content** (HTML
-or extracted text) to the Anthropic API for parsing. Your API key is sent with
-these requests for authentication. No personal data is included in these
-requests.
+or extracted text) to the Anthropic API for parsing. When you edit a recipe,
+the content of the recipe is re-sent for processing. Your API key is sent with
+these requests for authentication.
 
 ### Recipe Websites
 
-When you import a recipe by URL, the app fetches the web page directly. Only
-the page URL and its content are involved; no personal data is sent.
+When you import a recipe by URL, the app fetches the web page directly.
 
 ### Firebase (Google)
 


### PR DESCRIPTION
## Summary
- Adds `PRIVACY_POLICY.md` covering data collection, storage, external services, and deletion options as required by Google Play
- Addresses all points from #310: no ads/tracking, offline-first with optional Google Sign-In, data stored under Firebase UID (not email), in-app account deletion (#309), and issue-based deletion requests

## Details

The privacy policy covers:
- No ads, analytics, or third-party tracking
- Offline use without an account
- Google Sign-In and what data Firebase receives
- Local data storage (recipes, settings, encrypted API key, image cache)
- Cloud data storage (recipes, meal plans, images in Firebase)
- External services (Anthropic API, recipe website scraping, Firebase)
- Data retention and deletion (in-app + by request via GitHub issue)
- Children's privacy

Closes #310

## Test plan
- [ ] Review the privacy policy for accuracy and completeness
- [ ] Verify it meets [Google Play requirements](https://support.google.com/googleplay/android-developer/answer/9859455?hl=en#privacy_policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)