### PR TITLE
fix: add ProGuard keep rules for Firestore DTO classes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -43,6 +43,12 @@
 # jsoup (optional re2j dependency not present on Android)
 -dontwarn com.google.re2j.**
 
+# Firestore DTO classes (deserialized via reflection with toObject())
+-keep class com.lionotter.recipes.data.remote.dto.** {
+    <init>(...);
+    *;
+}
+
 # ojAlgo (ILP solver for tag selection)
 -keep class org.ojalgo.** { *; }
 -keepclassmembers class org.ojalgo.** { *; }


### PR DESCRIPTION
## Summary
- Firestore DTO classes (`RecipeDto`, `MealPlanDto`) were being obfuscated by R8 in release builds, stripping their no-arg constructors
- Firestore's `toObject()` uses reflection to instantiate these classes and requires the constructor to exist
- Added a `-keep` rule for the entire `data.remote.dto` package to preserve class names, constructors, and fields

This fixes the production crash:
```
java.lang.RuntimeException: Could not deserialize object. Class nd.b does not define a no-argument constructor.
If you are using ProGuard, make sure these constructors are not stripped
```

Debug builds were unaffected because `isMinifyEnabled = false` for the debug build type.

## Test plan
- [ ] Install a release build and verify recipes load correctly
- [ ] Verify meal plans load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)