### PR TITLE
feat: import recipes from Markdown, text, and HTML files

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -74,6 +74,55 @@
                 <data android:mimeType="*/*" />
                 <data android:pathPattern=".*\\.paprikarecipes" />
             </intent-filter>
+
+            <!-- Handle text recipe files (.md, .txt, .html) opened from file manager or shared -->
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" />
+                <data android:mimeType="text/markdown" />
+            </intent-filter>
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" />
+                <data android:mimeType="text/plain" />
+                <data android:pathPattern=".*\\.txt" />
+            </intent-filter>
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" />
+                <data android:mimeType="text/html" />
+            </intent-filter>
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" />
+                <data android:mimeType="*/*" />
+                <data android:pathPattern=".*\\.md" />
+            </intent-filter>
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" />
+                <data android:mimeType="*/*" />
+                <data android:pathPattern=".*\\.txt" />
+            </intent-filter>
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" />
+                <data android:mimeType="*/*" />
+                <data android:pathPattern=".*\\.html" />
+            </intent-filter>
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" />
+                <data android:mimeType="*/*" />
+                <data android:pathPattern=".*\\.htm" />
+            </intent-filter>
         </activity>
 
         <!-- FileProvider for sharing .lorecipes files -->

--- a/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/MainActivity.kt
@@ -30,6 +30,7 @@ import com.lionotter.recipes.data.remote.FirestoreService
 import com.lionotter.recipes.domain.model.ThemeMode
 import com.lionotter.recipes.ui.navigation.NavGraph
 import com.lionotter.recipes.ui.theme.LionOtterTheme
+import com.lionotter.recipes.worker.TextFileImportWorker
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -58,6 +59,7 @@ class MainActivity : ComponentActivity() {
 
         val sharedUrl = extractSharedUrl(intent)
         val sharedFileUri = extractFileUri(intent)
+        val sharedFileType = sharedFileUri?.let { detectTextFileType(it, intent) }
         val recipeId = extractRecipeId(intent)
 
         if (sharedUrl != null) {
@@ -67,7 +69,7 @@ class MainActivity : ComponentActivity() {
         }
         if (sharedFileUri != null) {
             lifecycleScope.launch {
-                sharedIntentViewModel.onSharedFileReceived(sharedFileUri)
+                sharedIntentViewModel.onSharedFileReceived(sharedFileUri, sharedFileType)
             }
         }
 
@@ -112,6 +114,7 @@ class MainActivity : ComponentActivity() {
                                 sharedIntentViewModel = sharedIntentViewModel,
                                 initialSharedUrl = sharedUrl,
                                 initialFileUri = sharedFileUri,
+                                initialFileType = sharedFileType,
                                 recipeId = recipeId
                             )
                         }
@@ -133,7 +136,35 @@ class MainActivity : ComponentActivity() {
         val sharedFileUri = extractFileUri(intent)
         if (sharedFileUri != null) {
             lifecycleScope.launch {
-                sharedIntentViewModel.onSharedFileReceived(sharedFileUri)
+                sharedIntentViewModel.onSharedFileReceived(
+                    sharedFileUri,
+                    detectTextFileType(sharedFileUri, intent)
+                )
+            }
+        }
+    }
+
+    /**
+     * Detect if a file URI points to a text file that should be imported via AI.
+     * Checks both the URI path extension and the intent MIME type.
+     */
+    private fun detectTextFileType(uri: Uri, intent: Intent?): String? {
+        val uriString = uri.toString().lowercase()
+        return when {
+            uriString.endsWith(".html") || uriString.endsWith(".htm") ->
+                TextFileImportWorker.FILE_TYPE_HTML
+            uriString.endsWith(".md") || uriString.endsWith(".markdown") ->
+                TextFileImportWorker.FILE_TYPE_MARKDOWN
+            uriString.endsWith(".txt") ->
+                TextFileImportWorker.FILE_TYPE_TEXT
+            else -> {
+                // Fall back to MIME type from intent
+                val mimeType = intent?.type
+                when (mimeType) {
+                    "text/html" -> TextFileImportWorker.FILE_TYPE_HTML
+                    "text/markdown" -> TextFileImportWorker.FILE_TYPE_MARKDOWN
+                    else -> null
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/lionotter/recipes/SharedIntentViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/SharedIntentViewModel.kt
@@ -7,13 +7,22 @@ import kotlinx.coroutines.flow.SharedFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
+/**
+ * A shared file with its detected type.
+ */
+data class SharedFile(
+    val uri: Uri,
+    /** Non-null for text files (.md, .txt, .html); null for ZIP archives */
+    val textFileType: String?
+)
+
 @HiltViewModel
 class SharedIntentViewModel @Inject constructor() : ViewModel() {
     private val _sharedUrl = MutableSharedFlow<String?>(replay = 0)
     val sharedUrl: SharedFlow<String?> = _sharedUrl
 
-    private val _sharedFileUri = MutableSharedFlow<Uri>(replay = 0)
-    val sharedFileUri: SharedFlow<Uri> = _sharedFileUri
+    private val _sharedFile = MutableSharedFlow<SharedFile>(replay = 0)
+    val sharedFile: SharedFlow<SharedFile> = _sharedFile
 
     suspend fun onSharedUrlReceived(url: String?) {
         if (url != null) {
@@ -21,7 +30,7 @@ class SharedIntentViewModel @Inject constructor() : ViewModel() {
         }
     }
 
-    suspend fun onSharedFileReceived(uri: Uri) {
-        _sharedFileUri.emit(uri)
+    suspend fun onSharedFileReceived(uri: Uri, textFileType: String? = null) {
+        _sharedFile.emit(SharedFile(uri, textFileType))
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/navigation/NavGraph.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.lionotter.recipes.R
 import com.lionotter.recipes.SharedIntentViewModel
+import com.lionotter.recipes.ui.screens.addrecipe.AddRecipeViewModel
 import com.lionotter.recipes.ui.screens.addrecipe.AddRecipeScreen
 import com.lionotter.recipes.ui.screens.importdebug.ImportDebugDetailScreen
 import com.lionotter.recipes.ui.screens.importdebug.ImportDebugListScreen
@@ -38,10 +39,13 @@ sealed class Screen(val route: String) {
     object EditRecipe : Screen("recipes/{recipeId}/edit") {
         fun createRoute(recipeId: String) = "recipes/$recipeId/edit"
     }
-    object AddRecipe : Screen("add-recipe?url={url}") {
+    object AddRecipe : Screen("add-recipe?url={url}&fileUri={fileUri}&fileType={fileType}") {
         fun createRoute(url: String? = null) =
             if (url != null) "add-recipe?url=${url.replace("/", "%2F").replace(":", "%3A").replace("?", "%3F").replace("&", "%26").replace("=", "%3D")}"
             else "add-recipe"
+
+        fun createRouteForFile(fileUri: String, fileType: String) =
+            "add-recipe?fileUri=${Uri.encode(fileUri)}&fileType=$fileType"
     }
     object Settings : Screen("settings")
     object MealPlan : Screen("meal-plan")
@@ -63,6 +67,7 @@ fun NavGraph(
     sharedIntentViewModel: SharedIntentViewModel? = null,
     initialSharedUrl: String? = null,
     initialFileUri: Uri? = null,
+    initialFileType: String? = null,
     recipeId: String? = null
 ) {
     val navController = rememberNavController()
@@ -83,21 +88,40 @@ fun NavGraph(
         }
     }
 
-    // Handle .lorecipes file import on launch - navigate to selection screen
+    // Handle file import on launch - text files go to AddRecipe, ZIPs go to ImportSelection
     LaunchedEffect(initialFileUri) {
         if (initialFileUri != null) {
-            navController.navigate(
-                Screen.ImportSelection.createRoute("lorecipes", initialFileUri.toString())
-            )
+            if (initialFileType != null) {
+                // Text file (.md, .txt, .html) → single-recipe AI import
+                navController.navigate(
+                    Screen.AddRecipe.createRouteForFile(initialFileUri.toString(), initialFileType)
+                )
+            } else {
+                // ZIP archive (.lorecipes, .paprikarecipes) → multi-recipe selection
+                navController.navigate(
+                    Screen.ImportSelection.createRoute("lorecipes", initialFileUri.toString())
+                )
+            }
         }
     }
 
-    // Handle .lorecipes file shared/opened while app is running
+    // Handle file shared/opened while app is running
     LaunchedEffect(sharedIntentViewModel) {
-        sharedIntentViewModel?.sharedFileUri?.collectLatest { uri ->
-            navController.navigate(
-                Screen.ImportSelection.createRoute("lorecipes", uri.toString())
-            )
+        sharedIntentViewModel?.sharedFile?.collectLatest { sharedFile ->
+            if (sharedFile.textFileType != null) {
+                // Text file → single-recipe AI import
+                navController.navigate(
+                    Screen.AddRecipe.createRouteForFile(
+                        sharedFile.uri.toString(),
+                        sharedFile.textFileType
+                    )
+                )
+            } else {
+                // ZIP archive → multi-recipe selection
+                navController.navigate(
+                    Screen.ImportSelection.createRoute("lorecipes", sharedFile.uri.toString())
+                )
+            }
         }
     }
 
@@ -187,12 +211,34 @@ fun NavGraph(
                     type = NavType.StringType
                     nullable = true
                     defaultValue = null
+                },
+                navArgument("fileUri") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
+                navArgument("fileType") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
                 }
             )
         ) { backStackEntry ->
             val urlArg = backStackEntry.arguments?.getString("url")
+            val fileUriArg = backStackEntry.arguments?.getString("fileUri")
+            val fileTypeArg = backStackEntry.arguments?.getString("fileType")
+            val viewModel: AddRecipeViewModel = hiltViewModel()
+
+            // Auto-start file import when navigated with file parameters
+            LaunchedEffect(fileUriArg, fileTypeArg) {
+                if (fileUriArg != null && fileTypeArg != null) {
+                    viewModel.importFromFile(fileUriArg, fileTypeArg)
+                }
+            }
+
             AddRecipeScreen(
                 sharedUrl = urlArg,
+                viewModel = viewModel,
                 onBackClick = navigateBack,
                 onRecipeAdded = { recipeId ->
                     // Clear back stack and set up proper navigation: RecipeList -> RecipeDetail

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeScreen.kt
@@ -47,6 +47,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lionotter.recipes.R
 import com.lionotter.recipes.ui.components.ErrorCard
 import com.lionotter.recipes.ui.components.RecipeTopAppBar
+import com.lionotter.recipes.worker.TextFileImportWorker
 
 @Composable
 fun AddRecipeScreen(
@@ -85,19 +86,25 @@ fun AddRecipeScreen(
         }
     }
 
-    // Unified file picker for .lorecipes and .paprikarecipes imports
+    // Unified file picker for recipe imports (.lorecipes, .paprikarecipes, .md, .txt, .html)
     val importFilePicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
         if (uri != null) {
-            // Determine import type from file extension
             val uriString = uri.toString().lowercase()
-            val importType = if (uriString.endsWith(".paprikarecipes")) {
-                "paprika"
+            val textFileType = detectTextFileType(uriString)
+            if (textFileType != null) {
+                // Text files (.md, .txt, .html) → single-recipe AI import
+                viewModel.importFromFile(uri.toString(), textFileType)
             } else {
-                "lorecipes"
+                // ZIP archives (.lorecipes, .paprikarecipes) → multi-recipe selection
+                val importType = if (uriString.endsWith(".paprikarecipes")) {
+                    "paprika"
+                } else {
+                    "lorecipes"
+                }
+                onNavigateToImportSelection(importType, uri)
             }
-            onNavigateToImportSelection(importType, uri)
         }
     }
 
@@ -357,5 +364,21 @@ private fun NoApiKeyContent(onNavigateToSettings: () -> Unit) {
         Button(onClick = onNavigateToSettings) {
             Text(stringResource(R.string.go_to_settings))
         }
+    }
+}
+
+/**
+ * Detect if a file URI (lowercased) points to a text file that can be imported
+ * as a single recipe via AI. Returns the file type constant or null for non-text files.
+ */
+private fun detectTextFileType(lowercasedUri: String): String? {
+    return when {
+        lowercasedUri.endsWith(".html") || lowercasedUri.endsWith(".htm") ->
+            TextFileImportWorker.FILE_TYPE_HTML
+        lowercasedUri.endsWith(".md") || lowercasedUri.endsWith(".markdown") ->
+            TextFileImportWorker.FILE_TYPE_MARKDOWN
+        lowercasedUri.endsWith(".txt") ->
+            TextFileImportWorker.FILE_TYPE_TEXT
+        else -> null
     }
 }

--- a/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeViewModel.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/ui/screens/addrecipe/AddRecipeViewModel.kt
@@ -8,6 +8,7 @@ import androidx.work.WorkManager
 import com.lionotter.recipes.data.local.SettingsDataStore
 import com.lionotter.recipes.ui.state.InProgressRecipeManager
 import com.lionotter.recipes.worker.RecipeImportWorker
+import com.lionotter.recipes.worker.TextFileImportWorker
 import com.lionotter.recipes.worker.observeWorkByTag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,34 +51,44 @@ class AddRecipeViewModel @Inject constructor(
     }
 
     /**
-     * Observe work status for the current URL import to update this screen's UI state.
+     * Observe work status for the current URL import or text file import
+     * to update this screen's UI state.
      * In-progress recipe cleanup is handled by [InProgressRecipeManager] itself.
      */
     private fun observeWorkStatus() {
         viewModelScope.launch {
             workManager.observeWorkByTag(RecipeImportWorker.TAG_RECIPE_IMPORT) { currentWorkId }
-                .collect { handleWorkInfo(it) }
+                .collect { handleWorkInfo(it, URL_IMPORT_KEYS) }
+        }
+        viewModelScope.launch {
+            workManager.observeWorkByTag(TextFileImportWorker.TAG_TEXT_FILE_IMPORT) { currentWorkId }
+                .collect { handleWorkInfo(it, TEXT_FILE_IMPORT_KEYS) }
         }
     }
 
-    private fun handleWorkInfo(workInfo: WorkInfo) {
+    /**
+     * Maps worker-specific output keys and progress values to UI state.
+     */
+    private data class WorkerKeys(
+        val progressKey: String,
+        val recipeIdKey: String,
+        val resultTypeKey: String,
+        val errorMessageKey: String,
+        val noApiKeyValue: String,
+        val progressMapping: (String?) -> ImportProgress
+    )
+
+    private fun handleWorkInfo(workInfo: WorkInfo, keys: WorkerKeys) {
         when (workInfo.state) {
             WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED -> {
                 _uiState.value = AddRecipeUiState.Loading(ImportProgress.Queued)
             }
             WorkInfo.State.RUNNING -> {
-                val progress = workInfo.progress.getString(RecipeImportWorker.KEY_PROGRESS)
-
-                val importProgress = when (progress) {
-                    RecipeImportWorker.PROGRESS_FETCHING -> ImportProgress.FetchingPage
-                    RecipeImportWorker.PROGRESS_PARSING -> ImportProgress.ParsingRecipe
-                    RecipeImportWorker.PROGRESS_SAVING -> ImportProgress.SavingRecipe
-                    else -> ImportProgress.Starting
-                }
-                _uiState.value = AddRecipeUiState.Loading(importProgress)
+                val progress = workInfo.progress.getString(keys.progressKey)
+                _uiState.value = AddRecipeUiState.Loading(keys.progressMapping(progress))
             }
             WorkInfo.State.SUCCEEDED -> {
-                val recipeId = workInfo.outputData.getString(RecipeImportWorker.KEY_RECIPE_ID)
+                val recipeId = workInfo.outputData.getString(keys.recipeIdKey)
                 if (recipeId != null) {
                     _uiState.value = AddRecipeUiState.Success(recipeId)
                 }
@@ -86,12 +97,11 @@ class AddRecipeViewModel @Inject constructor(
                 workManager.pruneWork()
             }
             WorkInfo.State.FAILED -> {
-                val resultType = workInfo.outputData.getString(RecipeImportWorker.KEY_RESULT_TYPE)
-                val errorMessage = workInfo.outputData.getString(RecipeImportWorker.KEY_ERROR_MESSAGE)
+                val resultType = workInfo.outputData.getString(keys.resultTypeKey)
+                val errorMessage = workInfo.outputData.getString(keys.errorMessageKey)
                     ?: "Unknown error"
-
                 _uiState.value = when (resultType) {
-                    RecipeImportWorker.RESULT_NO_API_KEY -> AddRecipeUiState.NoApiKey
+                    keys.noApiKeyValue -> AddRecipeUiState.NoApiKey
                     else -> AddRecipeUiState.Error(errorMessage)
                 }
                 currentImportId = null
@@ -105,6 +115,67 @@ class AddRecipeViewModel @Inject constructor(
                 workManager.pruneWork()
             }
         }
+    }
+
+    companion object {
+        private val URL_IMPORT_KEYS = WorkerKeys(
+            progressKey = RecipeImportWorker.KEY_PROGRESS,
+            recipeIdKey = RecipeImportWorker.KEY_RECIPE_ID,
+            resultTypeKey = RecipeImportWorker.KEY_RESULT_TYPE,
+            errorMessageKey = RecipeImportWorker.KEY_ERROR_MESSAGE,
+            noApiKeyValue = RecipeImportWorker.RESULT_NO_API_KEY,
+            progressMapping = { progress ->
+                when (progress) {
+                    RecipeImportWorker.PROGRESS_FETCHING -> ImportProgress.FetchingPage
+                    RecipeImportWorker.PROGRESS_PARSING -> ImportProgress.ParsingRecipe
+                    RecipeImportWorker.PROGRESS_SAVING -> ImportProgress.SavingRecipe
+                    else -> ImportProgress.Starting
+                }
+            }
+        )
+
+        private val TEXT_FILE_IMPORT_KEYS = WorkerKeys(
+            progressKey = TextFileImportWorker.KEY_PROGRESS,
+            recipeIdKey = TextFileImportWorker.KEY_RECIPE_ID,
+            resultTypeKey = TextFileImportWorker.KEY_RESULT_TYPE,
+            errorMessageKey = TextFileImportWorker.KEY_ERROR_MESSAGE,
+            noApiKeyValue = TextFileImportWorker.RESULT_NO_API_KEY,
+            progressMapping = { progress ->
+                when (progress) {
+                    TextFileImportWorker.PROGRESS_READING_FILE -> ImportProgress.FetchingPage
+                    TextFileImportWorker.PROGRESS_PARSING -> ImportProgress.ParsingRecipe
+                    TextFileImportWorker.PROGRESS_SAVING -> ImportProgress.SavingRecipe
+                    else -> ImportProgress.Starting
+                }
+            }
+        )
+    }
+
+    /**
+     * Import a recipe from a text file (.md, .txt, .html).
+     * Reads the file content and sends it to the AI for parsing.
+     */
+    fun importFromFile(fileUri: String, fileType: String) {
+        // Guard against double-enqueue (e.g., from LaunchedEffect recomposition)
+        if (currentImportId != null) return
+
+        currentImportId = UUID.randomUUID().toString()
+
+        val workRequest = OneTimeWorkRequestBuilder<TextFileImportWorker>()
+            .setInputData(
+                TextFileImportWorker.createInputData(fileUri, fileType, currentImportId!!)
+            )
+            .addTag(TextFileImportWorker.TAG_TEXT_FILE_IMPORT)
+            .build()
+
+        currentWorkId = workRequest.id
+        inProgressRecipeManager.addInProgressRecipe(
+            currentImportId!!, "Importing recipe from file\u2026",
+            workManagerId = workRequest.id.toString()
+        )
+        workManager.enqueue(workRequest)
+
+        _uiState.value = AddRecipeUiState.Loading(ImportProgress.Queued)
     }
 
     fun onUrlChange(url: String) {

--- a/app/src/main/kotlin/com/lionotter/recipes/worker/TextFileImportWorker.kt
+++ b/app/src/main/kotlin/com/lionotter/recipes/worker/TextFileImportWorker.kt
@@ -1,0 +1,208 @@
+package com.lionotter.recipes.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.core.net.toUri
+import androidx.hilt.work.HiltWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.lionotter.recipes.domain.usecase.ParseHtmlUseCase
+import com.lionotter.recipes.notification.RecipeNotificationHelper
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+
+/**
+ * Worker that imports a single recipe from a text file (.md, .txt, .html).
+ *
+ * - For .html files: uses [ParseHtmlUseCase.parseHtml] to extract readable content
+ *   via Readability4J before sending to AI (same pipeline as URL imports).
+ * - For .md and .txt files: uses [ParseHtmlUseCase.parseText] to send the raw content
+ *   directly to the AI.
+ */
+@HiltWorker
+class TextFileImportWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val parseHtmlUseCase: ParseHtmlUseCase,
+    notificationHelper: RecipeNotificationHelper
+) : BaseRecipeWorker(context, workerParams, notificationHelper) {
+
+    override val notificationTitle = "Importing Recipe from File"
+
+    companion object {
+        private const val TAG = "TextFileImportWorker"
+        const val TAG_TEXT_FILE_IMPORT = "text_file_import"
+
+        const val KEY_FILE_URI = "file_uri"
+        const val KEY_FILE_TYPE = "file_type"
+        const val KEY_IMPORT_ID = "import_id"
+        const val KEY_RECIPE_ID = "recipe_id"
+        const val KEY_RECIPE_NAME = "recipe_name"
+        const val KEY_ERROR_MESSAGE = "error_message"
+        const val KEY_PROGRESS = "progress"
+        const val KEY_RESULT_TYPE = "result_type"
+
+        const val RESULT_SUCCESS = "success"
+        const val RESULT_ERROR = "error"
+        const val RESULT_NO_API_KEY = "no_api_key"
+
+        const val PROGRESS_READING_FILE = "reading_file"
+        const val PROGRESS_PARSING = "parsing"
+        const val PROGRESS_SAVING = "saving"
+
+        const val FILE_TYPE_HTML = "html"
+        const val FILE_TYPE_MARKDOWN = "markdown"
+        const val FILE_TYPE_TEXT = "text"
+
+        fun createInputData(fileUri: String, fileType: String, importId: String): Data {
+            return workDataOf(
+                KEY_FILE_URI to fileUri,
+                KEY_FILE_TYPE to fileType,
+                KEY_IMPORT_ID to importId
+            )
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        val fileUriString = inputData.getString(KEY_FILE_URI)
+            ?: return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "No file URI provided"
+                )
+            )
+        val fileType = inputData.getString(KEY_FILE_TYPE) ?: FILE_TYPE_TEXT
+        val importId = inputData.getString(KEY_IMPORT_ID) ?: id.toString()
+
+        setForegroundProgress("Reading file...")
+        setProgress(
+            workDataOf(
+                KEY_IMPORT_ID to importId,
+                KEY_PROGRESS to PROGRESS_READING_FILE
+            )
+        )
+
+        // Read file content
+        val fileUri = fileUriString.toUri()
+        val content = try {
+            context.contentResolver.openInputStream(fileUri)?.use { stream ->
+                stream.bufferedReader().readText()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to read file", e)
+            return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "Failed to read file: ${e.message}"
+                )
+            )
+        }
+
+        if (content.isNullOrBlank()) {
+            return Result.failure(
+                workDataOf(
+                    KEY_RESULT_TYPE to RESULT_ERROR,
+                    KEY_ERROR_MESSAGE to "File is empty"
+                )
+            )
+        }
+
+        setForegroundProgress("AI is analyzing the recipe...")
+
+        // Parse with AI using the appropriate method
+        val parseResult = when (fileType) {
+            FILE_TYPE_HTML -> parseHtmlUseCase.parseHtml(
+                html = content,
+                saveRecipe = true,
+                onProgress = { progress -> handleProgress(progress, importId) }
+            )
+            else -> parseHtmlUseCase.parseText(
+                text = content,
+                saveRecipe = true,
+                onProgress = { progress -> handleProgress(progress, importId) }
+            )
+        }
+
+        return when (parseResult) {
+            is ParseHtmlUseCase.ParseResult.Success -> {
+                withContext(NonCancellable) {
+                    notificationHelper.showSuccessNotification(
+                        recipeName = parseResult.recipe.name,
+                        recipeId = parseResult.recipe.id
+                    )
+                }
+                Result.success(
+                    workDataOf(
+                        KEY_IMPORT_ID to importId,
+                        KEY_RESULT_TYPE to RESULT_SUCCESS,
+                        KEY_RECIPE_ID to parseResult.recipe.id,
+                        KEY_RECIPE_NAME to parseResult.recipe.name
+                    )
+                )
+            }
+            is ParseHtmlUseCase.ParseResult.Error -> errorResult(
+                errorNotificationTitle = "Import Failed",
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                errorType = RESULT_ERROR,
+                errorMessage = parseResult.message,
+                KEY_IMPORT_ID to importId
+            )
+            ParseHtmlUseCase.ParseResult.NoApiKey -> notAvailableResult(
+                resultTypeKey = KEY_RESULT_TYPE,
+                errorMessageKey = KEY_ERROR_MESSAGE,
+                resultType = RESULT_NO_API_KEY,
+                errorMessage = "API key not configured",
+                KEY_IMPORT_ID to importId
+            )
+        }
+    }
+
+    private suspend fun handleProgress(progress: ParseHtmlUseCase.ParseProgress, importId: String) {
+        when (progress) {
+            is ParseHtmlUseCase.ParseProgress.ExtractingContent -> {
+                setProgress(
+                    workDataOf(
+                        KEY_IMPORT_ID to importId,
+                        KEY_PROGRESS to PROGRESS_READING_FILE
+                    )
+                )
+                setForegroundProgress("Extracting content...")
+            }
+            is ParseHtmlUseCase.ParseProgress.ParsingRecipe -> {
+                setProgress(
+                    workDataOf(
+                        KEY_IMPORT_ID to importId,
+                        KEY_PROGRESS to PROGRESS_PARSING
+                    )
+                )
+                setForegroundProgress("AI is analyzing the recipe...")
+            }
+            is ParseHtmlUseCase.ParseProgress.RecipeNameAvailable -> {
+                setProgress(
+                    workDataOf(
+                        KEY_IMPORT_ID to importId,
+                        KEY_PROGRESS to PROGRESS_PARSING,
+                        KEY_RECIPE_NAME to progress.name
+                    )
+                )
+                setForegroundProgress("Parsing: ${progress.name}")
+            }
+            is ParseHtmlUseCase.ParseProgress.SavingRecipe -> {
+                setProgress(
+                    workDataOf(
+                        KEY_IMPORT_ID to importId,
+                        KEY_PROGRESS to PROGRESS_SAVING
+                    )
+                )
+                setForegroundProgress("Saving recipe...")
+            }
+            is ParseHtmlUseCase.ParseProgress.Complete -> {
+                // Handled by return value
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,7 +199,7 @@
 
     <!-- File Import -->
     <string name="import_from_file">Import from file</string>
-    <string name="import_from_file_description">Import recipes from a .lorecipes or Paprika (.paprikarecipes) file</string>
+    <string name="import_from_file_description">Import from .lorecipes, Paprika (.paprikarecipes), Markdown (.md), text (.txt), or HTML (.html) files</string>
     <string name="reading_paprika_export">Reading Paprika export\u2026</string>
     <string name="importing_paprika_recipe">Importing %1$d/%2$d: %3$s</string>
     <string name="paprika_import_complete">Paprika Import Complete</string>


### PR DESCRIPTION
## Summary
- Adds support for importing recipes directly from `.md`, `.txt`, and `.html`/`.htm` files
- Files can be imported via the file picker on the import page, or by sharing/opening a file from another app
- Markdown and text files are sent directly to the AI for recipe extraction; HTML files go through the existing Readability4J content extraction pipeline first (same as URL imports)

## Changes
- **New `TextFileImportWorker`** — background worker that reads file content and delegates to `ParseHtmlUseCase` (`.parseHtml()` for HTML, `.parseText()` for md/txt)
- **`AddRecipeViewModel`** — added `importFromFile()` method and work observer for text file imports
- **`AddRecipeScreen`** — file picker now detects `.md`/`.txt`/`.html`/`.htm` extensions and routes them to AI import instead of the ZIP selection screen
- **`AndroidManifest.xml`** — intent filters for `ACTION_VIEW` with text/markdown, text/html, text/plain MIME types and file extensions
- **`SharedIntentViewModel`** — carries file type metadata so the NavGraph can route text files to AddRecipe vs ImportSelection
- **`NavGraph`** — routes text file shares/opens to AddRecipe with auto-start file import; ZIP files still go to ImportSelection

## Test plan
- [ ] Pick a `.md` file from the import page file picker → should show loading/progress UI and create a recipe via AI
- [ ] Pick a `.txt` file with recipe content → same behavior
- [ ] Pick a `.html` file → should extract content via Readability then AI parse
- [ ] Pick a `.lorecipes` or `.paprikarecipes` file → should still go to the multi-recipe selection screen (no regression)
- [ ] Share a `.md` file from a file manager → should open the app and start importing
- [ ] Share an `.html` file from a file manager → same
- [ ] Cancel during import → should cancel cleanly
- [ ] Import without API key → should show API key required message

🤖 Generated with [Claude Code](https://claude.com/claude-code)